### PR TITLE
Fix: 프로토타입 속성 체크 로직 수정

### DIFF
--- a/app/api/newsletter/[date]/route.ts
+++ b/app/api/newsletter/[date]/route.ts
@@ -124,7 +124,9 @@ function parseAndValidateStocks(jsonString: string): { stocks: StockData[] | nul
         return { stocks: null, error: errorMsg };
       }
 
-      if ('__proto__' in stock || 'constructor' in stock) {
+      // 보안: 프로토타입 오염 방어 - 객체가 직접 소유한 속성인지 확인
+      // 'in' 연산자는 프로토타입 체인도 검사하므로 hasOwn 사용
+      if (Object.hasOwn(stock, '__proto__') || Object.hasOwn(stock, 'constructor') || Object.hasOwn(stock, 'prototype')) {
         const errorMsg = `stocks[${i}]에 위험한 프로토타입 속성이 있습니다`;
         console.error('[API]', errorMsg);
         return { stocks: null, error: errorMsg };


### PR DESCRIPTION
문제:
- 'in' 연산자는 프로토타입 체인까지 검사하여 모든 객체에서 constructor가 존재
- 이로 인해 정상적인 데이터도 "위험한 프로토타입 속성" 에러 발생
- 배포 환경에서 Supabase 데이터 로딩 실패

해결:
- Object.hasOwn()으로 변경하여 객체가 직접 소유한 속성만 검사
- __proto__, constructor, prototype 속성이 직접 정의된 경우만 차단
- 프로토타입 체인을 통한 상속 속성은 허용

🤖 Generated with [Claude Code](https://claude.com/claude-code)