### PR TITLE
Fix Framer Motion transition type error in mobile-menu

### DIFF
--- a/app/_components/shared/navigation/mobile-menu.tsx
+++ b/app/_components/shared/navigation/mobile-menu.tsx
@@ -22,8 +22,7 @@ function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
         exit={{ opacity: 0 }}
         transition={{
           duration: 0.35,
-          ease: 'easeInOut',
-          exit: { duration: 0.45, ease: 'easeIn' }
+          ease: 'easeInOut'
         }}
         className="fixed inset-0 bg-black z-40 lg:hidden"
         style={{ top: '64px' }}
@@ -42,16 +41,7 @@ function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
             stiffness: 250,
             mass: 1,
           },
-          opacity: { duration: 0.3 },
-          exit: {
-            x: {
-              type: 'spring',
-              damping: 40,
-              stiffness: 200,
-              mass: 1.2,
-            },
-            opacity: { duration: 0.4 }
-          }
+          opacity: { duration: 0.3 }
         }}
         className="fixed right-0 bottom-0 w-full max-w-md bg-black z-50 lg:hidden overflow-hidden"
         style={{


### PR DESCRIPTION
Remove invalid 'exit' property from transition objects in mobile-menu.tsx
- Lines 26: Remove exit property from backdrop transition
- Lines 46-54: Remove exit property from menu panel transition

Framer Motion's transition prop only controls animate state transitions. The exit animation timing is controlled by the exit prop itself.

Fixes TypeScript error: "exit does not exist in type 'Transition<any>'"