### PR TITLE
Fix blog posts not appearing: change publish flag to true

### DIFF
--- a/scripts/generate-blog-post.ts
+++ b/scripts/generate-blog-post.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   try {
     // AI 동적 키워드 5개 생성
     const results = await generateWithDynamicKeywords({
-      publish: false,
+      publish: true,
       count: 5,
       minRelevanceScore: 7.5,
     });


### PR DESCRIPTION
Blog posts were being saved with 'draft' status but the blog page
only queries 'published' posts, causing data to not appear.