### PR TITLE
fix: replace isomorphic-dompurify with rehype-sanitize

### DIFF
--- a/app/blog/_utils/markdown-parser.ts
+++ b/app/blog/_utils/markdown-parser.ts
@@ -9,8 +9,9 @@
  * 사용 라이브러리:
  * - remark: Markdown 처리 라이브러리
  * - remark-gfm: GitHub Flavored Markdown 플러그인 (테이블, 취소선 등)
- * - remark-html: Markdown → HTML 변환 플러그인
+ * - remark-rehype: Markdown AST → HTML AST 변환
  * - rehype-sanitize: XSS 방지를 위한 HTML 정화
+ * - rehype-stringify: HTML AST → 문자열 변환
  */
 
 import { remark } from 'remark';

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
-        "remark-html": "^16.0.1",
         "remark-rehype": "^11.1.2",
         "tailwind-merge": "^3.3.1",
         "twitter-api-v2": "^1.27.0",
@@ -8122,23 +8121,6 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-html": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-16.0.1.tgz",
-      "integrity": "sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "hast-util-sanitize": "^5.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
-    "remark-html": "^16.0.1",
     "remark-rehype": "^11.1.2",
     "tailwind-merge": "^3.3.1",
     "twitter-api-v2": "^1.27.0",


### PR DESCRIPTION
isomorphic-dompurify's jsdom dependency causes ESM/CommonJS
compatibility errors in Vercel + Turbopack environment.
Switched to rehype-sanitize which integrates natively with
the remark/rehype pipeline.