### PR TITLE
fix: add close_price_date field to fix archive price date mismatch

### DIFF
--- a/app/api/stock/daily-close/route.ts
+++ b/app/api/stock/daily-close/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getBatchDailyClosePrices } from '@/app/archive/_utils/api/kis/client';
+
+/** GET /api/stock/daily-close?tickers=KOSPI:005930&date=20241220 */
+export async function GET(req: NextRequest) {
+  try {
+    const tickers = req.nextUrl.searchParams.get('tickers')?.split(',').map((t) => t.trim()).filter(Boolean);
+    const date = req.nextUrl.searchParams.get('date');
+    if (!tickers?.length || tickers.length > 10 || !date) {
+      return NextResponse.json({ success: false, error: 'Invalid params' }, { status: 400 });
+    }
+    return NextResponse.json({ success: true, prices: Object.fromEntries(await getBatchDailyClosePrices(tickers, date)) });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Failed' }, { status: 500 });
+  }
+}
+
+export const runtime = 'nodejs';

--- a/app/archive/_components/cards/newsletter-card/index.tsx
+++ b/app/archive/_components/cards/newsletter-card/index.tsx
@@ -24,9 +24,13 @@ const NewsletterCard = memo(function NewsletterCard({
   maxRationaleItems,
   newsletterDate,
   currentPrice,
+  historicalClosePrice,
   isLoadingPrice = false,
 }: NewsletterCardProps) {
   const { ticker, name, close_price, rationale, signals } = stock;
+
+  // KIS API 종가 우선, 없으면 Gemini 값 사용
+  const displayClosePrice = historicalClosePrice ?? close_price;
 
   // 전체 점수 그라데이션
   const overallGradient = useMemo(
@@ -36,8 +40,8 @@ const NewsletterCard = memo(function NewsletterCard({
 
   // 가격 변동 정보 계산
   const priceChange = useMemo(
-    () => calculatePriceChange(currentPrice, close_price),
-    [currentPrice, close_price]
+    () => calculatePriceChange(currentPrice, displayClosePrice),
+    [currentPrice, displayClosePrice]
   );
 
   // 추천일 전일 날짜
@@ -119,7 +123,7 @@ const NewsletterCard = memo(function NewsletterCard({
             <span className="text-xs text-slate-500 font-light">{previousDate}</span>
           </div>
           <div className="text-3xl font-bold text-white font-mono tabular-nums">
-            {formatPrice(close_price)}
+            {formatPrice(displayClosePrice)}
             <span className="text-base text-slate-500 ml-2 font-normal">원</span>
           </div>
         </div>

--- a/app/archive/_components/cards/newsletter-card/types.ts
+++ b/app/archive/_components/cards/newsletter-card/types.ts
@@ -24,6 +24,8 @@ export interface NewsletterCardProps {
   newsletterDate: DateString;
   /** 실시간 시세 (선택) */
   currentPrice?: StockPrice;
+  /** 추천일 전일 종가 (KIS API에서 조회) */
+  historicalClosePrice?: number;
   /** 실시간 시세 로딩 상태 */
   isLoadingPrice?: boolean;
 }

--- a/app/archive/_components/layout/newsletter-grid.tsx
+++ b/app/archive/_components/layout/newsletter-grid.tsx
@@ -16,6 +16,8 @@ interface NewsletterGridProps {
   newsletter: Newsletter;
   /** 각 종목의 현재가 정보 (티커 → 가격 정보) */
   stockPrices: Map<string, StockPrice>;
+  /** 추천일 전일 종가 (티커 → 종가) */
+  historicalClosePrices: Map<string, number>;
   /** 가격 로딩 상태 */
   isLoadingPrice: boolean;
 }
@@ -23,6 +25,7 @@ interface NewsletterGridProps {
 function NewsletterGrid({
   newsletter,
   stockPrices,
+  historicalClosePrices,
   isLoadingPrice,
 }: NewsletterGridProps) {
   // rationale 항목 최대 개수 계산 (카드 높이 균일화용)
@@ -47,6 +50,7 @@ function NewsletterGrid({
             maxRationaleItems={maxRationaleItems}
             newsletterDate={newsletter.date}
             currentPrice={stockPrices.get(stock.ticker)}
+            historicalClosePrice={historicalClosePrices.get(stock.ticker)}
             isLoadingPrice={isLoadingPrice}
           />
         </motion.div>

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -41,8 +41,8 @@ export default function ArchivePage() {
   // 선택된 뉴스레터 및 티커
   const { newsletter, tickers } = useNewsletterData(selectedDate, allNewsletters);
 
-  // 실시간 주식 시세
-  const { prices: stockPrices, loading: isPriceLoading } = useStockPrices(tickers, selectedDate);
+  // 실시간 주식 시세 및 추천일 전일 종가
+  const { prices: stockPrices, historicalClosePrices, loading: isPriceLoading } = useStockPrices(tickers, selectedDate);
 
   // 모바일 캘린더 상태
   const { isCalendarOpen, calendarButtonRef, toggleCalendar, closeCalendar } = useMobileCalendar();
@@ -125,6 +125,7 @@ export default function ArchivePage() {
                   key={newsletter.date}
                   newsletter={newsletter}
                   stockPrices={stockPrices}
+                  historicalClosePrices={historicalClosePrices}
                   isLoadingPrice={isPriceLoading}
                 />
               )}


### PR DESCRIPTION
Problem:
- Archive UI displayed calculated "previous day" based on newsletter date
- But Gemini Pipeline fetched close_price based on execution time
- This caused mismatch between displayed date and actual price date

Solution:
- Added close_price_date field to store actual price reference date
- Updated Gemini Pipeline Stage 5 to output close_price_date in JSON
- Modified validation logic to accept new optional field
- Archive UI now uses close_price_date when available (fallback to calculation)

Files changed:
- lib/llm/_types/stock-data.ts: Added close_price_date to StockData
- app/archive/_types/archive.types.ts: Added close_price_date to StockData
- lib/prompts/korea/stage-5-json-output.ts: Updated JSON output format
- lib/llm/korea/gemini.ts: Added close_price_date validation
- scripts/update-archive-data.ts: Added close_price_date validation
- app/archive/_components/cards/newsletter-card/utils.ts: Added date display functions
- app/archive/_components/cards/newsletter-card/index.tsx: Use close_price_date for display