### PR TITLE
fix: add non-null assertion for newsletterDate in getPreviousBusinessDate

### DIFF
--- a/app/archive/_hooks/use-stock-prices.ts
+++ b/app/archive/_hooks/use-stock-prices.ts
@@ -114,7 +114,8 @@ export default function useStockPrices(
         setError(null);
 
         // 추천일 전일 종가 조회 (항상 실행)
-        const prevDate = getPreviousBusinessDate(newsletterDate);
+        // newsletterDate is guaranteed non-null (checked at line 96)
+        const prevDate = getPreviousBusinessDate(newsletterDate!);
         const historicalResponse = await fetch(
           `/api/stock/daily-close?tickers=${tickers.join(',')}&date=${prevDate}`,
           { signal: controller.signal }


### PR DESCRIPTION
The newsletterDate parameter is validated at the beginning of the useEffect
(line 96), but TypeScript doesn't narrow the type inside the async closure.
Adding the non-null assertion operator (!) resolves the type error.