### PR TITLE
fix: add type guard for historical close price API response

### DIFF
--- a/app/archive/_hooks/use-stock-prices.ts
+++ b/app/archive/_hooks/use-stock-prices.ts
@@ -190,7 +190,8 @@ export default function useStockPrices(
         saveBatchPricesToCache(cachePrices).catch(() => {});
         if (isMounted) setPrices(results);
       } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') return;
+        // AbortError: Error 또는 DOMException 타입 모두 처리
+        if ((err instanceof Error || err instanceof DOMException) && err.name === 'AbortError') return;
         if (isMounted) setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
         if (isMounted) setLoading(false);


### PR DESCRIPTION
Prevent potential runtime errors when browser tab is restored from
bfcache by properly validating the API response structure and value
types before creating the Map.