### PR TITLE
fix: improve mobile touch targets for tag filter buttons

### DIFF
--- a/app/blog/_components/filters/tag-filter.tsx
+++ b/app/blog/_components/filters/tag-filter.tsx
@@ -174,13 +174,13 @@ export function TagFilter({ tags, selectedTags, onToggle }: TagFilterProps) {
       </div>
 
       {/* 하단: 접기 + 더보기 버튼 */}
-      <div className="flex items-center justify-center gap-3 pt-2">
-        {/* 접기 버튼 */}
+      <div className="flex items-center justify-center gap-4 pt-2">
+        {/* 접기 버튼 - 모바일 터치 타겟 최소 44px 확보 */}
         {displayCount > initialCount && (
           <button
             type="button"
             onClick={handleReset}
-            className="group inline-flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-gray-500 hover:text-emerald-400 transition-all"
+            className="group inline-flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-4 py-2.5 text-xs font-medium text-gray-500 hover:text-emerald-400 active:text-emerald-500 transition-all rounded-xl hover:bg-gray-800/40 active:bg-gray-800/60"
             aria-label="태그 목록 접기"
           >
             <span>접기</span>
@@ -188,16 +188,17 @@ export function TagFilter({ tags, selectedTags, onToggle }: TagFilterProps) {
           </button>
         )}
 
-        {/* 더보기 버튼 - 개선된 UX */}
+        {/* 더보기 버튼 - 모바일 터치 타겟 최소 44px 확보 */}
         {hasMore && (
           <button
             type="button"
             onClick={handleLoadMore}
             aria-label={`${nextLoadCount}개 태그 더 보기 (전체 ${remainingCount}개 남음)`}
             className={cn(
-              'group relative px-5 py-2.5 text-xs font-medium rounded-xl overflow-hidden',
+              'group relative min-h-[44px] px-5 py-3 text-xs font-medium rounded-xl overflow-hidden',
               'bg-gradient-to-br from-gray-800/60 to-gray-800/40 backdrop-blur-sm border border-gray-700/50',
               'hover:from-gray-800/80 hover:to-gray-800/60 hover:border-emerald-500/30 hover:shadow-lg hover:shadow-emerald-500/5',
+              'active:from-gray-800/90 active:to-gray-800/70 active:border-emerald-500/40',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-black',
               'transition-all duration-300',
               'animate-fade-in-up'


### PR DESCRIPTION
- Add min-h-[44px] min-w-[44px] to meet minimum touch target guidelines
- Increase padding and gap for better touch accessibility
- Add active states for visual feedback on mobile tap