### PR TITLE
fix(tli): batchQuery 조용한 잘림 제거 — membership append duplicate key 근본 해결

### DIFF
--- a/scripts/tli/__tests__/supabase-batch.test.ts
+++ b/scripts/tli/__tests__/supabase-batch.test.ts
@@ -1,22 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+interface PageResponse {
+  readonly data: Record<string, unknown>[] | null
+  readonly count: number | null
+  readonly error?: { readonly message: string }
+}
+
 const supabaseBatchMocks = vi.hoisted(() => {
   const upsertResults: Array<{ readonly error: { readonly message: string } | null }> = []
-  return { upsertResults }
+  const pages: unknown[] = []
+  const rangeCalls: Array<{ readonly from: number; readonly to: number }> = []
+  const orderCalls: Array<{ readonly column: string; readonly ascending?: boolean }> = []
+  return { upsertResults, pages, rangeCalls, orderCalls }
 })
 
-vi.mock('@/scripts/tli/shared/supabase-admin', () => ({
-  supabaseAdmin: {
-    from: vi.fn(() => ({
-      upsert: vi.fn(async () => supabaseBatchMocks.upsertResults.shift() ?? { error: null }),
-      select: vi.fn(() => ({
-        in: vi.fn(() => ({
-          range: vi.fn(async () => ({ data: null, error: { message: 'boom' } })),
-        })),
+vi.mock('@/scripts/tli/shared/supabase-admin', () => {
+  const builder = () => {
+    const chain: Record<string, unknown> = {}
+    chain.in = vi.fn(() => chain)
+    chain.order = vi.fn((column: string, opts?: { ascending?: boolean }) => {
+      supabaseBatchMocks.orderCalls.push({ column, ascending: opts?.ascending })
+      return chain
+    })
+    chain.range = vi.fn(async (from: number, to: number) => {
+      supabaseBatchMocks.rangeCalls.push({ from, to })
+      return supabaseBatchMocks.pages.shift() ?? { data: null, count: null, error: { message: 'boom' } }
+    })
+    return chain
+  }
+
+  return {
+    supabaseAdmin: {
+      from: vi.fn(() => ({
+        upsert: vi.fn(async () => supabaseBatchMocks.upsertResults.shift() ?? { error: null }),
+        select: vi.fn(() => builder()),
       })),
-    })),
-  },
-}))
+    },
+  }
+})
+
+const rows = (count: number, offset = 0): Record<string, unknown>[] => Array.from(
+  { length: count },
+  (_, index) => ({ id: `row-${offset + index}` }),
+)
+
+const page = (data: Record<string, unknown>[], count: number): PageResponse => ({ data, count })
 
 const buildRows = (count: number): Record<string, unknown>[] => Array.from(
   { length: count },
@@ -25,6 +53,9 @@ const buildRows = (count: number): Record<string, unknown>[] => Array.from(
 
 beforeEach(() => {
   supabaseBatchMocks.upsertResults.length = 0
+  supabaseBatchMocks.pages.length = 0
+  supabaseBatchMocks.rangeCalls.length = 0
+  supabaseBatchMocks.orderCalls.length = 0
 })
 
 describe('supabase batch query strict mode', () => {
@@ -34,6 +65,70 @@ describe('supabase batch query strict mode', () => {
     await expect(
       batchQuery('themes', '*', ['theme-1'], undefined, 'id', { failOnError: true }),
     ).rejects.toThrow(/boom/)
+  })
+})
+
+// 2026-07-16 TLI 수집 실패 회귀: PostgREST max-rows가 PAGE_SIZE와 같아 모든 페이지가 상한에 걸려
+// 있었고, 서버가 상한보다 적게 돌려준 페이지를 '데이터 끝'으로 단정해 열린 membership version을
+// 통째로 놓쳤다. 그 결과 기존 매핑이 신규로 오판되어 uniq_theme_stock_membership_history_open 위반.
+describe('supabase batch query pagination completeness', () => {
+  it('keeps paging when a page returns fewer rows than requested', async () => {
+    supabaseBatchMocks.pages.push(
+      page(rows(500), 1200),
+      page(rows(700, 500), 1200),
+    )
+    const { batchQuery } = await import('@/scripts/tli/shared/supabase-batch')
+
+    const result = await batchQuery('theme_stock_membership_history', '*', ['theme-1'], undefined, 'theme_id', {
+      failOnError: true,
+    })
+
+    expect(result).toHaveLength(1200)
+    // 커서는 PAGE_SIZE가 아니라 실제 수신 행 수만큼 전진해야 행을 건너뛰지 않는다
+    expect(supabaseBatchMocks.rangeCalls).toEqual([{ from: 0, to: 999 }, { from: 500, to: 1499 }])
+  })
+
+  it('throws instead of silently truncating when paging stalls', async () => {
+    supabaseBatchMocks.pages.push(
+      page(rows(500), 1200),
+      page([], 1200),
+    )
+    const { batchQuery } = await import('@/scripts/tli/shared/supabase-batch')
+
+    await expect(
+      batchQuery('theme_stock_membership_history', '*', ['theme-1'], undefined, 'theme_id', { failOnError: true }),
+    ).rejects.toThrow(/잘렸습니다|정체/)
+  })
+
+  it('throws when the server never reports an exact count', async () => {
+    supabaseBatchMocks.pages.push({ data: rows(10), count: null })
+    const { batchQuery } = await import('@/scripts/tli/shared/supabase-batch')
+
+    await expect(
+      batchQuery('theme_stocks', '*', ['theme-1'], undefined, 'theme_id', { failOnError: true }),
+    ).rejects.toThrow(/완전성/)
+  })
+
+  it('stops exactly at the reported total without requesting an out-of-range page', async () => {
+    supabaseBatchMocks.pages.push(page(rows(1000), 1000))
+    const { batchQuery } = await import('@/scripts/tli/shared/supabase-batch')
+
+    const result = await batchQuery('theme_stocks', '*', ['theme-1'], undefined, 'theme_id', { failOnError: true })
+
+    expect(result).toHaveLength(1000)
+    expect(supabaseBatchMocks.rangeCalls).toHaveLength(1)
+  })
+
+  it('applies a deterministic order key when the caller requires an exact snapshot', async () => {
+    supabaseBatchMocks.pages.push(page(rows(3), 3))
+    const { batchQuery } = await import('@/scripts/tli/shared/supabase-batch')
+
+    await batchQuery('theme_stock_membership_history', '*', ['theme-1'], undefined, 'theme_id', {
+      failOnError: true,
+      orderBy: { column: 'id' },
+    })
+
+    expect(supabaseBatchMocks.orderCalls).toEqual([{ column: 'id', ascending: true }])
   })
 })
 

--- a/scripts/tli/shared/data-ops.ts
+++ b/scripts/tli/shared/data-ops.ts
@@ -166,10 +166,12 @@ export async function recordThemeStockMembershipHistory(input: {
   const observedThemeIds = [...new Set(input.observed.map(s => s.themeId))]
   if (observedThemeIds.length === 0) return { opened: 0, closed: 0, appended: 0 }
 
+  // orderBy: 이 읽기는 append-only 원장의 diff 기준점이다. 페이지 간 순서가 흔들려 열린 version을
+  // 하나라도 놓치면 이미 존재하는 매핑을 '신규'로 오판해 없던 membership 시작을 조작하게 된다.
   const openRows = await batchQuery<MembershipHistoryRow>(
     MEMBERSHIP_HISTORY_TABLE, MEMBERSHIP_HISTORY_COLUMNS, observedThemeIds,
     q => q.is('valid_to', null).is('superseded_at', null).eq('source', MEMBERSHIP_SOURCE),
-    'theme_id', { failOnError: true },
+    'theme_id', { failOnError: true, orderBy: { column: 'id' } },
   )
 
   const diff = planMembershipHistoryDiff({

--- a/scripts/tli/shared/supabase-admin.ts
+++ b/scripts/tli/shared/supabase-admin.ts
@@ -5,10 +5,18 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
-if (!supabaseUrl || !serviceRoleKey) {
+// next build는 이 모듈을 import하는 API 라우트(예: admin/tli/comparison-v4/promote)의 page data를
+// 수집하려고 모듈을 로드한다. 그 시점엔 서버 전용 시크릿이 없을 수 있다(특히 Vercel Preview 환경).
+// 빌드 단계에서만 placeholder로 대체해 빌드를 통과시키고, 스크립트/런타임에서는 그대로 fail-loud —
+// 잘못된 자격증명으로 조용히 도는 것을 막는다. lib/env.ts와 동일한 NEXT_PHASE 가드.
+const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
+
+if ((!supabaseUrl || !serviceRoleKey) && !isBuildPhase) {
   throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL');
 }
 
-export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
-  auth: { persistSession: false },
-});
+export const supabaseAdmin = createClient(
+  supabaseUrl || 'https://placeholder.supabase.co',
+  serviceRoleKey || 'placeholder-key',
+  { auth: { persistSession: false } },
+);

--- a/scripts/tli/shared/supabase-batch.ts
+++ b/scripts/tli/shared/supabase-batch.ts
@@ -13,10 +13,25 @@ interface BatchUpsertOptions {
   readonly failOnPartial?: boolean
 }
 
+export interface BatchQueryOptions {
+  readonly failOnError?: boolean
+  /**
+   * range() 페이지네이션의 결정적 정렬 키.
+   * ORDER BY 없는 LIMIT/OFFSET은 행 순서가 정의되지 않아 페이지 간 중복·누락이 발생할 수 있다
+   * (PostgreSQL 문서의 명시적 경고). 정확한 스냅샷이 필요한 읽기는 고유 컬럼을 지정한다.
+   */
+  readonly orderBy?: { readonly column: string; readonly ascending?: boolean }
+}
+
 /**
  * Supabase 배치 쿼리
  * - .in() 300개 제한 자동 분할
- * - 1000행 페이지네이션 자동 처리
+ * - count(exact) 기준 페이지네이션 — 서버가 돌려준 실제 행 수만큼만 커서를 전진시킨다.
+ *
+ * WHY count 기준: PostgREST의 max-rows가 PAGE_SIZE와 같으면 모든 페이지가 상한에 걸려 있어
+ * 여유가 0이다. "짧은 페이지 = 데이터 끝"으로 단정하면 서버가 한 페이지라도 적게 돌려준 순간
+ * 에러 없이 결과 전체가 잘리고, 호출자는 그 불완전한 집합을 사실로 오인한다.
+ * 잘린 읽기는 조용히 넘기지 않고 반드시 throw한다 — 부분 스냅샷은 어떤 호출자에게도 안전하지 않다.
  */
 export async function batchQuery<T>(
   table: string,
@@ -25,25 +40,33 @@ export async function batchQuery<T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Supabase 쿼리 빌더 타입이 제네릭 체인으로 추론 불가
   filters?: (q: any) => any,
   column = 'theme_id',
-  options?: { failOnError?: boolean },
+  options?: BatchQueryOptions,
 ): Promise<T[]> {
   const results: T[] = []
 
   for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
     const chunk = ids.slice(i, i + CHUNK_SIZE)
     let from = 0
+    let total: number | null = null
+    let fetched = 0
+    let toleratedError = false
 
     while (true) {
       let data: T[] | null = null
+      let pageTotal: number | null = null
       let lastError: string | null = null
 
       for (let retry = 0; retry < MAX_RETRIES; retry++) {
-        let q = supabaseAdmin.from(table).select(select).in(column, chunk)
+        let q = supabaseAdmin.from(table).select(select, { count: 'exact' }).in(column, chunk)
         if (filters) q = filters(q)
+        if (options?.orderBy) {
+          q = q.order(options.orderBy.column, { ascending: options.orderBy.ascending ?? true })
+        }
         const result = await q.range(from, from + PAGE_SIZE - 1)
 
         if (!result.error) {
           data = result.data as T[] | null
+          pageTotal = result.count ?? null
           lastError = null
           break
         }
@@ -60,12 +83,35 @@ export async function batchQuery<T>(
         if (options?.failOnError) {
           throw new Error(lastError)
         }
+        // failOnError를 끈 호출자는 조회 실패를 감수하기로 한 쪽이다(이미 로그로 드러남).
+        // 이 경우에만 완전성 단언을 건너뛴다 — 잘림을 묵인하는 유일한 경로.
+        toleratedError = true
         break
       }
-      if (!data?.length) break
-      results.push(...data)
-      if (data.length < PAGE_SIZE) break
-      from += PAGE_SIZE
+
+      if (total === null) total = pageTotal
+      const pageRows = data?.length ?? 0
+      if (pageRows > 0) {
+        results.push(...(data as T[]))
+        fetched += pageRows
+      }
+
+      // count를 못 받으면 전진 조건을 판정할 수 없다 — 짧은 페이지를 끝으로 단정하던 옛 동작으로
+      // 되돌아가면 조용한 잘림이 부활하므로, 알 수 없는 상태는 명시적으로 실패시킨다.
+      if (total === null) {
+        throw new Error(`batchQuery(${table}) count(exact)를 받지 못해 완전성을 보장할 수 없습니다`)
+      }
+      if (fetched >= total) break
+      if (pageRows === 0) {
+        throw new Error(
+          `batchQuery(${table}) 페이지네이션 정체: ${fetched}/${total}행에서 빈 페이지 — 결과가 잘렸습니다`,
+        )
+      }
+      from += pageRows
+    }
+
+    if (!toleratedError && total !== null && fetched !== total) {
+      throw new Error(`batchQuery(${table}) 결과 잘림: ${fetched}/${total}행만 조회되었습니다`)
     }
   }
 


### PR DESCRIPTION
## 무엇이 실패했나

`TLI Data Collection` 워크플로우가 2026-07-16 11:38 UTC 런에서 종목 수집 단계에 실패:

\`\`\`
❌ 종목 수집 실패: duplicate key value violates unique constraint
   "uniq_theme_stock_membership_history_open"
\`\`\`

membership history 기능이 7/10 배포 후 **6일간 정상 동작하다 처음 터진 간헐적 실패**.

## 근본 원인

`batchQuery`가 페이지네이션을 `if (data.length < PAGE_SIZE) break`로 끝냈는데, 이 단정이 **"서버가 적게 돌려줬다"와 "데이터가 끝났다"를 구분하지 못함**. 이 Supabase 프로젝트의 PostgREST `max-rows`가 **정확히 1000 = `PAGE_SIZE`**(실측: `range(0,1999)` 요청에 1000건만 반환)라 여유가 0이고, 한 페이지라도 1000건 미만이 오면 **에러 없이 결과 전체가 조용히 잘림**.

잘린 `openRows`를 받은 수집기가 이미 존재하는 매핑을 "신규"로 오판해 INSERT → unique index 위반. **인덱스가 제 역할을 해서 잘못된 이력 기록은 막혔고 DB는 무결**.

## 원인 확정 근거 (DB 포렌식 + 로그)

- history 테이블에 superseded 행 **0건** → close 미실행 → 예외는 반드시 `opens` INSERT
- `opens`는 Map 키가 유일해 **자체 중복 불가** → 충돌 상대는 기존 DB 행 → `openRows` 불완전
- `market`은 symbol에서 결정론적 파생(불일치 0), `relevance` 전부 1 → **속성변경 transition 불가**
- 실패 런 로그에 batchQuery 에러·재시도 **0건** → 조용한 잘림만이 유일한 경로
- 09:33 런은 동일 5788건을 `open 0건`으로 전량 조회, 11:38 런은 **같은 5788건** 일부를 신규 오판

## 수정

`count(exact)` 기반 페이지네이션:
- 커서를 `PAGE_SIZE`가 아니라 **실제 수신 행 수만큼** 전진 → 짧은 페이지에도 계속 페이징
- 잘림은 조용히 넘기지 않고 **throw** (`failOnError`를 끈 호출자만 예외)
- 정확히 `total`에서 멈춤 → 행 수가 1000 배수일 때 범위초과 요청(416)이 나던 **잠복 버그도 해소**
- `orderBy` 옵션 추가, membership 원장 읽기에 `id` 지정 (ORDER BY 없는 LIMIT/OFFSET은 순서 미정의)

`batchQuery`는 reflexivity·parity 로더도 사용하므로 **파이프라인 전반의 동일 위험이 함께 사라짐**.

## 검증

- 회귀 테스트 5종 추가 → 파일 내 11개 통과
- TLI 전체 **972/973 통과** (1건 실패 `tli-boundary-manifest`는 본 변경과 무관 — 로컬 전용 optimizer JSON 산출물 때문, CI엔 없음)
- `tsc` / `eslint` / `next build` 에러 0
- 수정된 `batchQuery`를 **실제 DB**에 호출 → 5788/5788 전량 조회 확인

**DB 복구 불필요** — 실패 런은 0행도 쓰지 못하고 죽었고 현재 open 행은 온전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)