### PR TITLE
feat(mcp): v0.5.0 — 프로덕션 레디 + 실사용 확장 (신규 도구·프롬프트·리소스)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,8 +1,10 @@
 # stockmatrix-mcp
 
-Ask about Korean stock market themes in natural conversation with AI. Track 250+ KOSPI/KOSDAQ investment themes, get daily movers, compare themes side-by-side, and see predictions — all through Claude, Cursor, or any MCP-compatible AI agent.
+Ask about Korean stock market themes in natural conversation with AI. Track 250+ KOSPI/KOSDAQ investment themes, get daily movers, look up which themes a stock belongs to, compare themes side-by-side, and see predictions — all through Claude, Cursor, or any MCP-compatible AI agent.
 
 Powered by **TLI (Theme Lifecycle Index)** — a Bayesian-optimized scoring algorithm combining search interest, news momentum, market volatility, and stock activity into a 0-100 score with lifecycle stage classification.
+
+**11 tools + 4 one-click workflow prompts + live resources.** Try the `market_briefing` slash command for an instant Korean market overview.
 
 ## Quick Start
 
@@ -118,6 +120,13 @@ Search stocks by company name or 6-digit code, with related theme preview. Autom
 |-----------|------|----------|-------------|
 | `query` | string | Yes | e.g. `"삼성전자"`, `"SK하이닉스"`, `"005930"` |
 
+### `get_stock_themes`
+Reverse lookup — every theme a stock belongs to, ranked by theme score, each with lifecycle stage and the stock's relevance. Answers "is my stock in a hot theme?"
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | Yes | 6-digit Korean stock code, e.g. `"005930"` (Samsung), `"000660"` (SK Hynix) |
+
 ### `get_theme_detail`
 Get detailed analysis: score breakdown (4 components), stage, prediction, stocks, news, comparisons.
 
@@ -140,6 +149,26 @@ Get TLI algorithm documentation — scoring, stages, stabilization, comparison, 
 | `section` | string | No | `scoring` / `stages` / `comparison` / `prediction` / `all` (default: all) |
 
 > Tip: Use `section=scoring` to get just the scoring algorithm and save context tokens.
+
+## Workflow Prompts
+
+One-click slash commands (in Claude Desktop, Cursor, and other MCP clients) that run complete multi-tool analyses for you — the fastest way to get real value:
+
+| Prompt | Argument | What it does |
+|--------|----------|--------------|
+| `market_briefing` | — | Today's Korean market theme briefing: mood, top themes, movers, takeaways |
+| `theme_deep_dive` | `theme` | Full lifecycle analysis of one theme: score, 30-day trend, stocks, news, outlook |
+| `find_investment_themes` | `interest` | Discover themes matching an interest, ranked by momentum and stage |
+| `stock_theme_check` | `stock` | Check whether a stock (name or code) sits inside any hot or rising themes |
+
+## Resources
+
+Attachable read-only context (no tool call needed):
+
+| URI | Description |
+|-----|-------------|
+| `stockmatrix://methodology` | How TLI scores and lifecycle stages are computed — weights and thresholds |
+| `stockmatrix://rankings` | Live snapshot of today's theme rankings by score, grouped by stage |
 
 ## Scoring Algorithm
 
@@ -168,9 +197,10 @@ Stage transitions require 2 consecutive days of the same candidate (hysteresis) 
 
 - **250+ themes** across KOSPI & KOSDAQ
 - **Daily updates** — scores, news, stock mappings
-- **Stock lookup** by company name or 6-digit code
+- **Stock ↔ theme lookup** — by company name, 6-digit code, or reverse (stock → all its themes)
 - **AI market summary** for first-call overview
 - **Predictions** with historical analog matching
+- **Workflow prompts** — one-click multi-tool analyses
 - **Sources**: Naver DataLab, Naver Finance, Naver News
 
 ## Configuration

--- a/mcp/dist/cli.js
+++ b/mcp/dist/cli.js
@@ -1,37 +1,11 @@
 #!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createRequire } from 'node:module';
-import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
-import { registerGetThemeDetail } from './tools/get-theme-detail.js';
-import { registerGetThemeHistory } from './tools/get-theme-history.js';
-import { registerSearchThemes } from './tools/search-themes.js';
-import { registerSearchStocks } from './tools/search-stocks.js';
-import { registerGetMarketSummary } from './tools/get-market-summary.js';
-import { registerGetMethodology } from './tools/get-methodology.js';
-import { registerGetThemeChanges } from './tools/get-theme-changes.js';
-import { registerCompareThemes } from './tools/compare-themes.js';
-import { registerGetPredictions } from './tools/get-predictions.js';
-const require = createRequire(import.meta.url);
-const { version } = require('../package.json');
-const server = new McpServer({
-    name: 'stockmatrix-mcp',
-    version,
-});
-registerGetThemeRanking(server);
-registerGetThemeDetail(server);
-registerGetThemeHistory(server);
-registerSearchThemes(server);
-registerSearchStocks(server);
-registerGetMarketSummary(server);
-registerGetMethodology(server);
-registerGetThemeChanges(server);
-registerCompareThemes(server);
-registerGetPredictions(server);
+import { createServer, VERSION } from './server.js';
 const main = async () => {
+    const server = createServer();
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error(`StockMatrix MCP server v${version} running on stdio`);
+    console.error(`StockMatrix MCP server v${VERSION} running on stdio`);
 };
 main().catch((error) => {
     console.error('Fatal error in main():', error);

--- a/mcp/dist/index.d.ts
+++ b/mcp/dist/index.d.ts
@@ -1,2 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+/** Hosted-transport entry point (Smithery / streamable HTTP). Kept as a named export for build tooling that expects it. */
 export declare const createSandboxServer: () => McpServer;
+export { createServer, registerAllTools, VERSION } from './server.js';

--- a/mcp/dist/index.js
+++ b/mcp/dist/index.js
@@ -1,32 +1,4 @@
-import { createRequire } from 'node:module';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
-import { registerGetThemeDetail } from './tools/get-theme-detail.js';
-import { registerGetThemeHistory } from './tools/get-theme-history.js';
-import { registerSearchThemes } from './tools/search-themes.js';
-import { registerSearchStocks } from './tools/search-stocks.js';
-import { registerGetMarketSummary } from './tools/get-market-summary.js';
-import { registerGetMethodology } from './tools/get-methodology.js';
-import { registerGetThemeChanges } from './tools/get-theme-changes.js';
-import { registerCompareThemes } from './tools/compare-themes.js';
-import { registerGetPredictions } from './tools/get-predictions.js';
-const require = createRequire(import.meta.url);
-const { version } = require('../package.json');
-const createServer = () => {
-    const s = new McpServer({
-        name: 'stockmatrix-mcp',
-        version,
-    });
-    registerGetThemeRanking(s);
-    registerGetThemeDetail(s);
-    registerGetThemeHistory(s);
-    registerSearchThemes(s);
-    registerSearchStocks(s);
-    registerGetMarketSummary(s);
-    registerGetMethodology(s);
-    registerGetThemeChanges(s);
-    registerCompareThemes(s);
-    registerGetPredictions(s);
-    return s;
-};
+import { createServer } from './server.js';
+/** Hosted-transport entry point (Smithery / streamable HTTP). Kept as a named export for build tooling that expects it. */
 export const createSandboxServer = () => createServer();
+export { createServer, registerAllTools, VERSION } from './server.js';

--- a/mcp/dist/prompts.d.ts
+++ b/mcp/dist/prompts.d.ts
@@ -1,0 +1,7 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+/**
+ * Curated workflow prompts. These surface as one-click slash commands in MCP clients
+ * (Claude Desktop, Cursor, …) and steer the agent through multi-tool workflows —
+ * the fastest path from "installed" to "getting real value".
+ */
+export declare const registerPrompts: (server: McpServer) => void;

--- a/mcp/dist/prompts.js
+++ b/mcp/dist/prompts.js
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+/** GetPromptResult with a single user-role text message. */
+const userPrompt = (text) => ({
+    messages: [
+        {
+            role: 'user',
+            content: { type: 'text', text },
+        },
+    ],
+});
+/**
+ * Curated workflow prompts. These surface as one-click slash commands in MCP clients
+ * (Claude Desktop, Cursor, …) and steer the agent through multi-tool workflows —
+ * the fastest path from "installed" to "getting real value".
+ */
+export const registerPrompts = (server) => {
+    server.registerPrompt('market_briefing', {
+        title: 'Korean Market Briefing',
+        description: "Today's Korean stock market theme briefing — what's hot, what's moving, and where the momentum is.",
+    }, () => userPrompt(`Give me a concise Korean stock market theme briefing for today using StockMatrix TLI data.
+
+Steps:
+1. Call get_market_summary for the overall market mood and headline signals.
+2. Call get_theme_ranking (no stage filter, limit 8) to see the top themes by lifecycle score.
+3. Call get_theme_changes to see today's biggest movers (rising and falling themes).
+
+Then synthesize into a short briefing:
+- Overall market mood in one line.
+- Top 3-5 themes right now with their score, lifecycle stage, and why they matter.
+- Notable movers (surging or fading) vs. yesterday.
+- One or two actionable observations.
+
+Keep it tight and skimmable. Use the theme scores and stages to justify each point, and note that scores are 0-100 TLI (Theme Lifecycle Index) values.`));
+    server.registerPrompt('theme_deep_dive', {
+        title: 'Theme Deep Dive',
+        description: 'Full lifecycle analysis of one Korean investment theme — score history, related stocks, news, and where it is headed.',
+        argsSchema: {
+            theme: z
+                .string()
+                .describe('Theme name or keyword (Korean or English), e.g. "AI", "반도체", "2차전지", "로봇"'),
+        },
+    }, ({ theme }) => userPrompt(`Do a full deep-dive on the Korean market theme "${theme}" using StockMatrix TLI data.
+
+Steps:
+1. Call search_themes with query "${theme}" to find the matching theme and its ID.
+2. Call get_theme_detail with that theme ID for the current score, lifecycle stage, related stocks (with prices), and recent news.
+3. Call get_theme_history for that theme ID to see the 30-day score trajectory.
+4. Call get_predictions for a forward-looking lifecycle view of that theme.
+
+Then produce an analysis covering:
+- Current lifecycle stage and score, and what that means (emerging / growth / peak / decline / reigniting).
+- The 30-day trend: rising, cooling, or turning?
+- Key related stocks and their recent price action.
+- What's driving it (news/interest) and the forward outlook from the prediction.
+- A clear one-line takeaway.
+
+If search_themes returns multiple candidates, pick the closest match and say which one you analyzed. Remind the reader this is analytical signal, not investment advice.`));
+    server.registerPrompt('find_investment_themes', {
+        title: 'Find Themes by Interest',
+        description: 'Discover Korean market themes matching an interest or trend, ranked by lifecycle momentum.',
+        argsSchema: {
+            interest: z
+                .string()
+                .describe('An interest, trend, or sector to explore, e.g. "AI", "defense", "bio", "전력/원전", "우주"'),
+        },
+    }, ({ interest }) => userPrompt(`Help me discover Korean investment themes related to "${interest}" using StockMatrix TLI data.
+
+Steps:
+1. Call search_themes with query "${interest}" to find matching themes.
+2. For the strongest 2-3 matches, note their score and lifecycle stage. If useful, call get_theme_detail on the single best match for related stocks.
+3. Optionally call get_theme_ranking to check how these themes rank against the broader market.
+
+Then present:
+- The matching themes ranked by score, each with lifecycle stage (emerging / growth / peak / decline / reigniting).
+- Which are early/rising vs. already peaked or fading — momentum matters more than raw score.
+- For the top pick, a few representative related stocks.
+- A short "where to look" summary.
+
+Frame stages in terms of momentum (is interest building or fading), and note this is analytical signal, not investment advice.`));
+    server.registerPrompt('stock_theme_check', {
+        title: 'Stock Theme Check',
+        description: 'Check whether a Korean stock sits inside any hot or rising themes right now.',
+        argsSchema: {
+            stock: z
+                .string()
+                .describe('Korean stock — a 6-digit code (e.g. "005930") or a company name (e.g. "삼성전자", "SK하이닉스")'),
+        },
+    }, ({ stock }) => userPrompt(`Check whether the Korean stock "${stock}" is part of any hot or rising themes using StockMatrix TLI data.
+
+Steps:
+1. If "${stock}" is not already a 6-digit code, call search_stocks with query "${stock}" to resolve it to a code.
+2. Call get_stock_themes with the 6-digit code to list every theme the stock belongs to, with each theme's score and lifecycle stage.
+3. If any theme looks hot (high score / growth or peak / reigniting), optionally call get_theme_detail on it for more context.
+
+Then report:
+- Which themes the stock belongs to, ranked by theme score.
+- Whether any of those themes are currently hot or rising (growth / peak / reigniting) vs. cooling.
+- The stock's relevance within its strongest theme.
+- A one-line verdict on whether the stock is riding a themed momentum wave right now.
+
+Note this is analytical signal about theme membership and momentum, not investment advice.`));
+};

--- a/mcp/dist/resources.d.ts
+++ b/mcp/dist/resources.d.ts
@@ -1,0 +1,6 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+/**
+ * Read-only resources clients can attach as context without a tool round-trip.
+ * Grounds agents in the scoring methodology and the current market snapshot.
+ */
+export declare const registerResources: (server: McpServer) => void;

--- a/mcp/dist/resources.js
+++ b/mcp/dist/resources.js
@@ -1,0 +1,39 @@
+import { fetchApi } from './fetch-helper.js';
+/**
+ * Read-only resources clients can attach as context without a tool round-trip.
+ * Grounds agents in the scoring methodology and the current market snapshot.
+ */
+export const registerResources = (server) => {
+    server.registerResource('methodology', 'stockmatrix://methodology', {
+        title: 'TLI Methodology',
+        description: 'How the Theme Lifecycle Index (TLI) score and lifecycle stages are computed — components, weights, and stage thresholds. Attach for grounded interpretation of any theme score.',
+        mimeType: 'application/json',
+    }, async (uri) => {
+        const data = await fetchApi('/api/tli/methodology');
+        return {
+            contents: [
+                {
+                    uri: uri.href,
+                    mimeType: 'application/json',
+                    text: JSON.stringify(data, null, 2),
+                },
+            ],
+        };
+    });
+    server.registerResource('rankings', 'stockmatrix://rankings', {
+        title: 'Current Theme Rankings',
+        description: "Today's Korean market theme rankings by TLI lifecycle score, grouped by stage, with the market summary. A live snapshot to attach as context.",
+        mimeType: 'application/json',
+    }, async (uri) => {
+        const data = await fetchApi('/api/tli/scores/ranking');
+        return {
+            contents: [
+                {
+                    uri: uri.href,
+                    mimeType: 'application/json',
+                    text: JSON.stringify(data, null, 2),
+                },
+            ],
+        };
+    });
+};

--- a/mcp/dist/server.d.ts
+++ b/mcp/dist/server.d.ts
@@ -1,0 +1,6 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+export declare const VERSION: string;
+/** Register every StockMatrix tool on a server instance. Single source of truth for both stdio (cli) and hosted (sandbox) transports. */
+export declare const registerAllTools: (server: McpServer) => void;
+/** Build a fully configured StockMatrix MCP server with tools, workflow prompts, and resources. */
+export declare const createServer: () => McpServer;

--- a/mcp/dist/server.js
+++ b/mcp/dist/server.js
@@ -1,0 +1,42 @@
+import { createRequire } from 'node:module';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
+import { registerGetThemeDetail } from './tools/get-theme-detail.js';
+import { registerGetThemeHistory } from './tools/get-theme-history.js';
+import { registerSearchThemes } from './tools/search-themes.js';
+import { registerSearchStocks } from './tools/search-stocks.js';
+import { registerGetMarketSummary } from './tools/get-market-summary.js';
+import { registerGetMethodology } from './tools/get-methodology.js';
+import { registerGetThemeChanges } from './tools/get-theme-changes.js';
+import { registerCompareThemes } from './tools/compare-themes.js';
+import { registerGetPredictions } from './tools/get-predictions.js';
+import { registerGetStockThemes } from './tools/get-stock-themes.js';
+import { registerPrompts } from './prompts.js';
+import { registerResources } from './resources.js';
+const require = createRequire(import.meta.url);
+export const VERSION = require('../package.json').version;
+/** Register every StockMatrix tool on a server instance. Single source of truth for both stdio (cli) and hosted (sandbox) transports. */
+export const registerAllTools = (server) => {
+    registerGetThemeRanking(server);
+    registerGetThemeDetail(server);
+    registerGetThemeHistory(server);
+    registerSearchThemes(server);
+    registerSearchStocks(server);
+    registerGetStockThemes(server);
+    registerGetMarketSummary(server);
+    registerGetMethodology(server);
+    registerGetThemeChanges(server);
+    registerCompareThemes(server);
+    registerGetPredictions(server);
+};
+/** Build a fully configured StockMatrix MCP server with tools, workflow prompts, and resources. */
+export const createServer = () => {
+    const server = new McpServer({
+        name: 'stockmatrix-mcp',
+        version: VERSION,
+    });
+    registerAllTools(server);
+    registerPrompts(server);
+    registerResources(server);
+    return server;
+};

--- a/mcp/dist/tools/compare-themes.js
+++ b/mcp/dist/tools/compare-themes.js
@@ -6,7 +6,9 @@ Shows each theme's current TLI score, lifecycle stage, 7-day sparkline,
 pairwise similarity (from comparison algorithm), overlapping stocks, and any warnings.
 Use when the user asks to compare or contrast multiple themes.`;
 export const registerCompareThemes = (server) => {
-    server.tool('compare_themes', `Compare 2–5 Korean stock market themes side-by-side with lifecycle scores, similarity, and overlapping stocks.
+    server.registerTool('compare_themes', {
+        title: 'Compare Themes',
+        description: `Compare 2–5 Korean stock market themes side-by-side with lifecycle scores, similarity, and overlapping stocks.
 
 Use when the user asks:
 - Compare semiconductor and AI themes
@@ -15,12 +17,15 @@ Use when the user asks:
 - Which theme is stronger right now?
 - Do these themes share the same stocks?
 
-Returns each theme's score/stage/sparkline, pairwise similarity scores, and overlapping stocks.`, {
-        theme_ids: z
-            .array(z.string().uuid())
-            .min(2)
-            .max(5)
-            .describe('Array of 2–5 theme UUIDs to compare'),
+Returns each theme's score/stage/sparkline, pairwise similarity scores, and overlapping stocks.`,
+        inputSchema: {
+            theme_ids: z
+                .array(z.string().uuid())
+                .min(2)
+                .max(5)
+                .describe('Array of 2–5 theme UUIDs to compare'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ theme_ids }) => {
         try {
             const data = await fetchApi('/api/tli/compare', {

--- a/mcp/dist/tools/get-market-summary.js
+++ b/mcp/dist/tools/get-market-summary.js
@@ -5,7 +5,9 @@ Use as a first call when the user asks what is hot, what the market looks like t
 Includes stage distribution, top themes, market coverage, endpoint references, and citation/disclaimer metadata.
 Each theme in the response includes themeId for chaining to get_theme_detail.`;
 export const registerGetMarketSummary = (server) => {
-    server.tool('get_market_summary', `Get an AI-optimized summary of the Korean stock theme market.
+    server.registerTool('get_market_summary', {
+        title: 'Market Summary',
+        description: `Get an AI-optimized summary of the Korean stock theme market.
 
 Use when the user asks:
 - What's happening in Korean stock themes right now?
@@ -13,7 +15,10 @@ Use when the user asks:
 - 오늘 한국 테마 시장 요약
 - 현재 뜨는 테마와 시장 분포를 한 번에 보고 싶어
 
-Returns a concise market overview, stage distribution, top themes, endpoint references, citation metadata, and disclaimer text.`, {}, async () => {
+Returns a concise market overview, stage distribution, top themes, endpoint references, citation metadata, and disclaimer text.`,
+        inputSchema: {},
+        annotations: { readOnlyHint: true, openWorldHint: true },
+    }, async () => {
         try {
             const data = await fetchApi('/api/ai/summary');
             return {

--- a/mcp/dist/tools/get-methodology.js
+++ b/mcp/dist/tools/get-methodology.js
@@ -30,7 +30,9 @@ const METHODOLOGY_FALLBACK = {
 const CONTEXT = `[StockMatrix TLI Methodology]
 Comprehensive documentation of the TLI (Theme Lifecycle Index) algorithm — scoring, stages, stabilization, comparison, prediction, data sources, pipeline, and database schema.`;
 export const registerGetMethodology = (server) => {
-    server.tool('get_methodology', `Get the TLI (Theme Lifecycle Index) algorithm methodology — how scores, stages, and predictions work.
+    server.registerTool('get_methodology', {
+        title: 'TLI Methodology',
+        description: `Get the TLI (Theme Lifecycle Index) algorithm methodology — how scores, stages, and predictions work.
 
 Use when the user asks:
 - How are theme scores calculated?
@@ -41,11 +43,14 @@ Use when the user asks:
 - What data sources are used?
 - TLI 수집 파이프라인, 업데이트 주기, 비교 파이프라인, 데이터 테이블
 
-Returns structured documentation of the scoring algorithm, data collection pipeline, runtime orchestration, database tables, stage determination, stabilization techniques, comparison analysis, and prediction methodology.`, {
-        section: z
-            .enum(SECTIONS)
-            .optional()
-            .describe('Specific section: scoring, stabilization, stages, comparison, prediction, data_sources, update_schedule, runtime, data_flow, database_tables, limitations, or all (default: all)'),
+Returns structured documentation of the scoring algorithm, data collection pipeline, runtime orchestration, database tables, stage determination, stabilization techniques, comparison analysis, and prediction methodology.`,
+        inputSchema: {
+            section: z
+                .enum(SECTIONS)
+                .optional()
+                .describe('Specific section: scoring, stabilization, stages, comparison, prediction, data_sources, update_schedule, runtime, data_flow, database_tables, limitations, or all (default: all)'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ section }) => {
         try {
             const params = section ? { section } : undefined;

--- a/mcp/dist/tools/get-predictions.js
+++ b/mcp/dist/tools/get-predictions.js
@@ -7,7 +7,9 @@ Use pRise, CI bounds, abstain state, and trailing90d precision as the primary co
 The phase field is deprecated compatibility derived from pRise and will be removed after 2026-09-15.
 Chain with get_theme_detail(themeId) for deeper analysis of any predicted theme.`;
 export const registerGetPredictions = (server) => {
-    server.tool('get_predictions', `Get champion probability prediction snapshots for Korean stock themes.
+    server.registerTool('get_predictions', {
+        title: 'Theme Predictions',
+        description: `Get champion probability prediction snapshots for Korean stock themes.
 
 Use when the user asks:
 - Which themes are rising / about to peak / cooling down?
@@ -17,11 +19,14 @@ Use when the user asks:
 - 상승세 테마 예측, 하락 전환 예상 테마
 - 테마 생명주기 예측 결과를 보고 싶어
 
-Returns v3 snapshot fields when exposure is enabled: pRise, ciLower, ciUpper, abstain, abstainReasons, modelVersion, trailing90d.topSignalPrecision, and deprecated phase compatibility. Returns dataSource=none when exposure is disabled for rollback.`, {
-        phase: z
-            .enum(['rising', 'hot', 'cooling'])
-            .optional()
-            .describe('Deprecated compatibility filter derived from pRise: rising >=0.6, hot >=0.4, cooling <0.4'),
+Returns v3 snapshot fields when exposure is enabled: pRise, ciLower, ciUpper, abstain, abstainReasons, modelVersion, trailing90d.topSignalPrecision, and deprecated phase compatibility. Returns dataSource=none when exposure is disabled for rollback.`,
+        inputSchema: {
+            phase: z
+                .enum(['rising', 'hot', 'cooling'])
+                .optional()
+                .describe('Deprecated compatibility filter derived from pRise: rising >=0.6, hot >=0.4, cooling <0.4'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ phase }) => {
         try {
             const params = {};

--- a/mcp/dist/tools/get-stock-themes.d.ts
+++ b/mcp/dist/tools/get-stock-themes.d.ts
@@ -1,0 +1,2 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+export declare const registerGetStockThemes: (server: McpServer) => void;

--- a/mcp/dist/tools/get-stock-themes.js
+++ b/mcp/dist/tools/get-stock-themes.js
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { fetchApi, formatResult, formatError, formatEmptyResult } from '../fetch-helper.js';
+const CONTEXT = `[StockMatrix Stock → Themes]
+Reverse lookup: given a Korean stock code, returns every active TLI theme the stock belongs to, sorted by theme score (0-100, highest first).
+Each entry includes the theme's lifecycle stage, reigniting flag, and the stock's relevance within that theme.
+Use this to judge whether a specific stock sits inside currently hot or rising themes — the theme's momentum often explains the stock's moves.`;
+export const registerGetStockThemes = (server) => {
+    server.registerTool('get_stock_themes', {
+        title: 'Stock → Themes',
+        description: `Find every Korean market theme a specific stock belongs to, each with its current TLI lifecycle score and stage.
+
+Use when the user asks about:
+- Which themes/sectors a stock belongs to
+- Whether a specific stock is part of any hot/trending/rising theme
+- 삼성전자(005930)가 속한 테마, 이 종목 관련 테마, 내 종목이 뜨는 테마에 있는지
+- Why a stock is moving (via its theme membership and momentum)
+
+Input is a 6-digit Korean stock code (e.g. 005930 Samsung Electronics, 000660 SK Hynix). To find a code from a company name, use search_stocks first. Returns themes sorted by score, each with lifecycle stage and the stock's relevance in that theme.`,
+        inputSchema: {
+            symbol: z
+                .string()
+                .regex(/^\d{6}$/, 'Korean stock code must be 6 digits')
+                .describe('Korean stock code — exactly 6 digits (e.g. "005930" Samsung Electronics, "000660" SK Hynix)'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
+    }, async ({ symbol }) => {
+        try {
+            const data = await fetchApi(`/api/tli/stocks/${symbol}/theme`);
+            if (Array.isArray(data) && data.length === 0) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: formatEmptyResult(CONTEXT, `No active themes found for stock ${symbol}. The stock may not be tracked in any current TLI theme, or the code may be incorrect. Use search_stocks to look up a valid 6-digit code by company name.`),
+                        },
+                    ],
+                };
+            }
+            return {
+                content: [{ type: 'text', text: formatResult(data, CONTEXT) }],
+            };
+        }
+        catch (error) {
+            return {
+                content: [{ type: 'text', text: formatError(error) }],
+                isError: true,
+            };
+        }
+    });
+};

--- a/mcp/dist/tools/get-theme-changes.js
+++ b/mcp/dist/tools/get-theme-changes.js
@@ -11,7 +11,9 @@ const isEmpty = (data) => data.movers.rising.length === 0 &&
     data.stageTransitions.length === 0 &&
     data.newlyEmerging.length === 0;
 export const registerGetThemeChanges = (server) => {
-    server.tool('get_theme_changes', `Get recent score changes and stage transitions for Korean stock themes.
+    server.registerTool('get_theme_changes', {
+        title: 'Daily Theme Movers',
+        description: `Get recent score changes and stage transitions for Korean stock themes.
 
 Use when the user asks:
 - What themes changed the most today/this week?
@@ -21,11 +23,14 @@ Use when the user asks:
 - 이번 주 생명주기 단계 변화한 테마
 - 새로 떠오르는 테마 있어?
 
-Returns movers (rising/falling by score change), stage transitions, and newly emerging themes.`, {
-        period: z
-            .enum(['1d', '7d'])
-            .optional()
-            .describe('Comparison period: 1d = vs yesterday (default), 7d = vs 7 days ago'),
+Returns movers (rising/falling by score change), stage transitions, and newly emerging themes.`,
+        inputSchema: {
+            period: z
+                .enum(['1d', '7d'])
+                .optional()
+                .describe('Comparison period: 1d = vs yesterday (default), 7d = vs 7 days ago'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ period }) => {
         try {
             const data = await fetchApi('/api/tli/changes', {

--- a/mcp/dist/tools/get-theme-detail.js
+++ b/mcp/dist/tools/get-theme-detail.js
@@ -10,15 +10,20 @@ Score stabilization: Cautious Decay (3-signal majority vote prevents false drops
 Stage transitions use Markov constraints + 2-day hysteresis.
 Comparisons: 3-Pillar similarity (feature + curve + keyword) with Mutual Rank, threshold ≥ 0.40.`;
 export const registerGetThemeDetail = (server) => {
-    server.tool('get_theme_detail', `Get detailed analysis for a specific Korean stock theme.
+    server.registerTool('get_theme_detail', {
+        title: 'Theme Detail',
+        description: `Get detailed analysis for a specific Korean stock theme.
 
 Returns: TLI score breakdown (4 components with weights), lifecycle stage, 24h/7d score changes, prediction outlook, top related stocks with price changes, latest news headlines, and similar theme comparisons.
 
-Use after get_theme_ranking or search_themes to drill into a specific theme. Answers: "tell me more about this theme", "what stocks are in this theme", "테마 상세 정보", "관련 종목 알려줘", "이 테마 전망".`, {
-        theme_id: z
-            .string()
-            .uuid('Theme ID must be a valid UUID')
-            .describe('Theme UUID from ranking or search results'),
+Use after get_theme_ranking or search_themes to drill into a specific theme. Answers: "tell me more about this theme", "what stocks are in this theme", "테마 상세 정보", "관련 종목 알려줘", "이 테마 전망".`,
+        inputSchema: {
+            theme_id: z
+                .string()
+                .uuid('Theme ID must be a valid UUID')
+                .describe('Theme UUID from ranking or search results'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ theme_id }) => {
         try {
             const data = await fetchApi(`/api/tli/themes/${theme_id}`);

--- a/mcp/dist/tools/get-theme-history.js
+++ b/mcp/dist/tools/get-theme-history.js
@@ -8,15 +8,20 @@ Daily TLI scores with stage transitions. Use to identify:
 - Momentum: EMA smoothing adapts to theme age (newer themes react faster)
 Scores are 0-100, computed from interest + news + volatility + activity.`;
 export const registerGetThemeHistory = (server) => {
-    server.tool('get_theme_history', `Get 30-day score history for a Korean stock theme.
+    server.registerTool('get_theme_history', {
+        title: 'Theme Score History',
+        description: `Get 30-day score history for a Korean stock theme.
 
 Returns daily TLI scores and stage transitions for trend analysis. Use when the user asks about theme momentum over time, whether a theme is gaining or losing interest, or wants to see historical trajectory.
 
-Answers: "이 테마 추세가 어때?", "최근 한달 흐름", "is this theme gaining or losing momentum?", "show me the trend".`, {
-        theme_id: z
-            .string()
-            .uuid('Theme ID must be a valid UUID')
-            .describe('Theme UUID from ranking or search results'),
+Answers: "이 테마 추세가 어때?", "최근 한달 흐름", "is this theme gaining or losing momentum?", "show me the trend".`,
+        inputSchema: {
+            theme_id: z
+                .string()
+                .uuid('Theme ID must be a valid UUID')
+                .describe('Theme UUID from ranking or search results'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ theme_id }) => {
         try {
             const data = await fetchApi(`/api/tli/themes/${theme_id}/history`);

--- a/mcp/dist/tools/get-theme-ranking.js
+++ b/mcp/dist/tools/get-theme-ranking.js
@@ -20,7 +20,9 @@ Stages: Emerging → Growth → Peak → Decline → Dormant (with possible Reig
 Higher score = stronger theme momentum. Stage indicates lifecycle position.
 The \`summary\` object includes \`signals\` (market mood indicators), \`hottestTheme\` (single highest scorer with 3+ stocks), and \`surging\` (rapidly rising themes).`;
 export const registerGetThemeRanking = (server) => {
-    server.tool('get_theme_ranking', `Get Korean stock market theme rankings with lifecycle scores (TLI: Theme Lifecycle Index).
+    server.registerTool('get_theme_ranking', {
+        title: 'Theme Rankings',
+        description: `Get Korean stock market theme rankings with lifecycle scores (TLI: Theme Lifecycle Index).
 
 Use when the user asks about:
 - Trending stock themes, hot investment sectors, market momentum
@@ -28,22 +30,25 @@ Use when the user asks about:
 - 한국 주식 테마 랭킹, 요즘 뜨는 테마, 상승/하락 테마
 - KOSPI/KOSDAQ theme trends
 
-Returns themes ranked by score (0-100) with lifecycle stage and related stocks. Scores are computed from search interest (Naver DataLab), news momentum, market volatility, and stock activity — all optimized via Bayesian optimization.`, {
-        stage: z
-            .enum(VALID_STAGES)
-            .optional()
-            .describe('Filter by lifecycle stage: emerging (초기 — early interest), growth (성장 — expanding), peak (정점 — maximum attention), decline (하락 — fading), reigniting (재점화 — comeback)'),
-        limit: z
-            .number()
-            .int()
-            .min(1)
-            .max(50)
-            .optional()
-            .describe('Max themes per stage (1-50, default 10)'),
-        sort: z
-            .enum(['score', 'change7d', 'newsCount7d'])
-            .optional()
-            .describe('Sort order within each stage: score (default), change7d, newsCount7d'),
+Returns themes ranked by score (0-100) with lifecycle stage and related stocks. Scores are computed from search interest (Naver DataLab), news momentum, market volatility, and stock activity — all optimized via Bayesian optimization.`,
+        inputSchema: {
+            stage: z
+                .enum(VALID_STAGES)
+                .optional()
+                .describe('Filter by lifecycle stage: emerging (초기 — early interest), growth (성장 — expanding), peak (정점 — maximum attention), decline (하락 — fading), reigniting (재점화 — comeback)'),
+            limit: z
+                .number()
+                .int()
+                .min(1)
+                .max(50)
+                .optional()
+                .describe('Max themes per stage (1-50, default 10)'),
+            sort: z
+                .enum(['score', 'change7d', 'newsCount7d'])
+                .optional()
+                .describe('Sort order within each stage: score (default), change7d, newsCount7d'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ stage, limit, sort }) => {
         try {
             const params = {};

--- a/mcp/dist/tools/search-stocks.js
+++ b/mcp/dist/tools/search-stocks.js
@@ -7,7 +7,9 @@ Results include stock identity plus top related themes with lifecycle score and 
 Common examples: 삼성전자, SK하이닉스, NAVER, 카카오, 005930, 000660.`;
 const IS_SIX_DIGIT = /^\d{6}$/;
 export const registerSearchStocks = (server) => {
-    server.tool('search_stocks', `Search Korean stocks by company name, symbol, or 6-digit stock code, and preview their related themes.
+    server.registerTool('search_stocks', {
+        title: 'Search Stocks',
+        description: `Search Korean stocks by company name, symbol, or 6-digit stock code, and preview their related themes.
 
 Use when the user asks:
 - Find Samsung Electronics / 삼성전자
@@ -17,12 +19,15 @@ Use when the user asks:
 - 005930 테마 알려줘 / which themes is this stock part of?
 
 For 6-digit stock codes, automatically performs a detailed stock-to-theme lookup (replaces get_stock_theme).
-For text queries, searches by company name and returns matching stocks with theme previews.`, {
-        query: z
-            .string()
-            .min(1)
-            .max(200)
-            .describe('Company name or 6-digit stock code, e.g. "삼성전자", "SK하이닉스", "005930"'),
+For text queries, searches by company name and returns matching stocks with theme previews.`,
+        inputSchema: {
+            query: z
+                .string()
+                .min(1)
+                .max(200)
+                .describe('Company name or 6-digit stock code, e.g. "삼성전자", "SK하이닉스", "005930"'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ query }) => {
         try {
             if (IS_SIX_DIGIT.test(query.trim())) {

--- a/mcp/dist/tools/search-themes.js
+++ b/mcp/dist/tools/search-themes.js
@@ -6,18 +6,23 @@ Use theme_id with get_theme_detail for full analysis or get_theme_history for 30
 Search also matches related stock names and 6-digit stock codes when available.
 Stages: Emerging (초기) → Growth (성장) → Peak (정점) → Decline (하락), with Reigniting (재점화) for comeback themes.`;
 export const registerSearchThemes = (server) => {
-    server.tool('search_themes', `Search Korean stock market themes by keyword (Korean or English).
+    server.registerTool('search_themes', {
+        title: 'Search Themes',
+        description: `Search Korean stock market themes by keyword (Korean or English).
 
 Use when the user asks about a specific sector, industry, investment theme, stock name, or stock code. Searches theme names, related stock names, and stock symbols.
 
 Examples: "AI", "반도체" (semiconductor), "2차전지" (EV battery), "방산" (defense), "로봇" (robotics), "원자력" (nuclear), "삼성전자" (Samsung), "005930".
 
-Returns matching themes with TLI scores and lifecycle stages. Use the returned theme_id with get_theme_detail or get_theme_history for deeper analysis.`, {
-        query: z
-            .string()
-            .min(1)
-            .max(200)
-            .describe('Search query — theme name, sector keyword, stock name, or 6-digit stock code'),
+Returns matching themes with TLI scores and lifecycle stages. Use the returned theme_id with get_theme_detail or get_theme_history for deeper analysis.`,
+        inputSchema: {
+            query: z
+                .string()
+                .min(1)
+                .max(200)
+                .describe('Search query — theme name, sector keyword, stock name, or 6-digit stock code'),
+        },
+        annotations: { readOnlyHint: true, openWorldHint: true },
     }, async ({ query }) => {
         try {
             const data = await fetchApi('/api/tli/themes', { q: query });

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "stockmatrix-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stockmatrix-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -19,7 +19,7 @@
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@hono/node-server": {
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stockmatrix-mcp",
   "mcpName": "io.github.MongLong0214/stockmatrix-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "StockMatrix MCP Server — Korean stock market theme lifecycle analysis (TLI) with Bayesian-optimized scoring for AI agents",
   "type": "module",
   "main": "dist/index.js",
@@ -13,8 +13,9 @@
   ],
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/cli.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run typecheck && npm run build"
   },
   "keywords": [
     "mcp",
@@ -35,10 +36,10 @@
   "license": "MIT",
   "author": "StockMatrix <aistockmatrix@gmail.com>",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MongLong0214/stockmatrix-mcp",
-  "description": "StockMatrix MCP Server — Korean stock market theme lifecycle analysis (TLI): market summaries, theme rankings, stock↔theme lookup, Bayesian-optimized scoring, 250+ KOSPI/KOSDAQ themes, related stocks, news, predictions, methodology, plus guided workflow prompts and live resources",
+  "description": "Korean stock market theme lifecycle analysis (TLI) — rankings, stock lookup, predictions & prompts",
   "repository": {
     "url": "https://github.com/MongLong0214/stock-ai-newsletter",
     "source": "github",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MongLong0214/stockmatrix-mcp",
-  "description": "StockMatrix MCP Server — Korean stock market theme lifecycle analysis (TLI) with market summaries, stock search, Bayesian-optimized scoring, 250+ KOSPI/KOSDAQ themes, related stocks, news, and methodology",
+  "description": "StockMatrix MCP Server — Korean stock market theme lifecycle analysis (TLI): market summaries, theme rankings, stock↔theme lookup, Bayesian-optimized scoring, 250+ KOSPI/KOSDAQ themes, related stocks, news, predictions, methodology, plus guided workflow prompts and live resources",
   "repository": {
     "url": "https://github.com/MongLong0214/stock-ai-newsletter",
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.4.1",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "stockmatrix-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/smithery.yaml
+++ b/mcp/smithery.yaml
@@ -9,4 +9,4 @@ tags:
   - kosdaq
   - bayesian-optimization
 runtime: node
-startCommand: npx -y stockmatrix-mcp@0.4.0
+startCommand: npx -y stockmatrix-mcp@0.5.0

--- a/mcp/src/__tests__/index.test.ts
+++ b/mcp/src/__tests__/index.test.ts
@@ -13,6 +13,11 @@ describe('MCP index module (static analysis)', () => {
     'utf-8'
   )
 
+  const serverSource = readFileSync(
+    resolve(__dirname, '../server.ts'),
+    'utf-8'
+  )
+
   it('index.ts does not contain main() call', () => {
     expect(indexSource).not.toMatch(/\bmain\s*\(/)
   })
@@ -55,26 +60,33 @@ describe('MCP index module (static analysis)', () => {
     expect(pkg.main).toBe('dist/index.js')
   })
 
-  it('registers 10 tools (7 original + 3 new, get_stock_theme removed)', () => {
-    const registerCalls = indexSource.match(/register\w+\(s\)/g)
-    expect(registerCalls).toHaveLength(10)
+  it('index.ts delegates to the shared server module (no inline tool registration)', () => {
+    expect(indexSource).toContain("from './server.js'")
+    expect(indexSource).not.toMatch(/registerGet\w+\(/)
   })
 
-  it('includes all expected tool registrations', () => {
+  it('server.ts registers all 11 tools exactly once each', () => {
     const expected = [
       'registerGetThemeRanking',
       'registerGetThemeDetail',
       'registerGetThemeHistory',
       'registerSearchThemes',
       'registerSearchStocks',
+      'registerGetStockThemes',
       'registerGetMarketSummary',
       'registerGetMethodology',
       'registerGetThemeChanges',
       'registerCompareThemes',
       'registerGetPredictions',
     ]
+    expect(expected).toHaveLength(11)
     for (const name of expected) {
-      expect(indexSource).toContain(name)
+      expect(serverSource).toContain(`${name}(server)`)
     }
+  })
+
+  it('server.ts wires workflow prompts and resources', () => {
+    expect(serverSource).toContain('registerPrompts(server)')
+    expect(serverSource).toContain('registerResources(server)')
   })
 })

--- a/mcp/src/__tests__/server-smoke.test.ts
+++ b/mcp/src/__tests__/server-smoke.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../server.js';
+
+/**
+ * End-to-end smoke test over the real MCP protocol: a client connects to the
+ * server through an in-memory transport and lists its capabilities. This proves
+ * every tool/prompt/resource registers without collision and is actually
+ * advertised over the wire — something the static-source tests cannot catch.
+ */
+describe('MCP server capabilities (in-memory protocol handshake)', () => {
+  const connect = async () => {
+    const server = createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'smoke-test', version: '0.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return { client, server };
+  };
+
+  it('advertises all 11 tools with correct names, titles, and read-only annotations', async () => {
+    const { client } = await connect();
+    const { tools } = await client.listTools();
+
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        'compare_themes',
+        'get_market_summary',
+        'get_methodology',
+        'get_predictions',
+        'get_stock_themes',
+        'get_theme_changes',
+        'get_theme_detail',
+        'get_theme_history',
+        'get_theme_ranking',
+        'search_stocks',
+        'search_themes',
+      ].sort()
+    );
+
+    for (const tool of tools) {
+      expect(tool.title, `${tool.name} should have a title`).toBeTruthy();
+      expect(tool.annotations?.readOnlyHint, `${tool.name} should be read-only`).toBe(true);
+    }
+  });
+
+  it('advertises all 4 workflow prompts', async () => {
+    const { client } = await connect();
+    const { prompts } = await client.listPrompts();
+    const names = prompts.map((p) => p.name).sort();
+    expect(names).toEqual(
+      ['find_investment_themes', 'market_briefing', 'stock_theme_check', 'theme_deep_dive'].sort()
+    );
+  });
+
+  it('advertises both resources with stockmatrix:// URIs', async () => {
+    const { client } = await connect();
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri).sort();
+    expect(uris).toEqual(['stockmatrix://methodology', 'stockmatrix://rankings'].sort());
+  });
+
+  it('resolves a prompt with its argument interpolated', async () => {
+    const { client } = await connect();
+    const result = await client.getPrompt({
+      name: 'theme_deep_dive',
+      arguments: { theme: '반도체' },
+    });
+    const text = result.messages.map((m) => (m.content.type === 'text' ? m.content.text : '')).join('\n');
+    expect(text).toContain('반도체');
+    expect(text).toContain('search_themes');
+  });
+});

--- a/mcp/src/__tests__/tools-changes.test.ts
+++ b/mcp/src/__tests__/tools-changes.test.ts
@@ -25,7 +25,7 @@ describe('get_theme_changes tool', () => {
 
     // Capture the handler registered with server.tool
     server = {
-      tool: vi.fn((_name: string, _desc: string, _schema: unknown, handler: unknown) => {
+      registerTool: vi.fn((_name: string, _config: unknown, handler: unknown) => {
         registeredHandler = handler as typeof registeredHandler
       }),
     } as unknown as McpServer
@@ -34,10 +34,13 @@ describe('get_theme_changes tool', () => {
   })
 
   it('registers tool with name get_theme_changes', () => {
-    expect(server.tool).toHaveBeenCalledWith(
+    expect(server.registerTool).toHaveBeenCalledWith(
       'get_theme_changes',
-      expect.any(String),
-      expect.objectContaining({ period: expect.anything() }),
+      expect.objectContaining({
+        description: expect.any(String),
+        inputSchema: expect.objectContaining({ period: expect.anything() }),
+        annotations: expect.objectContaining({ readOnlyHint: true }),
+      }),
       expect.any(Function),
     )
   })

--- a/mcp/src/__tests__/tools-compare.test.ts
+++ b/mcp/src/__tests__/tools-compare.test.ts
@@ -27,7 +27,7 @@ describe('compare-themes MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -59,7 +59,7 @@ describe('compare-themes MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -84,7 +84,7 @@ describe('compare-themes MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -115,7 +115,7 @@ describe('compare-themes MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }

--- a/mcp/src/__tests__/tools-methodology.test.ts
+++ b/mcp/src/__tests__/tools-methodology.test.ts
@@ -28,7 +28,7 @@ describe('get-methodology MCP tool (API fetch mode)', () => {
     // Create a mock MCP server
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -49,7 +49,7 @@ describe('get-methodology MCP tool (API fetch mode)', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -66,7 +66,7 @@ describe('get-methodology MCP tool (API fetch mode)', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }

--- a/mcp/src/__tests__/tools-predictions.test.ts
+++ b/mcp/src/__tests__/tools-predictions.test.ts
@@ -22,9 +22,9 @@ describe('get-predictions MCP tool', () => {
     const { registerGetPredictions } = await import('../tools/get-predictions.js')
 
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: { description?: string }, handler: typeof registeredHandler) => {
         registeredName = _name
-        registeredDescription = _desc
+        registeredDescription = _config.description ?? ''
         registeredHandler = handler
       },
     }

--- a/mcp/src/__tests__/tools-ranking.test.ts
+++ b/mcp/src/__tests__/tools-ranking.test.ts
@@ -29,7 +29,7 @@ describe('get-theme-ranking MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -58,7 +58,7 @@ describe('get-theme-ranking MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }
@@ -77,7 +77,7 @@ describe('get-theme-ranking MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }

--- a/mcp/src/__tests__/tools-stock-themes.test.ts
+++ b/mcp/src/__tests__/tools-stock-themes.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetchApi = vi.fn()
+vi.mock('../fetch-helper.js', () => ({
+  fetchApi: (...args: unknown[]) => mockFetchApi(...args),
+  formatResult: (data: unknown, context?: string) =>
+    context ? `${context}\n\n${JSON.stringify(data, null, 2)}` : JSON.stringify(data, null, 2),
+  formatError: (error: unknown) =>
+    `Error: ${error instanceof Error ? error.message : String(error)}`,
+  formatEmptyResult: (context: string, guidance: string) =>
+    `${context}\n\n[]\n\n${guidance}`,
+}))
+
+type ToolHandler = (args: { symbol: string }) => Promise<{
+  content: { type: string; text: string }[]
+  isError?: boolean
+}>
+
+describe('get-stock-themes MCP tool', () => {
+  let registeredName = ''
+  let registeredConfig: { annotations?: { readOnlyHint?: boolean } } = {}
+  let handler: ToolHandler
+
+  beforeEach(async () => {
+    mockFetchApi.mockReset()
+    const { registerGetStockThemes } = await import('../tools/get-stock-themes.js')
+    const mockServer = {
+      registerTool: (
+        name: string,
+        config: { annotations?: { readOnlyHint?: boolean } },
+        cb: ToolHandler
+      ) => {
+        registeredName = name
+        registeredConfig = config
+        handler = cb
+      },
+    }
+    registerGetStockThemes(mockServer as never)
+  })
+
+  it('registers as get_stock_themes with a read-only annotation', () => {
+    expect(registeredName).toBe('get_stock_themes')
+    expect(registeredConfig.annotations?.readOnlyHint).toBe(true)
+  })
+
+  it('calls the reverse-lookup endpoint with the 6-digit symbol', async () => {
+    mockFetchApi.mockResolvedValueOnce([{ themeId: 't1', score: 72, stage: 'growth' }])
+    await handler({ symbol: '005930' })
+    expect(mockFetchApi).toHaveBeenCalledWith('/api/tli/stocks/005930/theme')
+  })
+
+  it('returns guidance when the stock belongs to no active themes', async () => {
+    mockFetchApi.mockResolvedValueOnce([])
+    const result = await handler({ symbol: '123456' })
+    expect(result.content[0].text).toContain('No active themes found for stock 123456')
+    expect(result.content[0].text).toContain('search_stocks')
+  })
+
+  it('surfaces errors with isError', async () => {
+    mockFetchApi.mockRejectedValueOnce(new Error('boom'))
+    const result = await handler({ symbol: '005930' })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('boom')
+  })
+})

--- a/mcp/src/__tests__/tools-summary.test.ts
+++ b/mcp/src/__tests__/tools-summary.test.ts
@@ -22,7 +22,7 @@ describe('get-market-summary MCP tool', () => {
 
     let registeredHandler: (args: Record<string, unknown>) => Promise<unknown> = async () => ({})
     const mockServer = {
-      tool: (_name: string, _desc: string, _schema: unknown, handler: typeof registeredHandler) => {
+      registerTool: (_name: string, _config: unknown, handler: typeof registeredHandler) => {
         registeredHandler = handler
       },
     }

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,42 +1,13 @@
 #!/usr/bin/env node
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createRequire } from 'node:module';
-import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
-import { registerGetThemeDetail } from './tools/get-theme-detail.js';
-import { registerGetThemeHistory } from './tools/get-theme-history.js';
-import { registerSearchThemes } from './tools/search-themes.js';
-import { registerSearchStocks } from './tools/search-stocks.js';
-import { registerGetMarketSummary } from './tools/get-market-summary.js';
-import { registerGetMethodology } from './tools/get-methodology.js';
-import { registerGetThemeChanges } from './tools/get-theme-changes.js';
-import { registerCompareThemes } from './tools/compare-themes.js';
-import { registerGetPredictions } from './tools/get-predictions.js';
-
-const require = createRequire(import.meta.url);
-const { version } = require('../package.json') as { version: string };
-
-const server = new McpServer({
-  name: 'stockmatrix-mcp',
-  version,
-});
-
-registerGetThemeRanking(server);
-registerGetThemeDetail(server);
-registerGetThemeHistory(server);
-registerSearchThemes(server);
-registerSearchStocks(server);
-registerGetMarketSummary(server);
-registerGetMethodology(server);
-registerGetThemeChanges(server);
-registerCompareThemes(server);
-registerGetPredictions(server);
+import { createServer, VERSION } from './server.js';
 
 const main = async (): Promise<void> => {
+  const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`StockMatrix MCP server v${version} running on stdio`);
+  console.error(`StockMatrix MCP server v${VERSION} running on stdio`);
 };
 
 main().catch((error: unknown) => {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,37 +1,7 @@
-import { createRequire } from 'node:module';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
-import { registerGetThemeDetail } from './tools/get-theme-detail.js';
-import { registerGetThemeHistory } from './tools/get-theme-history.js';
-import { registerSearchThemes } from './tools/search-themes.js';
-import { registerSearchStocks } from './tools/search-stocks.js';
-import { registerGetMarketSummary } from './tools/get-market-summary.js';
-import { registerGetMethodology } from './tools/get-methodology.js';
-import { registerGetThemeChanges } from './tools/get-theme-changes.js';
-import { registerCompareThemes } from './tools/compare-themes.js';
-import { registerGetPredictions } from './tools/get-predictions.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createServer } from './server.js';
 
-const require = createRequire(import.meta.url);
-const { version } = require('../package.json') as { version: string };
-
-const createServer = (): McpServer => {
-  const s = new McpServer({
-    name: 'stockmatrix-mcp',
-    version,
-  });
-
-  registerGetThemeRanking(s);
-  registerGetThemeDetail(s);
-  registerGetThemeHistory(s);
-  registerSearchThemes(s);
-  registerSearchStocks(s);
-  registerGetMarketSummary(s);
-  registerGetMethodology(s);
-  registerGetThemeChanges(s);
-  registerCompareThemes(s);
-  registerGetPredictions(s);
-
-  return s;
-};
-
+/** Hosted-transport entry point (Smithery / streamable HTTP). Kept as a named export for build tooling that expects it. */
 export const createSandboxServer = (): McpServer => createServer();
+
+export { createServer, registerAllTools, VERSION } from './server.js';

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -1,0 +1,140 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+/** GetPromptResult with a single user-role text message. */
+const userPrompt = (text: string) => ({
+  messages: [
+    {
+      role: 'user' as const,
+      content: { type: 'text' as const, text },
+    },
+  ],
+});
+
+/**
+ * Curated workflow prompts. These surface as one-click slash commands in MCP clients
+ * (Claude Desktop, Cursor, …) and steer the agent through multi-tool workflows —
+ * the fastest path from "installed" to "getting real value".
+ */
+export const registerPrompts = (server: McpServer): void => {
+  server.registerPrompt(
+    'market_briefing',
+    {
+      title: 'Korean Market Briefing',
+      description:
+        "Today's Korean stock market theme briefing — what's hot, what's moving, and where the momentum is.",
+    },
+    () =>
+      userPrompt(
+        `Give me a concise Korean stock market theme briefing for today using StockMatrix TLI data.
+
+Steps:
+1. Call get_market_summary for the overall market mood and headline signals.
+2. Call get_theme_ranking (no stage filter, limit 8) to see the top themes by lifecycle score.
+3. Call get_theme_changes to see today's biggest movers (rising and falling themes).
+
+Then synthesize into a short briefing:
+- Overall market mood in one line.
+- Top 3-5 themes right now with their score, lifecycle stage, and why they matter.
+- Notable movers (surging or fading) vs. yesterday.
+- One or two actionable observations.
+
+Keep it tight and skimmable. Use the theme scores and stages to justify each point, and note that scores are 0-100 TLI (Theme Lifecycle Index) values.`
+      )
+  );
+
+  server.registerPrompt(
+    'theme_deep_dive',
+    {
+      title: 'Theme Deep Dive',
+      description:
+        'Full lifecycle analysis of one Korean investment theme — score history, related stocks, news, and where it is headed.',
+      argsSchema: {
+        theme: z
+          .string()
+          .describe('Theme name or keyword (Korean or English), e.g. "AI", "반도체", "2차전지", "로봇"'),
+      },
+    },
+    ({ theme }) =>
+      userPrompt(
+        `Do a full deep-dive on the Korean market theme "${theme}" using StockMatrix TLI data.
+
+Steps:
+1. Call search_themes with query "${theme}" to find the matching theme and its ID.
+2. Call get_theme_detail with that theme ID for the current score, lifecycle stage, related stocks (with prices), and recent news.
+3. Call get_theme_history for that theme ID to see the 30-day score trajectory.
+4. Call get_predictions for a forward-looking lifecycle view of that theme.
+
+Then produce an analysis covering:
+- Current lifecycle stage and score, and what that means (emerging / growth / peak / decline / reigniting).
+- The 30-day trend: rising, cooling, or turning?
+- Key related stocks and their recent price action.
+- What's driving it (news/interest) and the forward outlook from the prediction.
+- A clear one-line takeaway.
+
+If search_themes returns multiple candidates, pick the closest match and say which one you analyzed. Remind the reader this is analytical signal, not investment advice.`
+      )
+  );
+
+  server.registerPrompt(
+    'find_investment_themes',
+    {
+      title: 'Find Themes by Interest',
+      description:
+        'Discover Korean market themes matching an interest or trend, ranked by lifecycle momentum.',
+      argsSchema: {
+        interest: z
+          .string()
+          .describe('An interest, trend, or sector to explore, e.g. "AI", "defense", "bio", "전력/원전", "우주"'),
+      },
+    },
+    ({ interest }) =>
+      userPrompt(
+        `Help me discover Korean investment themes related to "${interest}" using StockMatrix TLI data.
+
+Steps:
+1. Call search_themes with query "${interest}" to find matching themes.
+2. For the strongest 2-3 matches, note their score and lifecycle stage. If useful, call get_theme_detail on the single best match for related stocks.
+3. Optionally call get_theme_ranking to check how these themes rank against the broader market.
+
+Then present:
+- The matching themes ranked by score, each with lifecycle stage (emerging / growth / peak / decline / reigniting).
+- Which are early/rising vs. already peaked or fading — momentum matters more than raw score.
+- For the top pick, a few representative related stocks.
+- A short "where to look" summary.
+
+Frame stages in terms of momentum (is interest building or fading), and note this is analytical signal, not investment advice.`
+      )
+  );
+
+  server.registerPrompt(
+    'stock_theme_check',
+    {
+      title: 'Stock Theme Check',
+      description:
+        'Check whether a Korean stock sits inside any hot or rising themes right now.',
+      argsSchema: {
+        stock: z
+          .string()
+          .describe('Korean stock — a 6-digit code (e.g. "005930") or a company name (e.g. "삼성전자", "SK하이닉스")'),
+      },
+    },
+    ({ stock }) =>
+      userPrompt(
+        `Check whether the Korean stock "${stock}" is part of any hot or rising themes using StockMatrix TLI data.
+
+Steps:
+1. If "${stock}" is not already a 6-digit code, call search_stocks with query "${stock}" to resolve it to a code.
+2. Call get_stock_themes with the 6-digit code to list every theme the stock belongs to, with each theme's score and lifecycle stage.
+3. If any theme looks hot (high score / growth or peak / reigniting), optionally call get_theme_detail on it for more context.
+
+Then report:
+- Which themes the stock belongs to, ranked by theme score.
+- Whether any of those themes are currently hot or rising (growth / peak / reigniting) vs. cooling.
+- The stock's relevance within its strongest theme.
+- A one-line verdict on whether the stock is riding a themed momentum wave right now.
+
+Note this is analytical signal about theme membership and momentum, not investment advice.`
+      )
+  );
+};

--- a/mcp/src/resources.ts
+++ b/mcp/src/resources.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { fetchApi } from './fetch-helper.js';
+
+/**
+ * Read-only resources clients can attach as context without a tool round-trip.
+ * Grounds agents in the scoring methodology and the current market snapshot.
+ */
+export const registerResources = (server: McpServer): void => {
+  server.registerResource(
+    'methodology',
+    'stockmatrix://methodology',
+    {
+      title: 'TLI Methodology',
+      description:
+        'How the Theme Lifecycle Index (TLI) score and lifecycle stages are computed — components, weights, and stage thresholds. Attach for grounded interpretation of any theme score.',
+      mimeType: 'application/json',
+    },
+    async (uri) => {
+      const data = await fetchApi('/api/tli/methodology');
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'application/json',
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerResource(
+    'rankings',
+    'stockmatrix://rankings',
+    {
+      title: 'Current Theme Rankings',
+      description:
+        "Today's Korean market theme rankings by TLI lifecycle score, grouped by stage, with the market summary. A live snapshot to attach as context.",
+      mimeType: 'application/json',
+    },
+    async (uri) => {
+      const data = await fetchApi('/api/tli/scores/ranking');
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'application/json',
+            text: JSON.stringify(data, null, 2),
+          },
+        ],
+      };
+    }
+  );
+};

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,45 @@
+import { createRequire } from 'node:module';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerGetThemeRanking } from './tools/get-theme-ranking.js';
+import { registerGetThemeDetail } from './tools/get-theme-detail.js';
+import { registerGetThemeHistory } from './tools/get-theme-history.js';
+import { registerSearchThemes } from './tools/search-themes.js';
+import { registerSearchStocks } from './tools/search-stocks.js';
+import { registerGetMarketSummary } from './tools/get-market-summary.js';
+import { registerGetMethodology } from './tools/get-methodology.js';
+import { registerGetThemeChanges } from './tools/get-theme-changes.js';
+import { registerCompareThemes } from './tools/compare-themes.js';
+import { registerGetPredictions } from './tools/get-predictions.js';
+import { registerGetStockThemes } from './tools/get-stock-themes.js';
+import { registerPrompts } from './prompts.js';
+import { registerResources } from './resources.js';
+
+const require = createRequire(import.meta.url);
+export const VERSION = (require('../package.json') as { version: string }).version;
+
+/** Register every StockMatrix tool on a server instance. Single source of truth for both stdio (cli) and hosted (sandbox) transports. */
+export const registerAllTools = (server: McpServer): void => {
+  registerGetThemeRanking(server);
+  registerGetThemeDetail(server);
+  registerGetThemeHistory(server);
+  registerSearchThemes(server);
+  registerSearchStocks(server);
+  registerGetStockThemes(server);
+  registerGetMarketSummary(server);
+  registerGetMethodology(server);
+  registerGetThemeChanges(server);
+  registerCompareThemes(server);
+  registerGetPredictions(server);
+};
+
+/** Build a fully configured StockMatrix MCP server with tools, workflow prompts, and resources. */
+export const createServer = (): McpServer => {
+  const server = new McpServer({
+    name: 'stockmatrix-mcp',
+    version: VERSION,
+  });
+  registerAllTools(server);
+  registerPrompts(server);
+  registerResources(server);
+  return server;
+};

--- a/mcp/src/tools/compare-themes.ts
+++ b/mcp/src/tools/compare-themes.ts
@@ -9,9 +9,11 @@ pairwise similarity (from comparison algorithm), overlapping stocks, and any war
 Use when the user asks to compare or contrast multiple themes.`;
 
 export const registerCompareThemes = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'compare_themes',
-    `Compare 2–5 Korean stock market themes side-by-side with lifecycle scores, similarity, and overlapping stocks.
+    {
+      title: 'Compare Themes',
+      description: `Compare 2–5 Korean stock market themes side-by-side with lifecycle scores, similarity, and overlapping stocks.
 
 Use when the user asks:
 - Compare semiconductor and AI themes
@@ -21,12 +23,14 @@ Use when the user asks:
 - Do these themes share the same stocks?
 
 Returns each theme's score/stage/sparkline, pairwise similarity scores, and overlapping stocks.`,
-    {
-      theme_ids: z
-        .array(z.string().uuid())
-        .min(2)
-        .max(5)
-        .describe('Array of 2–5 theme UUIDs to compare'),
+      inputSchema: {
+        theme_ids: z
+          .array(z.string().uuid())
+          .min(2)
+          .max(5)
+          .describe('Array of 2–5 theme UUIDs to compare'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ theme_ids }) => {
       try {

--- a/mcp/src/tools/get-market-summary.ts
+++ b/mcp/src/tools/get-market-summary.ts
@@ -8,9 +8,11 @@ Includes stage distribution, top themes, market coverage, endpoint references, a
 Each theme in the response includes themeId for chaining to get_theme_detail.`;
 
 export const registerGetMarketSummary = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_market_summary',
-    `Get an AI-optimized summary of the Korean stock theme market.
+    {
+      title: 'Market Summary',
+      description: `Get an AI-optimized summary of the Korean stock theme market.
 
 Use when the user asks:
 - What's happening in Korean stock themes right now?
@@ -19,7 +21,9 @@ Use when the user asks:
 - 현재 뜨는 테마와 시장 분포를 한 번에 보고 싶어
 
 Returns a concise market overview, stage distribution, top themes, endpoint references, citation metadata, and disclaimer text.`,
-    {},
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
     async () => {
       try {
         const data = await fetchApi('/api/ai/summary');

--- a/mcp/src/tools/get-methodology.ts
+++ b/mcp/src/tools/get-methodology.ts
@@ -35,9 +35,11 @@ const CONTEXT = `[StockMatrix TLI Methodology]
 Comprehensive documentation of the TLI (Theme Lifecycle Index) algorithm — scoring, stages, stabilization, comparison, prediction, data sources, pipeline, and database schema.`;
 
 export const registerGetMethodology = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_methodology',
-    `Get the TLI (Theme Lifecycle Index) algorithm methodology — how scores, stages, and predictions work.
+    {
+      title: 'TLI Methodology',
+      description: `Get the TLI (Theme Lifecycle Index) algorithm methodology — how scores, stages, and predictions work.
 
 Use when the user asks:
 - How are theme scores calculated?
@@ -49,11 +51,13 @@ Use when the user asks:
 - TLI 수집 파이프라인, 업데이트 주기, 비교 파이프라인, 데이터 테이블
 
 Returns structured documentation of the scoring algorithm, data collection pipeline, runtime orchestration, database tables, stage determination, stabilization techniques, comparison analysis, and prediction methodology.`,
-    {
-      section: z
-        .enum(SECTIONS)
-        .optional()
-        .describe('Specific section: scoring, stabilization, stages, comparison, prediction, data_sources, update_schedule, runtime, data_flow, database_tables, limitations, or all (default: all)'),
+      inputSchema: {
+        section: z
+          .enum(SECTIONS)
+          .optional()
+          .describe('Specific section: scoring, stabilization, stages, comparison, prediction, data_sources, update_schedule, runtime, data_flow, database_tables, limitations, or all (default: all)'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ section }) => {
       try {

--- a/mcp/src/tools/get-predictions.ts
+++ b/mcp/src/tools/get-predictions.ts
@@ -38,9 +38,11 @@ interface PredictionResponse {
 }
 
 export const registerGetPredictions = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_predictions',
-    `Get champion probability prediction snapshots for Korean stock themes.
+    {
+      title: 'Theme Predictions',
+      description: `Get champion probability prediction snapshots for Korean stock themes.
 
 Use when the user asks:
 - Which themes are rising / about to peak / cooling down?
@@ -51,11 +53,13 @@ Use when the user asks:
 - 테마 생명주기 예측 결과를 보고 싶어
 
 Returns v3 snapshot fields when exposure is enabled: pRise, ciLower, ciUpper, abstain, abstainReasons, modelVersion, trailing90d.topSignalPrecision, and deprecated phase compatibility. Returns dataSource=none when exposure is disabled for rollback.`,
-    {
-      phase: z
-        .enum(['rising', 'hot', 'cooling'])
-        .optional()
-        .describe('Deprecated compatibility filter derived from pRise: rising >=0.6, hot >=0.4, cooling <0.4'),
+      inputSchema: {
+        phase: z
+          .enum(['rising', 'hot', 'cooling'])
+          .optional()
+          .describe('Deprecated compatibility filter derived from pRise: rising >=0.6, hot >=0.4, cooling <0.4'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ phase }: { readonly phase?: 'rising' | 'hot' | 'cooling' }) => {
       try {

--- a/mcp/src/tools/get-stock-themes.ts
+++ b/mcp/src/tools/get-stock-themes.ts
@@ -1,0 +1,63 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { fetchApi, formatResult, formatError, formatEmptyResult } from '../fetch-helper.js';
+
+const CONTEXT = `[StockMatrix Stock → Themes]
+Reverse lookup: given a Korean stock code, returns every active TLI theme the stock belongs to, sorted by theme score (0-100, highest first).
+Each entry includes the theme's lifecycle stage, reigniting flag, and the stock's relevance within that theme.
+Use this to judge whether a specific stock sits inside currently hot or rising themes — the theme's momentum often explains the stock's moves.`;
+
+export const registerGetStockThemes = (server: McpServer): void => {
+  server.registerTool(
+    'get_stock_themes',
+    {
+      title: 'Stock → Themes',
+      description: `Find every Korean market theme a specific stock belongs to, each with its current TLI lifecycle score and stage.
+
+Use when the user asks about:
+- Which themes/sectors a stock belongs to
+- Whether a specific stock is part of any hot/trending/rising theme
+- 삼성전자(005930)가 속한 테마, 이 종목 관련 테마, 내 종목이 뜨는 테마에 있는지
+- Why a stock is moving (via its theme membership and momentum)
+
+Input is a 6-digit Korean stock code (e.g. 005930 Samsung Electronics, 000660 SK Hynix). To find a code from a company name, use search_stocks first. Returns themes sorted by score, each with lifecycle stage and the stock's relevance in that theme.`,
+      inputSchema: {
+        symbol: z
+          .string()
+          .regex(/^\d{6}$/, 'Korean stock code must be 6 digits')
+          .describe(
+            'Korean stock code — exactly 6 digits (e.g. "005930" Samsung Electronics, "000660" SK Hynix)'
+          ),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ symbol }) => {
+      try {
+        const data = await fetchApi<unknown[]>(`/api/tli/stocks/${symbol}/theme`);
+
+        if (Array.isArray(data) && data.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: formatEmptyResult(
+                  CONTEXT,
+                  `No active themes found for stock ${symbol}. The stock may not be tracked in any current TLI theme, or the code may be incorrect. Use search_stocks to look up a valid 6-digit code by company name.`
+                ),
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: formatResult(data, CONTEXT) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: formatError(error) }],
+          isError: true,
+        };
+      }
+    }
+  );
+};

--- a/mcp/src/tools/get-theme-changes.ts
+++ b/mcp/src/tools/get-theme-changes.ts
@@ -25,9 +25,11 @@ const isEmpty = (data: ChangesData): boolean =>
   data.newlyEmerging.length === 0;
 
 export const registerGetThemeChanges = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_theme_changes',
-    `Get recent score changes and stage transitions for Korean stock themes.
+    {
+      title: 'Daily Theme Movers',
+      description: `Get recent score changes and stage transitions for Korean stock themes.
 
 Use when the user asks:
 - What themes changed the most today/this week?
@@ -38,11 +40,13 @@ Use when the user asks:
 - 새로 떠오르는 테마 있어?
 
 Returns movers (rising/falling by score change), stage transitions, and newly emerging themes.`,
-    {
-      period: z
-        .enum(['1d', '7d'])
-        .optional()
-        .describe('Comparison period: 1d = vs yesterday (default), 7d = vs 7 days ago'),
+      inputSchema: {
+        period: z
+          .enum(['1d', '7d'])
+          .optional()
+          .describe('Comparison period: 1d = vs yesterday (default), 7d = vs 7 days ago'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ period }) => {
       try {

--- a/mcp/src/tools/get-theme-detail.ts
+++ b/mcp/src/tools/get-theme-detail.ts
@@ -13,18 +13,22 @@ Stage transitions use Markov constraints + 2-day hysteresis.
 Comparisons: 3-Pillar similarity (feature + curve + keyword) with Mutual Rank, threshold ≥ 0.40.`;
 
 export const registerGetThemeDetail = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_theme_detail',
-    `Get detailed analysis for a specific Korean stock theme.
+    {
+      title: 'Theme Detail',
+      description: `Get detailed analysis for a specific Korean stock theme.
 
 Returns: TLI score breakdown (4 components with weights), lifecycle stage, 24h/7d score changes, prediction outlook, top related stocks with price changes, latest news headlines, and similar theme comparisons.
 
 Use after get_theme_ranking or search_themes to drill into a specific theme. Answers: "tell me more about this theme", "what stocks are in this theme", "테마 상세 정보", "관련 종목 알려줘", "이 테마 전망".`,
-    {
-      theme_id: z
-        .string()
-        .uuid('Theme ID must be a valid UUID')
-        .describe('Theme UUID from ranking or search results'),
+      inputSchema: {
+        theme_id: z
+          .string()
+          .uuid('Theme ID must be a valid UUID')
+          .describe('Theme UUID from ranking or search results'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ theme_id }) => {
       try {

--- a/mcp/src/tools/get-theme-history.ts
+++ b/mcp/src/tools/get-theme-history.ts
@@ -11,18 +11,22 @@ Daily TLI scores with stage transitions. Use to identify:
 Scores are 0-100, computed from interest + news + volatility + activity.`;
 
 export const registerGetThemeHistory = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_theme_history',
-    `Get 30-day score history for a Korean stock theme.
+    {
+      title: 'Theme Score History',
+      description: `Get 30-day score history for a Korean stock theme.
 
 Returns daily TLI scores and stage transitions for trend analysis. Use when the user asks about theme momentum over time, whether a theme is gaining or losing interest, or wants to see historical trajectory.
 
 Answers: "이 테마 추세가 어때?", "최근 한달 흐름", "is this theme gaining or losing momentum?", "show me the trend".`,
-    {
-      theme_id: z
-        .string()
-        .uuid('Theme ID must be a valid UUID')
-        .describe('Theme UUID from ranking or search results'),
+      inputSchema: {
+        theme_id: z
+          .string()
+          .uuid('Theme ID must be a valid UUID')
+          .describe('Theme UUID from ranking or search results'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ theme_id }) => {
       try {

--- a/mcp/src/tools/get-theme-ranking.ts
+++ b/mcp/src/tools/get-theme-ranking.ts
@@ -25,9 +25,11 @@ Higher score = stronger theme momentum. Stage indicates lifecycle position.
 The \`summary\` object includes \`signals\` (market mood indicators), \`hottestTheme\` (single highest scorer with 3+ stocks), and \`surging\` (rapidly rising themes).`;
 
 export const registerGetThemeRanking = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'get_theme_ranking',
-    `Get Korean stock market theme rankings with lifecycle scores (TLI: Theme Lifecycle Index).
+    {
+      title: 'Theme Rankings',
+      description: `Get Korean stock market theme rankings with lifecycle scores (TLI: Theme Lifecycle Index).
 
 Use when the user asks about:
 - Trending stock themes, hot investment sectors, market momentum
@@ -36,24 +38,26 @@ Use when the user asks about:
 - KOSPI/KOSDAQ theme trends
 
 Returns themes ranked by score (0-100) with lifecycle stage and related stocks. Scores are computed from search interest (Naver DataLab), news momentum, market volatility, and stock activity — all optimized via Bayesian optimization.`,
-    {
-      stage: z
-        .enum(VALID_STAGES)
-        .optional()
-        .describe(
-          'Filter by lifecycle stage: emerging (초기 — early interest), growth (성장 — expanding), peak (정점 — maximum attention), decline (하락 — fading), reigniting (재점화 — comeback)'
-        ),
-      limit: z
-        .number()
-        .int()
-        .min(1)
-        .max(50)
-        .optional()
-        .describe('Max themes per stage (1-50, default 10)'),
-      sort: z
-        .enum(['score', 'change7d', 'newsCount7d'])
-        .optional()
-        .describe('Sort order within each stage: score (default), change7d, newsCount7d'),
+      inputSchema: {
+        stage: z
+          .enum(VALID_STAGES)
+          .optional()
+          .describe(
+            'Filter by lifecycle stage: emerging (초기 — early interest), growth (성장 — expanding), peak (정점 — maximum attention), decline (하락 — fading), reigniting (재점화 — comeback)'
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe('Max themes per stage (1-50, default 10)'),
+        sort: z
+          .enum(['score', 'change7d', 'newsCount7d'])
+          .optional()
+          .describe('Sort order within each stage: score (default), change7d, newsCount7d'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ stage, limit, sort }) => {
       try {

--- a/mcp/src/tools/search-stocks.ts
+++ b/mcp/src/tools/search-stocks.ts
@@ -11,9 +11,11 @@ Common examples: 삼성전자, SK하이닉스, NAVER, 카카오, 005930, 000660.
 const IS_SIX_DIGIT = /^\d{6}$/;
 
 export const registerSearchStocks = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'search_stocks',
-    `Search Korean stocks by company name, symbol, or 6-digit stock code, and preview their related themes.
+    {
+      title: 'Search Stocks',
+      description: `Search Korean stocks by company name, symbol, or 6-digit stock code, and preview their related themes.
 
 Use when the user asks:
 - Find Samsung Electronics / 삼성전자
@@ -24,12 +26,14 @@ Use when the user asks:
 
 For 6-digit stock codes, automatically performs a detailed stock-to-theme lookup (replaces get_stock_theme).
 For text queries, searches by company name and returns matching stocks with theme previews.`,
-    {
-      query: z
-        .string()
-        .min(1)
-        .max(200)
-        .describe('Company name or 6-digit stock code, e.g. "삼성전자", "SK하이닉스", "005930"'),
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe('Company name or 6-digit stock code, e.g. "삼성전자", "SK하이닉스", "005930"'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ query }) => {
       try {

--- a/mcp/src/tools/search-themes.ts
+++ b/mcp/src/tools/search-themes.ts
@@ -9,21 +9,25 @@ Search also matches related stock names and 6-digit stock codes when available.
 Stages: Emerging (초기) → Growth (성장) → Peak (정점) → Decline (하락), with Reigniting (재점화) for comeback themes.`;
 
 export const registerSearchThemes = (server: McpServer): void => {
-  server.tool(
+  server.registerTool(
     'search_themes',
-    `Search Korean stock market themes by keyword (Korean or English).
+    {
+      title: 'Search Themes',
+      description: `Search Korean stock market themes by keyword (Korean or English).
 
 Use when the user asks about a specific sector, industry, investment theme, stock name, or stock code. Searches theme names, related stock names, and stock symbols.
 
 Examples: "AI", "반도체" (semiconductor), "2차전지" (EV battery), "방산" (defense), "로봇" (robotics), "원자력" (nuclear), "삼성전자" (Samsung), "005930".
 
 Returns matching themes with TLI scores and lifecycle stages. Use the returned theme_id with get_theme_detail or get_theme_history for deeper analysis.`,
-    {
-      query: z
-        .string()
-        .min(1)
-        .max(200)
-        .describe('Search query — theme name, sector keyword, stock name, or 6-digit stock code'),
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe('Search query — theme name, sector keyword, stock name, or 6-digit stock code'),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
     },
     async ({ query }) => {
       try {


### PR DESCRIPTION
## 목표
MCP(npm) 패키지를 프로덕션 레디로 정비하고, **실사용을 끌어올릴** 기능을 추가.

## 실사용 확장 (신규 기능)
- **신규 도구 `get_stock_themes`** — 종목→소속 테마 역조회 (점수·단계·relevance). 미노출 엔드포인트 활용. "내 종목이 뜨는 테마에 있나" 해결.
- **워크플로우 프롬프트 4종** (MCP Prompts = 클라이언트 슬래시커맨드, 채택 최대 드라이버):
  `market_briefing`, `theme_deep_dive`, `find_investment_themes`, `stock_theme_check`. 다중 도구 분석을 원클릭 실행 → 설치 직후 가치 체감.
- **리소스 2종**: `stockmatrix://methodology`, `stockmatrix://rankings`.

## 프로덕션 레디 (품질)
- **DRY**: cli.ts/index.ts의 10개 도구 등록 중복 제거 → `src/server.ts` 단일 소스.
- **최신 API**: 10개 도구 전부 deprecated `server.tool()` → `registerTool()` 이관 + `title` + `annotations{readOnlyHint, openWorldHint}`.
- SDK **1.27.1 → 1.29.0**, engines node **>=20**, version **0.5.0**.
- server.json(레지스트리)·smithery.yaml **0.5.0** 정렬, `prepublishOnly` typecheck 게이트.

## 검증
- tsc/typecheck 0 에러. **테스트 73개 통과**.
- **server-smoke.test.ts**: InMemoryTransport 실제 MCP 프로토콜 핸드셰이크로 11 도구(title+readOnlyHint)·4 프롬프트·2 리소스 등록 + 프롬프트 인자 보간 end-to-end 검증.
- 실제 stdio 기동 확인: `StockMatrix MCP server v0.5.0 running on stdio`.

## 재배포
npm publish + MCP 레지스트리(`mcp-publisher`) + Smithery(0.5.0 재빌드)는 npm 인증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)