### PR TITLE
fix(tli): 점수 계산 절대 수준을 앵커 척도로 전환

### DIFF
--- a/lib/tli/__tests__/interest-scale.test.ts
+++ b/lib/tli/__tests__/interest-scale.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateLifecycleScore } from '@/lib/tli/calculator'
+import { MIN_ANCHOR_INTEREST } from '@/lib/tli/constants/score-config'
+import { resolveInterestLevel, resolveRunInterestScale } from '@/lib/tli/interest-scale'
+import type { InterestMetric, NewsMetric } from '@/lib/tli/types/db'
+
+/**
+ * 앵커(`계산기`) 투입 이후 raw_value가 정수 반올림으로 해상도를 잃은 구간을 재현한다.
+ * ratio 0.4~1.4 → round() → 0 또는 1. 실측 중앙값 테마의 모습이다.
+ */
+const anchorEraMetric = (index: number, ratio: number): InterestMetric => ({
+  id: `m${index}`,
+  theme_id: 'theme-a',
+  time: `2026-07-${String(24 - index).padStart(2, '0')}`,
+  source: 'naver_datalab',
+  raw_value: Math.round(ratio),
+  normalized: 50,
+  anchor_scaled_value: ratio / 79,
+})
+
+const rawEraMetric = (index: number, raw: number): InterestMetric => ({
+  id: `m${index}`,
+  theme_id: 'theme-a',
+  time: `2026-06-${String(6 - index).padStart(2, '0')}`,
+  source: 'naver_datalab',
+  raw_value: raw,
+  normalized: 50,
+  anchor_scaled_value: null,
+})
+
+const news: NewsMetric[] = Array.from({ length: 14 }, (_, i) => ({
+  id: `n${i}`,
+  theme_id: 'theme-a',
+  time: `2026-07-${String(24 - i).padStart(2, '0')}`,
+  article_count: 5,
+  growth_rate: null,
+}))
+
+/** ratio 합 6.1 / 7일 = 0.8714…  — 반올림하면 0,1,1,1,1,1,1 → 6/7 = 0.8571… */
+const RATIOS = [0.4, 1.4, 0.6, 1.2, 0.5, 1.3, 0.7] as const
+const RATIO_MEAN = RATIOS.reduce((a, b) => a + b, 0) / RATIOS.length
+const ROUNDED_MEAN = RATIOS.map(Math.round).reduce((a, b) => a + b, 0) / RATIOS.length
+
+describe('resolveInterestLevel — 척도별 절대 수준', () => {
+  const window = RATIOS.map((ratio, i) => anchorEraMetric(i, ratio))
+
+  it('raw 척도에서는 반올림된 정수 평균이 나온다', () => {
+    // 0.4는 0으로, 1.4는 1로 뭉개진다 — 3.5배 차이가 사라진다
+    expect(resolveInterestLevel(window, 'raw')).toBeCloseTo(ROUNDED_MEAN, 10)
+    expect(ROUNDED_MEAN).not.toBeCloseTo(RATIO_MEAN, 3)
+  })
+
+  it('앵커 척도는 반올림 전 실수를 보존한다', () => {
+    const level = resolveInterestLevel(window, 'anchor')
+    expect(level).not.toBeNull()
+    expect(level!).toBeCloseTo(RATIO_MEAN / 79, 10)
+  })
+
+  it('해당 척도의 관측이 없으면 null — 다른 척도 값으로 대체하지 않는다', () => {
+    expect(resolveInterestLevel([rawEraMetric(0, 20)], 'anchor')).toBeNull()
+  })
+})
+
+describe('resolveRunInterestScale — 런 단위 확정', () => {
+  const anchorWindow = [0.4, 1.4, 0.6].map((r, i) => anchorEraMetric(i, r))
+  const rawWindow = [20, 22, 24].map((r, i) => rawEraMetric(i, r))
+
+  it('과반이 앵커를 갖추면 앵커 척도', () => {
+    expect(resolveRunInterestScale([anchorWindow, anchorWindow, rawWindow])).toBe('anchor')
+  })
+
+  it('앵커 적재 이전 구간을 재계산하면 raw 척도로 남는다', () => {
+    expect(resolveRunInterestScale([rawWindow, rawWindow, anchorWindow])).toBe('raw')
+  })
+
+  it('테마가 없으면 raw 척도 (기존 동작)', () => {
+    expect(resolveRunInterestScale([])).toBe('raw')
+  })
+})
+
+describe('calculateLifecycleScore — 앵커 이후 감쇠 폭주 회귀', () => {
+  const metrics = RATIOS.map((r, i) => anchorEraMetric(i, r))
+
+  it('raw 척도로 매기면 감쇠가 min_raw_interest(4) 대비 1/5 수준으로 떨어진다', () => {
+    const result = calculateLifecycleScore({
+      interestMetrics: metrics,
+      newsMetrics: news,
+      firstSpikeDate: '2026-06-01',
+      today: '2026-07-24',
+      allThemesRawAvg: [0, 1, 2, 3, 4],
+      interestScale: 'raw',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.components.raw.dampening_factor).toBeCloseTo(ROUNDED_MEAN / 4, 10)
+    expect(result!.components.raw.dampening_factor).toBeLessThan(0.25)
+    expect(result!.components.raw.interest_scale).toBe('raw')
+  })
+
+  it('앵커 척도로 매기면 같은 테마가 감쇠를 받지 않는다', () => {
+    // 0.8714/79 ≈ 0.011 > MIN_ANCHOR_INTEREST(0.003)
+    const level = resolveInterestLevel(metrics, 'anchor')!
+    expect(level).toBeGreaterThan(MIN_ANCHOR_INTEREST)
+
+    const result = calculateLifecycleScore({
+      interestMetrics: metrics,
+      newsMetrics: news,
+      firstSpikeDate: '2026-06-01',
+      today: '2026-07-24',
+      allThemesRawAvg: [0.001, 0.003, 0.006, 0.018, 0.058],
+      interestScale: 'anchor',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.components.raw.dampening_factor).toBe(1)
+    expect(result!.components.raw.interest_scale).toBe('anchor')
+  })
+
+  it('앵커 척도에서도 진짜 바닥 테마는 여전히 감쇠된다', () => {
+    const dead = [0.05, 0.02, 0.03, 0.04, 0.02, 0.03, 0.05].map((r, i) => anchorEraMetric(i, r))
+
+    const result = calculateLifecycleScore({
+      interestMetrics: dead,
+      newsMetrics: news,
+      firstSpikeDate: '2026-06-01',
+      today: '2026-07-24',
+      allThemesRawAvg: [0.001, 0.003, 0.006, 0.018, 0.058],
+      interestScale: 'anchor',
+    })
+
+    expect(result!.components.raw.dampening_factor).toBeLessThan(1)
+  })
+
+  it('interestScale 미지정 시 기존 raw 동작을 유지한다', () => {
+    const result = calculateLifecycleScore({
+      interestMetrics: metrics,
+      newsMetrics: news,
+      firstSpikeDate: '2026-06-01',
+      today: '2026-07-24',
+      allThemesRawAvg: [0, 1, 2, 3, 4],
+    })
+
+    expect(result!.components.raw.interest_scale).toBe('raw')
+  })
+})

--- a/lib/tli/calculator.ts
+++ b/lib/tli/calculator.ts
@@ -12,7 +12,8 @@ import {
 } from './normalize';
 import { getKSTDateString } from './date-utils';
 import { getTLIParams, computeWActivity, type TLIParams } from './constants/tli-params';
-import { getMinRawInterest, getScoreWeights } from './constants/score-config';
+import { getNoiseFloor, getScoreWeights } from './constants/score-config';
+import { resolveInterestLevel, type InterestScale } from './interest-scale';
 import { computeSentimentProxy } from './sentiment-proxy';
 import { computeScoreConfidence } from './score-confidence';
 import type { InterestMetric, NewsMetric, ScoreComponents, ScoreConfidence } from './types';
@@ -29,6 +30,11 @@ interface CalculateScoreInput {
   avgVolume?: number;
   allThemesRawAvg?: number[];
   rawPercentile?: number;
+  /**
+   * 절대 관심 수준을 읽을 척도. `allThemesRawAvg`도 반드시 같은 척도로 만들어져야 한다.
+   * 기본 'raw'는 앵커 이전 동작 그대로 — 호출부가 명시적으로 넘길 때만 앵커로 전환된다.
+   */
+  interestScale?: InterestScale;
   prevSmoothedScore?: number;
   prevAvgVolume?: number;
   config?: Partial<TLIParams>;
@@ -53,8 +59,9 @@ export function calculateLifecycleScore(input: CalculateScoreInput): {
   const recent7dAvg = avg(recent7d);
   const baselineAvg = baseline.length > 0 ? avg(baseline) : recent7dAvg;
 
-  const recent7dRaw = interestMetrics.slice(0, 7).map(m => m.raw_value);
-  const rawAvg = avg(recent7dRaw);
+  // 절대 수준은 척도에 따라 다른 컬럼에서 온다 — 감쇠 임계값도 같은 척도의 것을 써야 한다
+  const interestScale: InterestScale = input.interestScale ?? 'raw';
+  const rawAvg = resolveInterestLevel(interestMetrics.slice(0, 7), interestScale) ?? 0;
 
   const newsThisWeek = newsMetrics.slice(0, 7).reduce((sum, m) => sum + m.article_count, 0);
   const newsLastWeek = newsMetrics.slice(7, 14).reduce((sum, m) => sum + m.article_count, 0);
@@ -65,8 +72,12 @@ export function calculateLifecycleScore(input: CalculateScoreInput): {
     levelScore = percentileRank(rawAvg, input.allThemesRawAvg);
   } else if (input.rawPercentile !== undefined) {
     levelScore = input.rawPercentile;
-  } else {
+  } else if (interestScale === 'raw') {
     levelScore = sigmoid_normalize(rawAvg, cfg.interest_level_center, cfg.interest_level_scale);
+  } else {
+    // sigmoid 중심·스케일 상수는 raw 척도로 교정돼 있어 앵커 값(~0.006)에 쓰면 전부 0이 된다.
+    // 교차 모집단 없이 앵커 척도의 수준을 놓을 방법이 없으므로 중립값으로 둔다.
+    levelScore = 0.5;
   }
 
   const recent7dAsc = [...recent7d].reverse();
@@ -75,14 +86,18 @@ export function calculateLifecycleScore(input: CalculateScoreInput): {
   let momentumScore: number;
   if (baselineAvg > 0) {
     momentumScore = sigmoid_normalize(growthRate, 0, cfg.interest_momentum_scale);
-  } else {
+  } else if (interestScale === 'raw') {
     momentumScore = sigmoid_normalize(rawAvg, cfg.interest_level_center, cfg.interest_level_scale) * 0.5;
+  } else {
+    momentumScore = levelScore * 0.5;
   }
 
   let interestScore = levelScore * cfg.interest_level_ratio + momentumScore * (1 - cfg.interest_level_ratio);
 
-  const minRawInterest = input.config?.min_raw_interest ?? getMinRawInterest();
-  const dampeningFactor = rawAvg < minRawInterest ? rawAvg / minRawInterest : 1;
+  const noiseFloor = interestScale === 'raw' && input.config?.min_raw_interest !== undefined
+    ? input.config.min_raw_interest
+    : getNoiseFloor(interestScale);
+  const dampeningFactor = rawAvg < noiseFloor ? rawAvg / noiseFloor : 1;
   interestScore *= dampeningFactor;
 
   // ── 2. News Score ──
@@ -181,6 +196,7 @@ export function calculateLifecycleScore(input: CalculateScoreInput): {
       interest_stddev: interestStdDev,
       active_days: activeDays,
       raw_interest_avg: rawAvg,
+      interest_scale: interestScale,
       dampening_factor: dampeningFactor,
       raw_percentile: input.rawPercentile ?? null,
       level_score: levelScore,

--- a/lib/tli/constants/score-config.ts
+++ b/lib/tli/constants/score-config.ts
@@ -18,6 +18,59 @@ export function getMinRawInterest(): number {
   return _calibratedMinRawInterest ?? MIN_RAW_INTEREST
 }
 
+/**
+ * 앵커 척도 노이즈 감쇠 임계값
+ *
+ * `min_raw_interest(4)`는 앵커 이전 raw_value 스케일에 맞춰져 있어 앵커 척도에 그대로 쓸 수 없다
+ * (두 값의 크기가 세 자릿수 다르다). 단위를 기계적으로 환산하면 앵커 도입으로 이미 어긋난
+ * 감쇠율을 그대로 박제하므로, **감쇠 대상 비율**을 기준으로 역산했다.
+ *
+ * 실측(2026-07-26, 프로덕션): 앵커 이전 체제(base ≤ 2026-06-06)에서 min_raw_interest=4가
+ * 감쇠하던 테마 비율은 36.9%였다. 현재 앵커 척도 분포에서 같은 36.9%를 재현하는 값이
+ * 0.0031이고, 이를 0.003으로 둔다(감쇠 대상 36.5%). 같은 시점 raw_value 기준 감쇠율은
+ * 88.1%까지 폭주해 있었다.
+ *
+ * 이 값은 앵커 키워드가 바뀌면 다시 역산해야 한다 (PRD §5.4.1의 CV>0.3 앵커 교체 경로).
+ */
+export const MIN_ANCHOR_INTEREST = 0.003
+
+let _calibratedMinAnchorInterest: number | null = null
+
+/** 캘리브레이션된 앵커 노이즈 임계값 설정 */
+export function setMinAnchorInterest(value: number) {
+  _calibratedMinAnchorInterest = value
+}
+
+/** 현재 앵커 노이즈 임계값 반환 (캘리브레이션 우선, 없으면 기본값) */
+export function getMinAnchorInterest(): number {
+  return _calibratedMinAnchorInterest ?? MIN_ANCHOR_INTEREST
+}
+
+/**
+ * 척도에 맞는 노이즈 감쇠 임계값 — 계산기가 쓰는 단일 진입점
+ *
+ * 두 척도의 임계값은 크기가 세 자릿수 다르므로 서로 대체할 수 없다.
+ */
+export function getNoiseFloor(scale: 'raw' | 'anchor'): number {
+  return scale === 'anchor' ? getMinAnchorInterest() : getMinRawInterest()
+}
+
+/**
+ * 해당 척도에 실제로 적용되는 캘리브레이션 값이 있는지
+ *
+ * `calibrate-noise.ts`는 raw 척도로만 임계값을 산출한다. 앵커 척도로 도는 런에서
+ * raw 캘리브레이션을 적재하면 **조용히 무시**되므로, 호출부가 이 상태를 드러내야 한다.
+ */
+export function describeNoiseFloorCalibration(scale: 'raw' | 'anchor'): {
+  readonly applied: number | null
+  readonly ignoredRawCalibration: number | null
+} {
+  if (scale === 'anchor') {
+    return { applied: _calibratedMinAnchorInterest, ignoredRawCalibration: _calibratedMinRawInterest }
+  }
+  return { applied: _calibratedMinRawInterest, ignoredRawCalibration: null }
+}
+
 /** 기본 점수 컴포넌트 가중치 — tli-params에서 파생 */
 export const SCORE_WEIGHTS = {
   interest: DEFAULT_TLI_PARAMS.w_interest,

--- a/lib/tli/constants/tli-params.ts
+++ b/lib/tli/constants/tli-params.ts
@@ -16,6 +16,14 @@ export interface TLIParams {
 
   // ── Smoothing Core (2개) ──
   ema_alpha: number
+  /**
+   * raw 척도 노이즈 감쇠 임계값.
+   *
+   * ⚠️ 프로덕션은 2026-07-26부터 앵커 척도로 돌아 이 값을 쓰지 않는다
+   * (`score-config.ts`의 `MIN_ANCHOR_INTEREST`가 대응값). 옵티마이저는 앵커 적재 이전
+   * 구간을 재생하므로 여전히 raw 척도로 이 파라미터를 탐색한다 — 즉 여기서 튜닝한 값은
+   * 현행 프로덕션 점수에 반영되지 않는다. 앵커 척도 임계값 탐색은 별도 과제.
+   */
   min_raw_interest: number
 
   // ── Interest (4개) ──

--- a/lib/tli/interest-scale.ts
+++ b/lib/tli/interest-scale.ts
@@ -1,0 +1,73 @@
+/**
+ * 관심도 절대 수준의 척도 선택 — 점수 계산의 SSOT
+ *
+ * `interest_metrics`에는 절대 수준 후보가 두 개 있고 성질이 다르다.
+ *
+ * - `raw_value`: DataLab 응답 ratio를 **정수 반올림**한 값. DataLab은 한 요청 안의 모든
+ *   키워드 그룹을 통틀어 최대=100으로 정규화하므로, 2026-07-07 앵커(`계산기`) 투입 이후
+ *   실제 테마의 ratio는 0.02~5 구간으로 눌렸고 반올림이 그 해상도를 파괴했다.
+ *   실측: 테마의 7일 평균이 정확히 0인 비율 48.2%.
+ * - `anchor_scaled_value`: 같은 ratio를 앵커의 7일 중앙값으로 나눈 **부동소수** 값.
+ *   반올림이 없고 앵커 기준이라 테마 간 비교가 성립한다. 실측 0값 비율 0%.
+ *
+ * 앵커 도입 전에는 raw_value가 유일한 절대 수준이었고 임계값도 거기에 맞춰져 있었다.
+ * 두 척도는 값의 크기가 세 자릿수 다르므로, **한 백분위 모집단에 섞으면 안 된다.**
+ * 그래서 척도를 런 단위로 한 번만 정하고 테마 값과 교차 모집단이 항상 같은 척도를 쓰게 한다.
+ */
+
+/** 절대 수준을 읽어낼 컬럼 */
+export type InterestScale = 'raw' | 'anchor'
+
+/** 척도 판정에 필요한 최소 관측일 — 7일 창에서 과반 */
+const MIN_OBSERVATIONS = 3
+
+/** 런 전체를 앵커 척도로 돌리기 위한 최소 테마 커버리지 */
+const ANCHOR_RUN_COVERAGE = 0.5
+
+interface InterestLevelSource {
+  readonly raw_value: number
+  readonly anchor_scaled_value?: number | null
+}
+
+const finite = (values: readonly (number | null | undefined)[]): number[] =>
+  values.flatMap((value) => (typeof value === 'number' && Number.isFinite(value) ? [value] : []))
+
+const mean = (values: readonly number[]): number =>
+  values.reduce((sum, value) => sum + value, 0) / values.length
+
+/**
+ * 최근 창의 절대 관심 수준. 해당 척도의 관측이 부족하면 null
+ *
+ * @param recent - 최신순 관심도 관측 (호출부가 이미 7일로 자른 상태)
+ * @param scale - 런 단위로 확정된 척도
+ */
+export function resolveInterestLevel(
+  recent: readonly InterestLevelSource[],
+  scale: InterestScale,
+): number | null {
+  const values = scale === 'anchor'
+    ? finite(recent.map((row) => row.anchor_scaled_value))
+    : finite(recent.map((row) => row.raw_value))
+
+  if (values.length < Math.min(MIN_OBSERVATIONS, recent.length) || values.length === 0) return null
+  return mean(values)
+}
+
+/**
+ * 런 전체가 쓸 척도를 정한다
+ *
+ * 앵커 적재는 2026-07-06부터 시작됐으므로 그 이전 구간을 재계산하면 앵커 값이 없다.
+ * 과반이 앵커를 갖출 때만 앵커 척도로 넘어가고, 아니면 기존 raw 동작을 그대로 유지한다.
+ *
+ * @param themeWindows - 테마별 최근 창 관측
+ */
+export function resolveRunInterestScale(
+  themeWindows: readonly (readonly InterestLevelSource[])[],
+): InterestScale {
+  if (themeWindows.length === 0) return 'raw'
+
+  const withAnchor = themeWindows
+    .filter((window) => resolveInterestLevel(window, 'anchor') !== null).length
+
+  return withAnchor / themeWindows.length >= ANCHOR_RUN_COVERAGE ? 'anchor' : 'raw'
+}

--- a/lib/tli/types/db.ts
+++ b/lib/tli/types/db.ts
@@ -55,6 +55,8 @@ export interface InterestMetric {
   source: string;
   raw_value: number;
   normalized: number;
+  /** 앵커 보정 절대 수준. 2026-07-06 적재 시작 — 그 이전 행은 null */
+  anchor_scaled_value?: number | null;
 }
 
 export interface NewsMetric {
@@ -98,6 +100,8 @@ export interface ScoreComponents {
     interest_stddev: number;
     active_days: number;
     raw_interest_avg?: number;
+    /** raw_interest_avg를 읽어온 척도 — 'raw'(정수 반올림) 또는 'anchor'(앵커 보정 실수) */
+    interest_scale?: 'raw' | 'anchor';
     dampening_factor?: number;
     raw_percentile?: number | null;
     /** v2 이중축 필드 */

--- a/scripts/tli/scoring/calculate-scores.ts
+++ b/scripts/tli/scoring/calculate-scores.ts
@@ -1,6 +1,8 @@
 import { supabaseAdmin } from '@/scripts/tli/shared/supabase-admin'
 import { batchQuery, groupByThemeId } from '@/scripts/tli/shared/supabase-batch'
 import { calculateLifecycleScore } from '@/lib/tli/calculator'
+import { resolveInterestLevel, resolveRunInterestScale } from '@/lib/tli/interest-scale'
+import { describeNoiseFloorCalibration } from '@/lib/tli/constants/score-config'
 import { applyEMASmoothing, resolveStageWithHysteresis } from '@/lib/tli/score-smoothing'
 import { getKSTDate } from '@/scripts/tli/shared/utils'
 import { getKSTDate as getKSTDateObject } from '@/lib/tli/date-utils'
@@ -102,15 +104,26 @@ export async function calculateAndSaveScores(themes: ThemeWithKeywords[]) {
       .slice(0, 30)
     interestCache.set(theme.id, sorted)
 
-    const raw7d = sorted.slice(0, 7).map(m => m.raw_value)
-    if (raw7d.length > 0) {
-      rawAvgMap.set(theme.id, raw7d.reduce((s, v) => s + v, 0) / raw7d.length)
-    }
+  }
+
+  // 척도를 런 단위로 먼저 확정한다 — 테마 값과 교차 모집단이 다른 척도면 백분위가 무의미해진다
+  const interestWindows = [...interestCache.values()].map(rows => rows.slice(0, 7))
+  const interestScale = resolveRunInterestScale(interestWindows)
+
+  for (const theme of themes) {
+    const level = resolveInterestLevel((interestCache.get(theme.id) ?? []).slice(0, 7), interestScale)
+    if (level !== null) rawAvgMap.set(theme.id, level)
   }
 
   const allThemesRawAvg = Array.from(rawAvgMap.values()).filter(v => v > 0).sort((a, b) => a - b)
   const medianRaw = allThemesRawAvg.length > 0 ? allThemesRawAvg[Math.floor(allThemesRawAvg.length / 2)] : 0
-  console.log(`   📊 Cross-theme percentile: ${allThemesRawAvg.length}개 테마, median rawAvg=${medianRaw.toFixed(1)}`)
+  console.log(`   📊 Cross-theme percentile: ${allThemesRawAvg.length}개 테마, 척도=${interestScale}, median=${medianRaw.toPrecision(3)}`)
+
+  // raw 캘리브레이션은 앵커 척도에서 적용되지 않는다 — 조용히 무시되지 않도록 드러낸다
+  const calibration = describeNoiseFloorCalibration(interestScale)
+  if (calibration.ignoredRawCalibration !== null) {
+    console.warn(`   ⚠️ raw 노이즈 캘리브레이션(${calibration.ignoredRawCalibration})은 앵커 척도에 적용되지 않음 — calibrate-noise를 앵커 척도로 재산출해야 함`)
+  }
 
   const newsCache = new Map<string, NewsMetric[]>()
   for (const theme of themes) {
@@ -161,6 +174,7 @@ export async function calculateAndSaveScores(themes: ThemeWithKeywords[]) {
         firstSpikeDate: theme.first_spike_date,
         today,
         allThemesRawAvg,
+        interestScale,
         avgPriceChangePct,
         avgVolume,
         prevSmoothedScore,


### PR DESCRIPTION
2026-07-07 DataLab 앵커(`계산기`) 투입이 `interest_metrics.raw_value`의 스케일을 약 7배 압축했고, 이를 **절대 임계값**으로 읽던 점수 계산기가 무너졌습니다.

> **PR 분리 안내**: 같은 근본 원인의 파이프라인 실패 수정은 **#104**입니다. 그쪽은 7/27 study 시계 시작 전에 들어가야 하는 긴급 건이라, 사용자 화면 점수를 바꾸는 이 변경과 분리했습니다. 두 PR은 파일이 겹치지 않아 독립적으로 머지 가능합니다. **진단 전문은 #104에 포함된 `docs/tli-anchor-scale-regression-2026-07-26.md` §5.**

## 무엇이 일어났나

네이버 DataLab은 한 요청 안의 **모든 키워드 그룹을 통틀어** 최대=100으로 정규화합니다. 앵커는 초대형 일반 검색어라 사실상 항상 100을 가져가고, 같은 배치의 테마 4개는 ratio 0.02~5로 눌린 뒤 `Math.round()`에 대부분 0이 됩니다.

- 220개 테마 중 자기 30일 창에서 `raw_value=100`에 도달한 건 **4개(1.8%)** — 그룹별 정규화라면 100%여야 합니다
- 데이터 경계 06-06/06-07 = 앵커 첫 실행(`c966e3c`, 2026-07-07 10:19 KST)의 30일 요청 창 시작점과 정확히 일치
- `min_raw_interest=4` 감쇠 대상 **36.9% → 88.1%**, `lifecycle_score` 중앙값 **51~54 → 31**, `/themes` visibleThemes **45+ → 38**

마지막 항목은 `tli-v3-status-2026-07-22.md` §6이 *"하락 추세면 품질게이트 점수 조사"*로 열어둔 Watch 항목이고, 이 PR이 그 답입니다.

## 수정

절대 수준을 `anchor_scaled_value`에서 읽습니다. 정수 반올림이 없고(**0값 테마 0.0%** vs raw **48.2%**) 앵커 기준이라 테마 간 비교가 성립합니다. PRD L303이 `interest_level_pct`에 배정해둔 컬럼인데 점수 계산이 쓰지 않고 있었습니다.

두 척도는 크기가 세 자릿수 달라 **한 백분위 모집단에 섞으면 안 됩니다.** `lib/tli/interest-scale.ts`를 SSOT로 두고 척도를 **런 단위로 한 번만** 정해, 교차 모집단과 계산기가 항상 같은 척도를 쓰게 했습니다. 기본값 `'raw'`라 옵티마이저·기존 테스트는 그대로이고, 앵커 적재 이전 구간 재계산은 자동으로 raw로 남습니다.

**임계값은 임의로 정하지 않았습니다.** 단위 환산은 이미 어긋난 감쇠율을 박제하므로 감쇠 **대상 비율**로 역산했습니다:

```
앵커 이전(base <= 2026-06-06) 감쇠 대상 : 36.9%  ← 설계 의도
현재 raw_value 기준                     : 88.1%  ← 폭주
36.9%를 재현하는 앵커 척도 임계값        : 0.0031
채택 MIN_ANCHOR_INTEREST                : 0.003  (감쇠 대상 36.5%)
```

## 검증

**점수** (프로덕션 read-only dry-run, 2026-07-26)
```
percentile 모집단   112개 → 220개 (활성 241)
점수 p50               43 → 58
감쇠 대상 비율      87.8% → 36.6%   ← 역산 목표 36.9% 재현
```

**stage** — 점수는 `determineStage`의 `score >= 50` Peak 바이패스로 흘러가므로 별도 측정했습니다. `prevStage` 없이 원점수만 넣은 1차 dry-run은 `Peak 36 → 115`를 냈지만 **허상**이었습니다. 저장된 2026-07-16 상태를 시드로 8거래일을 순차 재생(`resolveStageWithHysteresis` = prevStage + EMA + Markov + 2일 hysteresis):

```
stage        실제저장(07-26)  재생:raw   재생:anchor
  Emerging           45          45            45
  Growth             49          49            49
  Peak              142         142           142
척도 전환으로 stage가 바뀌는 테마: 0 / 241
```

재생 결과가 실제 저장 분포와 **정확히 일치**하므로 충실도가 검증됐고, 두 척도 결과가 동일하므로 **stage 라벨은 움직이지 않습니다.**

한계: 8거래일 구간만 확인했고, 재생의 `smoothed_score` 절대 수준은 근사입니다(중앙값 raw=41 vs 실제 31 — `recentSmoothed` 이력 미재현). 신뢰할 수 있는 건 **두 척도의 차이**입니다.

## 자기리뷰에서 잡은 잔여 결합

| 결합 | 처리 |
|---|---|
| `load-calibrations` → `setMinRawInterest()`가 앵커 척도에서 **조용히 무시** | `getNoiseFloor(scale)` 단일 진입점 + `describeNoiseFloorCalibration()`로 무시된 값 반환, `calculate-scores`가 경고. 현재 DB에 `noise_threshold` 행 없어 휴면 |
| 옵티마이저 `min_raw_interest`가 프로덕션 미반영 | `TLIParams`에 경고 주석 명시 |
| 옵티마이저가 `allThemesRawAvg` 미전달 → sigmoid 경로 | **이 PR 이전부터의 발산** — 미해결, 문서 권고 4 |

## 인정할 트레이드오프

`MIN_ANCHOR_INTEREST = 0.003`도 **여전히 절대 임계값**입니다. `계산기`의 검색량이 계절적으로 움직이면 모든 `anchor_scaled_value`가 이동합니다 — 이 PR이 비판하는 것과 같은 결합 구조입니다. 백분위 기반이면 완전히 없앨 수 있지만 "절대적으로 미미함"이라는 원 의미를 잃습니다. **결합을 줄였지 없애지는 않았습니다.** 앵커 교체 시(PRD §5.4.1 CV>0.3) 재역산이 필수입니다.

## 리뷰 포인트

1. **`MIN_ANCHOR_INTEREST` 역산 방식** — 감쇠 대상 비율 기준이 맞는 기준인지
2. **런 단위 척도 판정** (`resolveRunInterestScale`, 과반 커버리지 0.5) — 앵커 적재 커버리지는 07-09 이후 매일 100%라 플래핑 위험은 낮게 봤습니다(7일 창에서 3일만 있으면 되므로 5일 연속 앵커 실패 필요)
3. **stage 재생의 8거래일 한계** — 더 긴 구간 검증이 필요한지

## 검증

- `tsc --noEmit` 0 · `vitest` 신규 회귀 10건 포함 통과
- ⚠️ `scripts/tli/__tests__/tli-boundary-manifest.test.ts` 1건 실패는 **main의 기존 결함**이며 #104에서 수정됩니다. 이 브랜치가 유발한 것이 아닙니다.
