### PR TITLE
fix(security): fail-closed 인증·이중 옵트인·토큰 기반 구독취소 (PR #111 Task 1/5)

### DIFF
--- a/.github/workflows/daily-newsletter.yml
+++ b/.github/workflows/daily-newsletter.yml
@@ -123,6 +123,9 @@ jobs:
           SENDGRID_FROM_EMAIL: ${{ secrets.SENDGRID_FROM_EMAIL }}
           SENDGRID_FROM_NAME: ${{ secrets.SENDGRID_FROM_NAME }}
 
+          # 발송 메일의 구독취소 링크 서명에 필요. 없으면 발송이 실패한다.
+          UNSUBSCRIBE_TOKEN_SECRET: ${{ secrets.UNSUBSCRIBE_TOKEN_SECRET }}
+
           # Twitter/X API
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}

--- a/app/__tests__/subscribe-suspense.test.tsx
+++ b/app/__tests__/subscribe-suspense.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { useSearchParamsMock } = vi.hoisted(() => ({
+  useSearchParamsMock: vi.fn(() => {
+    throw new Error('useSearchParams must only run below the page Suspense boundary')
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: useSearchParamsMock,
+}))
+
+import SubscribePage from '@/app/subscribe/page'
+
+describe('subscribe page prerender contract', () => {
+  it('places the search-param consumer below an accessible Suspense boundary', () => {
+    const page = SubscribePage() as React.ReactElement<{
+      fallback: React.ReactElement<{ role?: string; 'aria-live'?: string }>
+    }>
+
+    expect(page.type).toBe(React.Suspense)
+    expect(page.props.fallback.props.role).toBe('status')
+    expect(page.props.fallback.props['aria-live']).toBe('polite')
+    expect(useSearchParamsMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/__tests__/subscription-lifecycle.test.ts
+++ b/app/api/__tests__/subscription-lifecycle.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for the double opt-in / opt-out lifecycle.
+ *
+ * Covers two defects found reviewing the original remediation batch:
+ * - a returning subscriber could never re-confirm, because the pending row kept
+ *   its previous confirmed_at and confirm_subscription then reported
+ *   'already_confirmed' while the subscriber stayed inactive.
+ * - a subscriber holding a legacy or expired link had no way to opt out at all.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, upsertMock, sendConfirmationMock, sendUnsubscribeLinkMock, maybeSingleMock } =
+  vi.hoisted(() => ({
+    createClientMock: vi.fn(),
+    upsertMock: vi.fn(),
+    sendConfirmationMock: vi.fn(),
+    sendUnsubscribeLinkMock: vi.fn(),
+    maybeSingleMock: vi.fn(),
+  }))
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
+vi.mock('@/lib/sendgrid', () => ({
+  sendSubscriptionConfirmation: sendConfirmationMock,
+  sendUnsubscribeLink: sendUnsubscribeLinkMock,
+}))
+vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 5, resetAt: 0 }),
+    getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  }
+})
+
+const originalEnv = process.env
+
+function jsonRequest(body: unknown): Request {
+  return new Request('https://stockmatrix.co.kr/api/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-real-ip': '203.0.113.5' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  upsertMock.mockReset().mockResolvedValue({ error: null })
+  sendConfirmationMock.mockReset().mockResolvedValue(undefined)
+  sendUnsubscribeLinkMock.mockReset().mockResolvedValue(undefined)
+  maybeSingleMock.mockReset().mockResolvedValue({ data: null, error: null })
+
+  createClientMock.mockReset().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      upsert: upsertMock,
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({ maybeSingle: maybeSingleMock }),
+          maybeSingle: maybeSingleMock,
+        }),
+      }),
+    }),
+  })
+
+  process.env = {
+    ...originalEnv,
+    NEXT_PUBLIC_SUPABASE_URL: 'https://lifecycle-test.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-key',
+    UNSUBSCRIBE_TOKEN_SECRET: 'u'.repeat(32),
+    RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32),
+  }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('POST /api/subscribe', () => {
+  it('clears confirmed_at so a returning subscriber can confirm again', async () => {
+    const { POST } = await import('@/app/api/subscribe/route')
+
+    const response = await POST(jsonRequest({ email: 'returning@example.com' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(upsertMock).toHaveBeenCalledTimes(1)
+
+    const [payload, options] = upsertMock.mock.calls[0]
+    expect(payload).toMatchObject({ email: 'returning@example.com', confirmed_at: null })
+    expect(options).toEqual({ onConflict: 'email' })
+  })
+})
+
+describe('POST /api/unsubscribe/request', () => {
+  it('mails a fresh link when the address is an active subscriber', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+
+    const response = await POST(jsonRequest({ email: 'active@example.com' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(sendUnsubscribeLinkMock).toHaveBeenCalledTimes(1)
+    const [recipient, token] = sendUnsubscribeLinkMock.mock.calls[0]
+    expect(recipient).toBe('active@example.com')
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(0)
+  })
+
+  it('does not mail unknown addresses but returns an identical response', async () => {
+    maybeSingleMock.mockResolvedValue({ data: null, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+
+    const response = await POST(jsonRequest({ email: 'stranger@example.com' }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(sendUnsubscribeLinkMock).not.toHaveBeenCalled()
+    expect(body).toEqual({
+      status: 'requested',
+      message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+    })
+  })
+
+  it('issues a token the unsubscribe endpoint accepts', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+    await POST(jsonRequest({ email: 'active@example.com' }) as never)
+
+    const [, token] = sendUnsubscribeLinkMock.mock.calls[0]
+    const { validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth')
+
+    expect(validateUnsubscribeToken(token)).toEqual({ valid: true, email: 'active@example.com' })
+  })
+})

--- a/app/api/stock/__tests__/price-cache-wiring.test.ts
+++ b/app/api/stock/__tests__/price-cache-wiring.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for the server-side price cache.
+ *
+ * Migration 056b revokes anonymous writes to stock_price_cache, so the browser
+ * can no longer populate it. This route became the only writer — if it stops
+ * reading and writing the cache, the table stays permanently empty and every
+ * request falls through to KIS.
+ */
+
+import { NextRequest } from 'next/server'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getBatchStockPricesMock, getCacheMock, saveCacheMock } = vi.hoisted(() => ({
+  getBatchStockPricesMock: vi.fn(),
+  getCacheMock: vi.fn(),
+  saveCacheMock: vi.fn(),
+}))
+
+vi.mock('@/app/archive/_utils/api/kis/client', () => ({
+  getBatchStockPrices: getBatchStockPricesMock,
+}))
+vi.mock('@/app/archive/_utils/cache/stock-price', () => ({
+  getBatchPricesFromCache: getCacheMock,
+  saveBatchPricesToCache: saveCacheMock,
+}))
+vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 30, resetAt: 0 }),
+    getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  }
+})
+
+const originalEnv = process.env
+
+function priceRequest(tickers: string): NextRequest {
+  return new NextRequest(`https://stockmatrix.co.kr/api/stock/price?tickers=${tickers}`, {
+    headers: { 'x-real-ip': '203.0.113.5' },
+  })
+}
+
+function livePrice(ticker: string) {
+  return {
+    ticker,
+    currentPrice: 70000,
+    previousClose: 69000,
+    changeRate: 1.45,
+    volume: 1_000_000,
+    timestamp: 1_800_000_000,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  getCacheMock.mockReset().mockResolvedValue(new Map())
+  saveCacheMock.mockReset().mockResolvedValue(undefined)
+  getBatchStockPricesMock.mockReset().mockResolvedValue({
+    prices: new Map(),
+    failures: new Map<string, string>(),
+  })
+  process.env = { ...originalEnv, RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32) }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('GET /api/stock/price cache wiring', () => {
+  it('only asks KIS for tickers the cache missed', async () => {
+    getCacheMock.mockResolvedValue(
+      new Map([['005930', { ...livePrice('005930'), expires_at: 1_900_000_000 }]])
+    )
+    getBatchStockPricesMock.mockResolvedValue({
+      prices: new Map([['035720', livePrice('035720')]]),
+      failures: new Map<string, string>(),
+    })
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    const response = await GET(priceRequest('005930,035720'))
+    const body = await response.json()
+
+    expect(getBatchStockPricesMock).toHaveBeenCalledWith(['035720'])
+    expect(Object.keys(body.prices).sort()).toEqual(['005930', '035720'])
+    expect(body.meta.success).toBe(2)
+  })
+
+  it('writes freshly fetched prices back to the cache', async () => {
+    getBatchStockPricesMock.mockResolvedValue({
+      prices: new Map([['005930', livePrice('005930')]]),
+      failures: new Map<string, string>(),
+    })
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    await GET(priceRequest('005930'))
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(1)
+    const [rows] = saveCacheMock.mock.calls[0]
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ ticker: '005930', currentPrice: 70000 })
+    expect(typeof rows[0].expires_at).toBe('number')
+  })
+
+  it('skips the KIS call entirely when every ticker is cached', async () => {
+    getCacheMock.mockResolvedValue(
+      new Map([['005930', { ...livePrice('005930'), expires_at: 1_900_000_000 }]])
+    )
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    const response = await GET(priceRequest('005930'))
+    const body = await response.json()
+
+    expect(getBatchStockPricesMock).not.toHaveBeenCalled()
+    expect(saveCacheMock).not.toHaveBeenCalled()
+    // expires_at is an internal cache field and must not leak into the response
+    expect(body.prices['005930']).not.toHaveProperty('expires_at')
+  })
+})

--- a/app/api/stock/daily-close/route.ts
+++ b/app/api/stock/daily-close/route.ts
@@ -1,18 +1,98 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBatchDailyClosePrices } from '@/app/archive/_utils/api/kis/client';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
 
-/** GET /api/stock/daily-close?tickers=KOSPI:005930&date=20241220 */
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/stock/daily-close?tickers=KOSPI:005930&date=20241220
+ *
+ * Strict validation:
+ * - Tickers: EXCHANGE:TICKER format (e.g. KOSPI:005930), max 10
+ * - Date: YYYYMMDD, must be a real calendar date within valid range (2020-01-01 to tomorrow)
+ */
+
+const TICKER_WITH_EXCHANGE_PATTERN = /^[A-Z]{2,10}:[0-9A-Za-z]{1,10}$/;
+const DATE_PATTERN = /^\d{8}$/;
+
+/** Days in each month (non-leap year) */
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Validate a date string as a real calendar date.
+ * Rejects Feb 30, Apr 31, etc.
+ */
+function isValidCalendarDate(dateStr: string): boolean {
+  if (!DATE_PATTERN.test(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  if (year < 2020 || year > 2100) return false;
+  if (month < 1 || month > 12) return false;
+
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  if (day < 1 || day > maxDay) return false;
+
+  // Check it's not in the far future (next day at most)
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(23, 59, 59, 999);
+  const inputDate = new Date(year, month - 1, day);
+  return inputDate <= tomorrow;
+}
+
 export async function GET(req: NextRequest) {
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(req.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.dailyClose);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { success: false, error: 'Rate limit exceeded' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { success: false, error: 'Service temporarily unavailable' },
+      { status: 503 }
+    );
+  }
+
   try {
     const tickers = req.nextUrl.searchParams.get('tickers')?.split(',').map((t) => t.trim()).filter(Boolean);
     const date = req.nextUrl.searchParams.get('date');
+
     if (!tickers?.length || tickers.length > 10 || !date) {
-      return NextResponse.json({ success: false, error: 'Invalid params' }, { status: 400 });
+      return NextResponse.json({ success: false, error: 'Invalid params: tickers (max 10) and date required' }, { status: 400 });
     }
-    return NextResponse.json({ success: true, prices: Object.fromEntries(await getBatchDailyClosePrices(tickers, date)) });
+
+    // Strict ticker format validation
+    const invalidTickers = tickers.filter((t) => !TICKER_WITH_EXCHANGE_PATTERN.test(t));
+    if (invalidTickers.length > 0) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid ticker format. Expected EXCHANGE:TICKER (e.g. KOSPI:005930)' },
+        { status: 400 }
+      );
+    }
+
+    // Strict date validation (real calendar date)
+    if (!isValidCalendarDate(date)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid date. Expected YYYYMMDD, a real calendar date within valid range (2020-present)' },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      prices: Object.fromEntries(await getBatchDailyClosePrices(tickers, date)),
+    });
   } catch {
-    return NextResponse.json({ success: false, error: 'Failed' }, { status: 500 });
+    return NextResponse.json({ success: false, error: 'Failed to fetch daily close prices' }, { status: 500 });
   }
 }
-
-export const runtime = 'nodejs';

--- a/app/api/stock/price/route.ts
+++ b/app/api/stock/price/route.ts
@@ -1,36 +1,60 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBatchStockPrices } from '@/app/archive/_utils/api/kis/client';
+import type { KisStockPrice } from '@/app/archive/_utils/api/kis/types';
+import type { StockPriceCache } from '@/app/archive/_utils/cache/types';
+import { getStockPriceCacheExpiry } from '@/app/archive/_utils/market/hours';
+import { getBatchPricesFromCache, saveBatchPricesToCache } from '@/app/archive/_utils/cache/stock-price';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { isValidTicker, MAX_TICKERS_PER_REQUEST } from '@/lib/security/validators';
 
 /**
  * 주식 현재가 조회 API
- * GET /api/stock/price?tickers=AAPL,GOOGL,MSFT
+ * GET /api/stock/price?tickers=005930,035720
  *
- * 프로덕션급 엔터프라이즈 API 엔드포인트
- * - 입력 검증 및 sanitization
- * - 에러 핸들링 및 상세 로깅
- * - Rate limiting 보호
- * - 캐싱 전략 적용
+ * Validation:
+ * - Tickers must be Korean stock format (6-digit numeric) or alphanumeric up to 10 chars
+ * - Max 10 tickers per request
+ * - Distributed rate limiting via Supabase
+ *
+ * Caching: the Supabase price cache is read/written with the service role here.
+ * The browser never touches the cache table (SEC-005), so this route is the only
+ * writer that keeps it warm — without it the table stays empty and every request
+ * would hit KIS directly.
  */
+
+type PriceResponseEntry = KisStockPrice | Omit<StockPriceCache, 'expires_at'>;
+
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
+
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.stockPrice);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { success: false, error: 'Rate limit exceeded. Try again later.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { success: false, error: 'Service temporarily unavailable.' },
+      { status: 503 }
+    );
+  }
 
   try {
     const searchParams = request.nextUrl.searchParams;
     const tickersParam = searchParams.get('tickers');
 
-    // 입력 검증
-    if (!tickersParam) {
+    if (!tickersParam || tickersParam.trim().length === 0) {
       return NextResponse.json(
-        {
-          success: false,
-          error: 'tickers parameter is required',
-          message: 'Please provide tickers as comma-separated values',
-        },
+        { success: false, error: 'tickers parameter is required' },
         { status: 400 }
       );
     }
 
-    // 티커 파싱 및 sanitization
+    // 티커 파싱 및 strict validation
     const tickers = tickersParam
       .split(',')
       .map((t) => t.trim())
@@ -38,38 +62,74 @@ export async function GET(request: NextRequest) {
 
     if (tickers.length === 0) {
       return NextResponse.json(
-        {
-          success: false,
-          error: 'At least one valid ticker is required',
-          message: 'Tickers must be non-empty strings',
-        },
+        { success: false, error: 'At least one valid ticker is required' },
         { status: 400 }
       );
     }
 
-    // 최대 10개로 제한 (API 호출 최적화 및 rate limiting 보호)
-    if (tickers.length > 10) {
+    // 최대 10개로 제한
+    if (tickers.length > MAX_TICKERS_PER_REQUEST) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Maximum 10 tickers allowed per request',
-          message: 'Please split your request into multiple calls',
+          error: `Maximum ${MAX_TICKERS_PER_REQUEST} tickers allowed per request`,
           requested: tickers.length,
-          max: 10,
+          max: MAX_TICKERS_PER_REQUEST,
         },
         { status: 400 }
       );
     }
 
-    // KIS API 호출
-    const result = await getBatchStockPrices(tickers);
+    // Strict ticker format validation
+    const invalidTickers = tickers.filter((t) => !isValidTicker(t));
+    if (invalidTickers.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid ticker format. Korean tickers must be 6 digits (e.g. 005930).',
+          invalid: invalidTickers,
+        },
+        { status: 400 }
+      );
+    }
 
-    const successCount = result.prices.size;
-    const failedCount = result.failures.size;
+    // 캐시 우선 조회 — 미스인 티커만 KIS로 넘긴다
+    const cached = await getBatchPricesFromCache(tickers);
+    const uncachedTickers = tickers.filter((ticker) => !cached.has(ticker));
 
-    // Map을 객체로 변환
-    const pricesObject = Object.fromEntries(result.prices);
-    const failuresObject = Object.fromEntries(result.failures);
+    const fetched = uncachedTickers.length > 0
+      ? await getBatchStockPrices(uncachedTickers)
+      : { prices: new Map<string, KisStockPrice>(), failures: new Map<string, string>() };
+
+    if (fetched.prices.size > 0) {
+      const expiresAt = getStockPriceCacheExpiry();
+      await saveBatchPricesToCache(
+        [...fetched.prices.values()].map((price) => ({
+          ticker: price.ticker,
+          currentPrice: price.currentPrice,
+          previousClose: price.previousClose,
+          changeRate: price.changeRate,
+          volume: price.volume,
+          timestamp: price.timestamp,
+          expires_at: expiresAt,
+        }))
+      );
+    }
+
+    // expires_at은 캐시 내부 필드이므로 응답 형태를 균일하게 유지하기 위해 제외한다
+    const merged = new Map<string, PriceResponseEntry>();
+    for (const [ticker, { expires_at: _expiresAt, ...price }] of cached) {
+      merged.set(ticker, price);
+    }
+    for (const [ticker, price] of fetched.prices) {
+      merged.set(ticker, price);
+    }
+
+    const successCount = merged.size;
+    const failedCount = fetched.failures.size;
+
+    const pricesObject = Object.fromEntries(merged);
+    const failuresObject = Object.fromEntries(fetched.failures);
 
     const duration = Date.now() - startTime;
 
@@ -78,17 +138,15 @@ export async function GET(request: NextRequest) {
         success: true,
         prices: pricesObject,
         failures: failedCount > 0 ? failuresObject : undefined,
-        metadata: {
-          requested: tickers.length,
+        meta: {
+          total: tickers.length,
           success: successCount,
           failed: failedCount,
           duration_ms: duration,
-          timestamp: new Date().toISOString(),
         },
       },
       {
         headers: {
-          // 1분 캐싱 (Vercel Edge에서도 캐싱)
           'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
           'X-Response-Time': `${duration}ms`,
         },
@@ -97,50 +155,21 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     const duration = Date.now() - startTime;
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    const errorName = error instanceof Error ? error.name : 'Error';
 
-    console.error('[API] Stock price API error:', {
-      name: errorName,
-      message: errorMessage,
-      duration_ms: duration,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    // 프로덕션에서는 민감한 정보 숨김
-    const isProduction = process.env.NODE_ENV === 'production';
+    console.error('[stock/price] API error:', errorMessage);
 
     return NextResponse.json(
       {
         success: false,
         error: 'Failed to fetch stock prices',
-        message: isProduction
-          ? 'An error occurred while fetching stock prices. Please try again later.'
-          : errorMessage,
-        details: !isProduction
-          ? {
-              name: errorName,
-              message: errorMessage,
-            }
-          : undefined,
+        message: 'An error occurred while fetching stock prices. Please try again later.',
       },
       {
         status: 500,
-        headers: {
-          'X-Response-Time': `${duration}ms`,
-        },
+        headers: { 'X-Response-Time': `${duration}ms` },
       }
     );
   }
 }
 
-// Route segment config for Vercel
-export const runtime = 'nodejs'; // KIS API는 Node.js runtime 필요
-
-// 🔧 캐싱 전략:
-// - force-dynamic 제거: Cache-Control 헤더가 제대로 작동하도록 함
-// - 장 중: 1분 캐싱 (실시간성 유지)
-// - 장 마감 후: Supabase 캐시가 다음 영업일 09:00까지 유지됨
-// - CDN 캐싱: s-maxage=60으로 Vercel Edge에서 1분간 캐시
-
-// Rate limiting은 Vercel Pro 이상에서 자동 적용됨
-// 무료 플랜에서는 애플리케이션 레벨에서 관리
+export const runtime = 'nodejs';

--- a/app/api/subscribe/confirm/route.ts
+++ b/app/api/subscribe/confirm/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { validateConfirmToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+
+/**
+ * POST /api/subscribe/confirm
+ *
+ * Confirms a subscription via opaque token.
+ * POST-only: confirmation must NOT mutate on GET.
+ * Uses transactional confirm_subscription RPC.
+ */
+
+const confirmSchema = z.object({
+  token: z.string().min(1, '토큰이 필요합니다'),
+});
+
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function POST(request: NextRequest) {
+  // Rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.subscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
+  }
+
+  const parsed = confirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: '유효하지 않은 확인 요청입니다.' }, { status: 400 });
+  }
+
+  const { token } = parsed.data;
+
+  // Validate token (AEAD decrypt, purpose=confirm)
+  const tokenResult = validateConfirmToken(token);
+  if (!tokenResult.valid || !tokenResult.email) {
+    const status = tokenResult.error === 'expired' ? 410 : 400;
+    const message = tokenResult.error === 'expired'
+      ? '확인 링크가 만료되었습니다. 다시 구독 신청해주세요.'
+      : '유효하지 않은 확인 링크입니다.';
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[subscribe/confirm] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
+
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+
+  // Use transactional RPC (locks row, verifies, activates atomically)
+  const { data, error } = await supabase.rpc('confirm_subscription', {
+    p_token_hash: tokenHash,
+    p_email: tokenResult.email,
+  });
+
+  if (error) {
+    console.error('[subscribe/confirm] RPC error:', error.message);
+    return NextResponse.json({ error: '확인 처리 중 오류가 발생했습니다.' }, { status: 500 });
+  }
+
+  const result = data as { success: boolean; error?: string } | null;
+  if (!result || !result.success) {
+    const rpcError = result?.error;
+    if (rpcError === 'expired') {
+      return NextResponse.json({ error: '확인 링크가 만료되었습니다.' }, { status: 410 });
+    }
+    if (rpcError === 'already_confirmed') {
+      return NextResponse.json({ status: 'confirmed', message: '이미 확인된 구독입니다.' });
+    }
+    return NextResponse.json({ error: '유효하지 않거나 이미 확인된 요청입니다.' }, { status: 400 });
+  }
+
+  return NextResponse.json({ status: 'confirmed', message: '구독이 확인되었습니다!' });
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { isDisposableEmail } from 'disposable-email-domains-js';
-import { getServerSupabaseClient } from '@/lib/supabase/server-client';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { generateConfirmToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { sendSubscriptionConfirmation } from '@/lib/sendgrid';
 
 const subscribeSchema = z.object({
   email: z
@@ -13,7 +17,34 @@ const subscribeSchema = z.object({
   name: z.string().max(100, '이름 길이 제한 초과').optional(),
 });
 
+/**
+ * Get a service-role Supabase client.
+ * Fail-closed: returns null if service role key is not configured.
+ */
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
 export async function POST(request: NextRequest) {
+  // Rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.subscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -26,42 +57,67 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
 
-  const { email, name } = parsed.data;
-  const supabase = getServerSupabaseClient();
+  // Normalize email (lowercase, trim)
+  const email = parsed.data.email.toLowerCase().trim();
+  const name = parsed.data.name?.trim() || null;
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[subscribe] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
 
   try {
-    const { data: existing } = await supabase
-      .from('subscribers')
-      .select('name')
-      .eq('email', email)
-      .maybeSingle();
+    // Generate a confirmation token (opaque, AEAD encrypted)
+    const confirmToken = generateConfirmToken(email);
+    const tokenHash = createHash('sha256').update(confirmToken).digest('hex');
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
-    if (existing) {
-      const { error: updateError } = await supabase
-        .from('subscribers')
-        .update({ is_active: true, name: name || existing.name })
-        .eq('email', email);
+    // Upsert pending subscriber.
+    // confirmed_at MUST be reset: a returning subscriber (previously confirmed,
+    // then unsubscribed) would otherwise keep the old confirmed_at, and
+    // confirm_subscription would reject the fresh token as 'already_confirmed' —
+    // leaving them permanently unable to re-subscribe.
+    const { error: upsertError } = await supabase
+      .from('pending_subscribers')
+      .upsert(
+        { email, name, confirm_token_hash: tokenHash, expires_at: expiresAt, confirmed_at: null },
+        { onConflict: 'email' }
+      );
 
-      if (updateError) {
-        console.error('Resubscribe error:', updateError);
-        return NextResponse.json({ error: '구독 처리 중 오류가 발생했습니다. 다시 시도해주세요.' }, { status: 500 });
-      }
-
-      return NextResponse.json({ status: 'resubscribed' });
+    if (upsertError) {
+      console.error('[subscribe] pending upsert error:', upsertError.message);
+      return NextResponse.json(
+        { error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
+        { status: 500 }
+      );
     }
 
-    const { error: insertError } = await supabase
-      .from('subscribers')
-      .insert({ email, name: name || null });
+    // Send confirmation email
+    try {
+      await sendSubscriptionConfirmation(email, confirmToken);
+    } catch (sendError) {
+      // Clean up the pending row if sending fails
+      console.error('[subscribe] email send failed:', sendError instanceof Error ? sendError.message : 'unknown');
+      await supabase
+        .from('pending_subscribers')
+        .delete()
+        .eq('email', email)
+        .is('confirmed_at', null);
 
-    if (insertError) {
-      console.error('Subscribe error:', insertError);
-      return NextResponse.json({ error: '구독 처리 중 오류가 발생했습니다. 다시 시도해주세요.' }, { status: 500 });
+      return NextResponse.json(
+        { error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
+        { status: 500 }
+      );
     }
 
-    return NextResponse.json({ status: 'subscribed' });
+    // Always return same response to prevent account enumeration
+    return NextResponse.json({
+      status: 'pending',
+      message: '확인 이메일을 발송했습니다. 이메일을 확인해주세요.',
+    });
   } catch (error) {
-    console.error('Subscribe error:', error);
+    console.error('[subscribe] unexpected error:', error instanceof Error ? error.message : 'unknown');
     return NextResponse.json({ error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' }, { status: 500 });
   }
 }

--- a/app/api/unsubscribe/request/route.ts
+++ b/app/api/unsubscribe/request/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
+import { generateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { sendUnsubscribeLink } from '@/lib/sendgrid';
+
+/**
+ * POST /api/unsubscribe/request
+ *
+ * Mails a fresh opaque unsubscribe token to the address supplied by the user.
+ *
+ * This is the recovery path for links that predate opaque tokens (`?email=`) and
+ * for tokens that have expired. It never unsubscribes on its own — the mailed
+ * link still goes through the normal confirm step — so an unauthenticated caller
+ * cannot opt someone else out.
+ *
+ * The response is identical whether or not the address is subscribed, so this
+ * endpoint cannot be used to enumerate subscribers.
+ */
+
+const requestSchema = z.object({
+  email: z
+    .string()
+    .min(1, '이메일을 입력해주세요')
+    .max(255, '이메일 길이 제한 초과')
+    .pipe(z.email({ message: '잘못된 이메일 형식' })),
+});
+
+const GENERIC_RESPONSE = {
+  status: 'requested',
+  message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+} as const;
+
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function POST(request: NextRequest) {
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.unsubscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+
+  const email = parsed.data.email.toLowerCase().trim();
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[unsubscribe/request] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
+
+  try {
+    // Only mail addresses that are actually subscribed — otherwise this endpoint
+    // becomes an open relay for sending mail to arbitrary addresses.
+    const { data: subscriber, error } = await supabase
+      .from('subscribers')
+      .select('email')
+      .eq('email', email)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[unsubscribe/request] db error');
+      return NextResponse.json({ error: '요청 처리 중 오류가 발생했습니다.' }, { status: 500 });
+    }
+
+    if (subscriber) {
+      await sendUnsubscribeLink(email, generateUnsubscribeToken(email));
+    }
+
+    return NextResponse.json(GENERIC_RESPONSE);
+  } catch (err) {
+    console.error(
+      '[unsubscribe/request] unexpected error:',
+      err instanceof Error ? err.message : 'unknown'
+    );
+    return NextResponse.json({ error: '시스템 오류가 발생했습니다.' }, { status: 500 });
+  }
+}

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,12 +1,44 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getServerSupabaseClient } from '@/lib/supabase/server-client';
+import { createClient } from '@supabase/supabase-js';
+import { validateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
 
-const bodySchema = z.object({
-  email: z.string().min(1).max(255).pipe(z.email({ message: '잘못된 이메일 형식' })),
+/**
+ * Unsubscribe API — POST only (no GET side-effects).
+ *
+ * Requires an opaque AEAD token. No email-based fallback.
+ * Missing or invalid tokens are rejected (fail-closed).
+ */
+
+const tokenBodySchema = z.object({
+  token: z.string().min(1),
 });
 
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
 export async function POST(request: NextRequest) {
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.unsubscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -14,27 +46,52 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
   }
 
-  const parsed = bodySchema.safeParse(body);
+  // Token is required — no email fallback
+  const parsed = tokenBodySchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    return NextResponse.json({ error: '유효하지 않은 구독 취소 요청입니다.' }, { status: 400 });
   }
 
-  const supabase = getServerSupabaseClient();
+  const result = validateUnsubscribeToken(parsed.data.token);
+
+  if (!result.valid || !result.email) {
+    if (result.error === 'expired') {
+      return NextResponse.json(
+        { error: '구독 취소 링크가 만료되었습니다. 최신 뉴스레터의 링크를 사용해주세요.' },
+        { status: 410 }
+      );
+    }
+    if (result.error === 'no_secret') {
+      console.error('[unsubscribe] UNSUBSCRIBE_TOKEN_SECRET not configured');
+      return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+    }
+    return NextResponse.json({ error: '유효하지 않은 구독 취소 링크입니다.' }, { status: 400 });
+  }
+
+  return await performUnsubscribe(result.email);
+}
+
+async function performUnsubscribe(email: string): Promise<NextResponse> {
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[unsubscribe] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
 
   try {
     const { error } = await supabase
       .from('subscribers')
       .update({ is_active: false })
-      .eq('email', parsed.data.email);
+      .eq('email', email);
 
     if (error) {
-      console.error('Unsubscribe error:', error);
+      console.error('[unsubscribe] db error');
       return NextResponse.json({ error: '구독 해지 처리 중 오류가 발생했습니다.' }, { status: 500 });
     }
 
     return NextResponse.json({ status: 'unsubscribed' });
   } catch (error) {
-    console.error('Unsubscribe error:', error);
+    console.error('[unsubscribe] unexpected error:', error instanceof Error ? error.message : 'unknown');
     return NextResponse.json({ error: '시스템 오류가 발생했습니다.' }, { status: 500 });
   }
 }

--- a/app/archive/_hooks/use-stock-prices.ts
+++ b/app/archive/_hooks/use-stock-prices.ts
@@ -1,14 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { MAX_BUSINESS_DAYS } from '../_utils/formatting/date';
 import {
-  getStockPriceCacheExpiry,
   getPreviousBusinessDate,
   getNthBusinessDateAfter,
   calculateBusinessDays,
   isTodayMarketClosed,
 } from '../_utils/market/hours';
-import { getBatchPricesFromCache, saveBatchPricesToCache } from '../_utils/cache/stock-price';
-import type { StockPriceCache } from '../_utils/cache/types';
 import type { DateString } from '../_types/archive.types';
 
 /** 주식 가격 정보 */
@@ -28,13 +25,10 @@ export type PriceUnavailableReason = 'api_error';
 interface UseStockPricesResult {
   prices: Map<string, StockPrice>;
   historicalClosePrices: Map<string, number>;
-  /** 7영업일 후 확정 종가 (tracking 만료 시) */
   settledClosePrices: Map<string, number>;
   loading: boolean;
   unavailableReason: PriceUnavailableReason | null;
-  /** 오늘이 휴장일인지 여부 (직전 개장일 종가 표시용) */
   isMarketClosed: boolean;
-  /** 실시간 추적 기간이 만료되었는지 여부 */
   isTrackingExpired: boolean;
 }
 
@@ -77,12 +71,6 @@ function isHistoricalPriceAPIResponse(data: unknown): data is HistoricalPriceAPI
   return r.success === true && typeof r.prices === 'object' && r.prices !== null;
 }
 
-/**
- * 재시도 로직을 포함한 fetch (모듈 레벨)
- *
- * - ok 응답만 반환, 4xx는 즉시 실패, 5xx는 재시도
- * - AbortError는 즉시 전파 (컴포넌트 언마운트 대응)
- */
 async function fetchWithRetry(
   url: string,
   options: RequestInit,
@@ -116,52 +104,35 @@ async function fetchWithRetry(
   throw lastError ?? new Error('Failed after retries');
 }
 
-/**
- * 실시간 추적 기간 만료 여부 확인
- * @returns true면 7영업일 초과 (확정 종가 조회 필요)
- */
 function isTrackingPeriodExpired(newsletterDate: DateString): boolean {
   const recommendDate = new Date(newsletterDate);
   recommendDate.setHours(0, 0, 0, 0);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const businessDays = calculateBusinessDays(recommendDate, today);
-
   return businessDays > MAX_BUSINESS_DAYS;
 }
 
 /**
- * 실시간 주식 시세 조회 훅 (2-tier 캐싱)
+ * 실시간 주식 시세 조회 훅
  *
- * 캐싱 전략:
- * - Supabase 캐시 우선 조회 (~50ms)
- * - 캐시 미스 시 KIS API 호출
- *
- * TTL 전략:
- * - 장 중: 1분
- * - 장 마감 후: 다음 영업일 09:00까지
+ * All price data is fetched from /api/stock/price (authoritative, server-cached).
+ * No direct Supabase/cache access from the client.
  */
 export default function useStockPrices(
   tickers: string[],
   newsletterDate: DateString | null
 ): UseStockPricesResult {
   const [prices, setPrices] = useState<Map<string, StockPrice>>(new Map());
-  const [historicalClosePrices, setHistoricalClosePrices] = useState<Map<string, number>>(
-    new Map()
-  );
+  const [historicalClosePrices, setHistoricalClosePrices] = useState<Map<string, number>>(new Map());
   const [settledClosePrices, setSettledClosePrices] = useState<Map<string, number>>(new Map());
   const [loading, setLoading] = useState(true);
   const [unavailableReason, setUnavailableReason] = useState<PriceUnavailableReason | null>(null);
   const [isMarketClosed, setIsMarketClosed] = useState(false);
   const [isExpired, setIsExpired] = useState(false);
 
-  // React 19: 단순 연산은 useMemo 불필요
   const tickersKey = tickers.join(',');
 
-  // ── 레이스 컨디션 방지: 의존성 변경 시 렌더 단계에서 즉시 loading 리셋 ──
-  // useEffect는 paint 이후 실행되므로, 의존성이 바뀐 첫 렌더에서
-  // loading=false(이전 값) + prices=이전Map 조합이 한 프레임 노출될 수 있다.
-  // useRef로 이전 의존성을 추적하고, 변경 감지 시 paint 전에 loading=true로 전환한다.
   const prevDepsRef = useRef(`${newsletterDate}:${tickersKey}`);
   const currentDeps = `${newsletterDate}:${tickersKey}`;
 
@@ -192,7 +163,7 @@ export default function useStockPrices(
         setSettledClosePrices(new Map());
         setPrices(new Map());
 
-        // 추천일 전일 종가 조회 (비핵심 — 실패해도 newsletter 종가로 fallback)
+        // Historical close price (non-critical)
         const prevDate = getPreviousBusinessDate(currentDate);
         try {
           const historicalRes = await fetchWithRetry(
@@ -214,10 +185,9 @@ export default function useStockPrices(
         } catch (histErr) {
           if (histErr instanceof Error && histErr.name === 'AbortError') throw histErr;
           if (histErr instanceof DOMException && histErr.name === 'AbortError') throw histErr;
-          // 비핵심 데이터 — 무시하고 계속 진행
         }
 
-        // 추적 기간 만료 시 7영업일 후 확정 종가 조회
+        // Tracking period expired: fetch settled close
         const expired = isTrackingPeriodExpired(currentDate);
         if (expired) {
           if (isMounted) setIsExpired(true);
@@ -250,51 +220,24 @@ export default function useStockPrices(
           return;
         }
 
-        // 캐시 조회
-        const results = new Map<string, StockPrice>();
-        const cached = await getBatchPricesFromCache(tickers);
-        const uncachedTickers: string[] = [];
-
-        for (const ticker of tickers) {
-          const cachedPrice = cached.get(ticker);
-          if (cachedPrice) {
-            results.set(ticker, cachedPrice);
-          } else {
-            uncachedTickers.push(ticker);
-          }
-        }
-
-        // 모든 티커가 캐시에 있으면 종료
-        if (uncachedTickers.length === 0) {
-          if (isMounted) {
-            setPrices(results);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // API 호출 (재시도 로직 적용)
+        // Fetch current prices from /api/stock/price (server handles caching)
         const response = await fetchWithRetry(
-          `/api/stock/price?tickers=${uncachedTickers.join(',')}`,
+          `/api/stock/price?tickers=${tickersKey}`,
           { signal: controller.signal },
-          3,  // 최대 3회 재시도
-          300 // 기본 대기 시간 300ms
+          3,
+          300
         );
 
         const data: unknown = await response.json();
         if (!isStockPriceAPIResponse(data)) throw new Error('Invalid API response');
 
-        const expiresAt = getStockPriceCacheExpiry();
-        const cachePrices: StockPriceCache[] = [];
-
+        const results = new Map<string, StockPrice>();
         for (const price of Object.values(data.prices)) {
           if (isStockPrice(price)) {
             results.set(price.ticker, price);
-            cachePrices.push({ ...price, expires_at: expiresAt });
           }
         }
 
-        saveBatchPricesToCache(cachePrices).catch(() => {});
         if (isMounted) setPrices(results);
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
@@ -311,7 +254,6 @@ export default function useStockPrices(
       isMounted = false;
       controller.abort();
     };
-    // tickersKey가 tickers 내용을 대표하므로 tickers 배열 참조 불필요
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newsletterDate, tickersKey]);
 

--- a/app/archive/_utils/api/kis/__tests__/client-auth-refresh.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/client-auth-refresh.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tokenStorage = vi.hoisted(() => ({
+  getTokenFromStorage: vi.fn(),
+  saveTokenToStorage: vi.fn(),
+  invalidateTokenInStorage: vi.fn(),
+}))
+
+vi.mock('../token-storage', () => tokenStorage)
+vi.mock('@/lib/_utils/env-validator', () => ({
+  validateKisEnv: () => ({
+    KIS_BASE_URL: 'https://kis.example.test',
+    KIS_APP_KEY: 'app-key',
+    KIS_APP_SECRET: 'app-secret',
+  }),
+}))
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const VALID_STOCK_RESPONSE = {
+  rt_cd: '0',
+  output: {
+    stck_prpr: '70000',
+    stck_sdpr: '69000',
+    prdy_ctrt: '1.45',
+    acml_vol: '100000',
+  },
+}
+
+const TOKEN_ISSUANCE_RESPONSE = {
+  access_token: 'fresh-token-xyz',
+  token_type: 'Bearer',
+  expires_in: 86400,
+}
+
+describe('KIS client auth refresh (AI-006)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'stale-token',
+      expires_at: Date.now() + 60_000,
+    })
+    tokenStorage.saveTokenToStorage.mockResolvedValue(undefined)
+    tokenStorage.invalidateTokenInStorage.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('retries exactly once on 401 with a fresh token for getStockPrice', async () => {
+    const fetchMock = vi.fn()
+      // First call: 401 from the API
+      .mockResolvedValueOnce(jsonResponse({ msg1: 'token expired' }, 401))
+      // Token issuance call
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      // Retry call: success
+      .mockResolvedValueOnce(jsonResponse(VALID_STOCK_RESPONSE))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    const result = await getStockPrice('005930')
+    expect(result.currentPrice).toBe(70000)
+
+    // Verify: original request, token refresh, retry — exactly 3 calls
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    // Token was invalidated from storage
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(1)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledWith('stale-token')
+    expect(tokenStorage.saveTokenToStorage).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: 'fresh-token-xyz' }),
+    )
+  })
+
+  it('retries exactly once on 403 for getDailyRangeClosePrices', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ msg1: 'forbidden' }, 403))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_bsop_date: '20260701', stck_clpr: '70000', acml_vol: '1234' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    const result = await getDailyRangeClosePrices('005930', '20260701', '20260701')
+    expect(result).toEqual([{ date: '2026-07-01', close: 70_000, volume: 1_234 }])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries exactly once on 401 for getIndexDailyRangeClosePrices', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_bsop_date: '20260701', bstp_nmix_prpr: '2750.50', acml_vol: '5000' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getIndexDailyRangeClosePrices } = await import('../client')
+
+    const result = await getIndexDailyRangeClosePrices('0001', '20260701', '20260701')
+    expect(result).toEqual([{ date: '2026-07-01', close: 2750.50, volume: 5_000 }])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not loop: second 401 after refresh propagates the error', async () => {
+    const fetchMock = vi.fn()
+      // First call: 401
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      // Token issuance
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      // Retry also returns 401 — must NOT loop
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    await expect(getStockPrice('005930')).rejects.toThrow(/401/)
+    // Exactly 3 calls: original, token issuance, retry — no further attempts
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('invalidates only the rejected token, not a concurrently refreshed one', async () => {
+    // Simulate: cache already has a different (newer) token when invalidation runs
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'already-refreshed-by-other-caller',
+      expires_at: Date.now() + 60_000,
+    })
+
+    let callCount = 0
+    const fetchMock = vi.fn().mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        // First API call with the cached stale-token gets 401
+        return Promise.resolve(jsonResponse({}, 401))
+      }
+      if (callCount === 2) {
+        // Token issuance
+        return Promise.resolve(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      }
+      // Retry succeeds
+      return Promise.resolve(jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    const result = await getStockPrice('005930')
+    expect(result.currentPrice).toBe(70000)
+  })
+
+  it('shares concurrent token issuance (single-flight)', async () => {
+    // No cached token — force issuance
+    tokenStorage.getTokenFromStorage.mockResolvedValue(null)
+
+    let tokenIssuanceCalls = 0
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/oauth2/tokenP')) {
+        tokenIssuanceCalls++
+        return Promise.resolve(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      }
+      return Promise.resolve(jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    // Launch two concurrent requests
+    const [r1, r2] = await Promise.all([
+      getStockPrice('005930'),
+      getStockPrice('000660'),
+    ])
+
+    expect(r1.currentPrice).toBe(70000)
+    expect(r2.currentPrice).toBe(70000)
+    // Only ONE token issuance, not two
+    expect(tokenIssuanceCalls).toBe(1)
+  })
+
+  it('shares one refresh across concurrent 401 responses without deleting the new token', async () => {
+    let resolveIssuance: ((response: Response) => void) | undefined
+    const issuanceResponse = new Promise<Response>((resolve) => { resolveIssuance = resolve })
+    let issuanceCalls = 0
+    const fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/oauth2/tokenP')) {
+        issuanceCalls += 1
+        return issuanceResponse
+      }
+      const authorization = (options?.headers as Record<string, string> | undefined)?.authorization
+      return Promise.resolve(authorization === 'Bearer stale-token'
+        ? jsonResponse({}, 401)
+        : jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+    const requests = Promise.all([getStockPrice('005930'), getStockPrice('000660')])
+    await vi.waitFor(() => expect(issuanceCalls).toBe(1))
+    resolveIssuance?.(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+
+    const results = await requests
+    expect(results.map((result) => result.currentPrice)).toEqual([70_000, 70_000])
+    expect(issuanceCalls).toBe(1)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(2)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenNthCalledWith(1, 'stale-token')
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenNthCalledWith(2, 'stale-token')
+    expect(tokenStorage.saveTokenToStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a second auth rejection as terminal for outer batch retries', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getBatchStockPrices } = await import('../client')
+    const result = await getBatchStockPrices(['005930'])
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.prices.size).toBe(0)
+    expect(result.failures.get('005930')).toMatch(/after one token refresh/)
+  })
+
+  it('retries on 401 for getAuthoritativeStockMarket (market path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output: { rprs_mrkt_kor_name: '코스피' },
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getAuthoritativeStockMarket } = await import('../client')
+
+    const market = await getAuthoritativeStockMarket('005930')
+    expect(market).toBe('KOSPI')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries on 403 for getDailyClosePrice (daily close path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_clpr: '68000' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getDailyClosePrice } = await import('../client')
+
+    const price = await getDailyClosePrice('005930', '20260730')
+    expect(price).toBe(68000)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries on 401 for getIndexDailyClosePrice (index close path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ bstp_nmix_prpr: '2750.50' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getIndexDailyClosePrice } = await import('../client')
+
+    const price = await getIndexDailyClosePrice('0001', '20260730')
+    expect(price).toBe(2750.50)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/app/archive/_utils/api/kis/__tests__/client-range.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/client-range.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tokenStorage = vi.hoisted(() => ({
+  getTokenFromStorage: vi.fn(),
+  saveTokenToStorage: vi.fn(),
+  invalidateTokenInStorage: vi.fn(),
+}))
+
+vi.mock('../token-storage', () => tokenStorage)
+vi.mock('@/lib/_utils/env-validator', () => ({
+  validateKisEnv: () => ({
+    KIS_BASE_URL: 'https://kis.example.test',
+    KIS_APP_KEY: 'app-key',
+    KIS_APP_SECRET: 'app-secret',
+  }),
+}))
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('KIS daily-range client contract', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'cached-token',
+      expires_at: Date.now() + 60_000,
+    })
+    tokenStorage.saveTokenToStorage.mockResolvedValue(undefined)
+    tokenStorage.invalidateTokenInStorage.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps a successful empty output2 as a legitimate empty trading result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '0', output2: [] })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260702')).resolves.toEqual([])
+  })
+
+  it('throws a typed failure for HTTP and KIS API errors instead of returning []', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '1' }, 503)))
+    const { getDailyRangeClosePrices, KisDailyRangeRequestError } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260702'))
+      .rejects.toBeInstanceOf(KisDailyRangeRequestError)
+  })
+
+  it('throws when output2 is missing or not an array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '0', output2: null })))
+    const { getIndexDailyRangeClosePrices } = await import('../client')
+
+    await expect(getIndexDailyRangeClosePrices('0001', '20260701', '20260702'))
+      .rejects.toThrow(/output2 array/)
+  })
+
+  it('rejects malformed rows rather than filtering them into a false empty result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      rt_cd: '0',
+      output2: [{ stck_bsop_date: '20260231', stck_clpr: '70000', acml_vol: '100' }],
+    })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260201', '20260228'))
+      .rejects.toThrow(/invalid date\/close/)
+  })
+
+  it('parses valid stock range rows without changing numeric meaning', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      rt_cd: '0',
+      output2: [{ stck_bsop_date: '20260701', stck_clpr: '70000', acml_vol: '1234' }],
+    })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260701')).resolves.toEqual([
+      { date: '2026-07-01', close: 70_000, volume: 1_234 },
+    ])
+  })
+})

--- a/app/archive/_utils/api/kis/__tests__/token-storage.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/token-storage.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('KIS token storage credentials', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('fails closed when only the public anon key is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'public-anon-key')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+    const { getTokenFromStorage, KisTokenStorageError } = await import('../token-storage')
+
+    await expect(getTokenFromStorage()).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(getTokenFromStorage()).rejects.toThrow(/SUPABASE_SERVICE_ROLE_KEY/)
+  })
+
+  it('invalidateTokenInStorage fails closed without service role key', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+    const { invalidateTokenInStorage, KisTokenStorageError } = await import('../token-storage')
+
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toThrow(/SUPABASE_SERVICE_ROLE_KEY/)
+  })
+
+  it('invalidates only the exact rejected stored token and propagates errors', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'valid-service-key')
+
+    const accessTokenEq = vi.fn().mockResolvedValue({ error: { message: 'delete denied' } })
+    const idEq = vi.fn().mockReturnValue({ eq: accessTokenEq })
+    const mockDelete = vi.fn().mockReturnValue({ eq: idEq })
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ delete: mockDelete }),
+      }),
+    }))
+
+    const { invalidateTokenInStorage, KisTokenStorageError } = await import('../token-storage')
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toThrow(/invalidate/)
+    expect(idEq).toHaveBeenCalledWith('id', 'kis_access_token')
+    expect(accessTokenEq).toHaveBeenCalledWith('access_token', 'rejected-token')
+  })
+})

--- a/app/archive/_utils/api/kis/client.ts
+++ b/app/archive/_utils/api/kis/client.ts
@@ -8,7 +8,7 @@
  */
 
 import { validateKisEnv } from '@/lib/_utils/env-validator';
-import { getTokenFromStorage, saveTokenToStorage } from './token-storage';
+import { getTokenFromStorage, saveTokenToStorage, invalidateTokenInStorage } from './token-storage';
 import { checkRateLimit } from './rate-limiter';
 import type { KisToken, KisStockPrice, KisErrorResponse, KisConfig, BatchPriceResult } from './types';
 
@@ -18,11 +18,25 @@ const tokenCache: { token: KisToken | null } = { token: null };
 // 환경 변수 캐시 (런타임에 로드)
 let configCache: KisConfig | null = null;
 
+/**
+ * Single-flight token issuance/refresh: concurrent callers share a single
+ * in-progress token request rather than issuing duplicate requests.
+ */
+let tokenIssuanceInFlight: Promise<KisToken> | null = null;
+
 /** KIS API 요청 타임아웃 (ms) */
 const FETCH_TIMEOUT_MS = 8_000;
 
 /** 종목 간 요청 간격 (ms) — KIS API rate limit 방지 */
 const INTER_REQUEST_DELAY_MS = 100;
+
+export class KisAuthenticationError extends Error {
+  readonly name = 'KisAuthenticationError';
+
+  constructor(status: number) {
+    super(`KIS authentication failed after one token refresh: HTTP ${status}`);
+  }
+}
 
 /**
  * 타임아웃이 있는 fetch
@@ -55,6 +69,7 @@ async function retryAsync<T>(
       return await fn();
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
+      if (lastError instanceof KisAuthenticationError) throw lastError;
       if (attempt < maxRetries) {
         await new Promise((resolve) => setTimeout(resolve, baseDelay * Math.pow(2, attempt)));
       }
@@ -164,6 +179,7 @@ async function issueNewToken(): Promise<KisToken> {
 
 /**
  * 접근 토큰 발급 (2-tier 캐싱: 메모리 → Supabase)
+ * Uses single-flight pattern: concurrent callers share a single token issuance.
  */
 async function getAccessToken(): Promise<string> {
   const now = Date.now();
@@ -180,14 +196,66 @@ async function getAccessToken(): Promise<string> {
     return storedToken.access_token;
   }
 
-  // 3. 새 토큰 발급
-  checkRateLimit('token');
-  const newToken = await issueNewToken();
+  // 3. 새 토큰 발급 (single-flight)
+  return (await singleFlightIssueToken()).access_token;
+}
 
-  tokenCache.token = newToken;
-  saveTokenToStorage(newToken).catch(() => {});
+/**
+ * Single-flight token issuance: if a request is already in progress, join it.
+ */
+async function singleFlightIssueToken(): Promise<KisToken> {
+  if (tokenIssuanceInFlight) {
+    return tokenIssuanceInFlight;
+  }
 
-  return newToken.access_token;
+  tokenIssuanceInFlight = (async () => {
+    try {
+      checkRateLimit('token');
+      const newToken = await issueNewToken();
+      await saveTokenToStorage(newToken);
+      tokenCache.token = newToken;
+      return newToken;
+    } finally {
+      tokenIssuanceInFlight = null;
+    }
+  })();
+
+  return tokenIssuanceInFlight;
+}
+
+/** 401/403으로 거절된 정확한 token만 memory/storage에서 무효화한다. */
+async function invalidateToken(rejectedAccessToken: string): Promise<void> {
+  if (tokenCache.token?.access_token === rejectedAccessToken) {
+    tokenCache.token = null;
+  }
+  await invalidateTokenInStorage(rejectedAccessToken);
+}
+
+/** concurrent caller가 이미 만든 새 token을 재사용하고, 아니면 single-flight issuance에 합류한다. */
+async function refreshAccessToken(rejectedAccessToken: string): Promise<string> {
+  await invalidateToken(rejectedAccessToken);
+  const current = tokenCache.token;
+  if (current && current.access_token !== rejectedAccessToken && current.expires_at > Date.now()) {
+    return current.access_token;
+  }
+  return (await singleFlightIssueToken()).access_token;
+}
+
+/** 401/403에 한해 정확히 한 번 refresh/retry하고 두 번째 rejection은 terminal이다. */
+async function authenticatedKisFetch(
+  buildRequest: (accessToken: string) => Promise<Response>,
+): Promise<Response> {
+  const token = await getAccessToken();
+  const response = await buildRequest(token);
+
+  if (response.status !== 401 && response.status !== 403) return response;
+
+  const freshToken = await refreshAccessToken(token);
+  const retriedResponse = await buildRequest(freshToken);
+  if (retriedResponse.status === 401 || retriedResponse.status === 403) {
+    throw new KisAuthenticationError(retriedResponse.status);
+  }
+  return retriedResponse;
 }
 
 /**
@@ -211,29 +279,94 @@ function parseOptionalFloat(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+/** KIS가 명시적으로 확인한 국내 거래소. 추정값이나 UNKNOWN은 허용하지 않는다. */
+export type AuthoritativeKoreanStockMarket = 'KOSPI' | 'KOSDAQ';
+
+export function classifyKisRepresentativeMarketName(value: unknown): AuthoritativeKoreanStockMarket | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toUpperCase().replace(/\s+/g, '');
+  if (normalized.startsWith('KOSDAQ') || normalized.startsWith('코스닥')) return 'KOSDAQ';
+  if (normalized.startsWith('KOSPI') || normalized.startsWith('코스피') || normalized.startsWith('유가증권')) {
+    return 'KOSPI';
+  }
+  return null;
+}
+
+/**
+ * KIS 국내주식 현재가 응답의 대표시장명으로 거래소를 확인한다.
+ * 누락·알 수 없는 시장은 임의 기본값으로 바꾸지 않고 실패시킨다.
+ */
+export async function getAuthoritativeStockMarket(ticker: string): Promise<AuthoritativeKoreanStockMarket> {
+  const cleanedTicker = cleanTicker(ticker);
+  const config = getKisConfig();
+  checkRateLimit('price');
+
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
+      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
+        new URLSearchParams({
+          FID_COND_MRKT_DIV_CODE: 'J',
+          FID_INPUT_ISCD: cleanedTicker,
+        }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${accessToken}`,
+          appkey: config.KIS_APP_KEY,
+          appsecret: config.KIS_APP_SECRET,
+          tr_id: 'FHKST01010100',
+        },
+      },
+    ),
+  );
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error: unknown) {
+    throw new Error(
+      `KIS market response JSON parse failed for ${cleanedTicker}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const candidate = typeof payload === 'object' && payload !== null
+    ? payload as { readonly rt_cd?: unknown; readonly output?: { readonly rprs_mrkt_kor_name?: unknown } }
+    : null;
+  if (!response.ok || (candidate?.rt_cd !== undefined && candidate.rt_cd !== '0')) {
+    throw new Error(`KIS market lookup failed for ${cleanedTicker}: HTTP ${response.status}`);
+  }
+
+  const market = classifyKisRepresentativeMarketName(candidate?.output?.rprs_mrkt_kor_name);
+  if (market === null) {
+    throw new Error(`KIS market lookup returned no recognized exchange for ${cleanedTicker}`);
+  }
+  return market;
+}
+
 /**
  * 국내 주식 현재가 조회
  */
 export async function getStockPrice(ticker: string): Promise<KisStockPrice> {
-  const token = await getAccessToken();
   const cleanedTicker = cleanTicker(ticker);
   const config = getKisConfig();
 
-  const response = await fetchWithTimeout(
-    `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
-      new URLSearchParams({
-        FID_COND_MRKT_DIV_CODE: 'J',
-        FID_INPUT_ISCD: cleanedTicker,
-      }),
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        authorization: `Bearer ${token}`,
-        appkey: config.KIS_APP_KEY,
-        appsecret: config.KIS_APP_SECRET,
-        tr_id: 'FHKST01010100',
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
+      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
+        new URLSearchParams({
+          FID_COND_MRKT_DIV_CODE: 'J',
+          FID_INPUT_ISCD: cleanedTicker,
+        }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${accessToken}`,
+          appkey: config.KIS_APP_KEY,
+          appsecret: config.KIS_APP_SECRET,
+          tr_id: 'FHKST01010100',
+        },
       },
-    }
+    ),
   );
 
   if (!response.ok) {
@@ -307,7 +440,6 @@ export async function getBatchStockPrices(tickers: string[]): Promise<BatchPrice
 export async function getDailyClosePrice(ticker: string, date: string): Promise<number | null> {
   try {
     const config = getKisConfig();
-    const token = await getAccessToken();
 
     const params = new URLSearchParams({
       FID_COND_MRKT_DIV_CODE: 'J',
@@ -318,17 +450,19 @@ export async function getDailyClosePrice(ticker: string, date: string): Promise<
       FID_ORG_ADJ_PRC: '0',
     });
 
-    const res = await fetchWithTimeout(
-      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
-          appkey: config.KIS_APP_KEY,
-          appsecret: config.KIS_APP_SECRET,
-          tr_id: 'FHKST03010100',
+    const res = await authenticatedKisFetch((accessToken) =>
+      fetchWithTimeout(
+        `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${accessToken}`,
+            appkey: config.KIS_APP_KEY,
+            appsecret: config.KIS_APP_SECRET,
+            tr_id: 'FHKST03010100',
+          },
         },
-      }
+      ),
     );
 
     const data = await res.json();
@@ -348,7 +482,6 @@ export async function getDailyClosePrice(ticker: string, date: string): Promise<
 export async function getIndexDailyClosePrice(indexCode: string, date: string): Promise<number | null> {
   try {
     const config = getKisConfig();
-    const token = await getAccessToken();
 
     const params = new URLSearchParams({
       FID_COND_MRKT_DIV_CODE: 'U',
@@ -358,17 +491,19 @@ export async function getIndexDailyClosePrice(indexCode: string, date: string): 
       FID_PERIOD_DIV_CODE: 'D',
     });
 
-    const res = await fetchWithTimeout(
-      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
-          appkey: config.KIS_APP_KEY,
-          appsecret: config.KIS_APP_SECRET,
-          tr_id: 'FHKUP03500100',
+    const res = await authenticatedKisFetch((accessToken) =>
+      fetchWithTimeout(
+        `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${accessToken}`,
+            appkey: config.KIS_APP_KEY,
+            appsecret: config.KIS_APP_SECRET,
+            tr_id: 'FHKUP03500100',
+          },
         },
-      }
+      ),
     );
 
     const data = await res.json();
@@ -388,18 +523,92 @@ export interface KisDailyRangePricePoint {
   readonly volume: number | null;
 }
 
+export class KisDailyRangeRequestError extends Error {
+  readonly name = 'KisDailyRangeRequestError';
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
 function toIsoDate(kisDate: string): string | null {
   if (!/^\d{8}$/.test(kisDate)) return null;
+  const year = Number(kisDate.slice(0, 4));
+  const month = Number(kisDate.slice(4, 6));
+  const day = Number(kisDate.slice(6, 8));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return null;
+  }
   return `${kisDate.slice(0, 4)}-${kisDate.slice(4, 6)}-${kisDate.slice(6, 8)}`;
 }
 
-function parseRangePriceRow(row: Record<string, string>, closeField: string, parseClose: (v: string) => number): KisDailyRangePricePoint | null {
-  const date = toIsoDate(row.stck_bsop_date);
-  const close = parseClose(row[closeField]);
-  if (!date || !Number.isFinite(close) || close <= 0) return null;
+function parseRangePriceRow(
+  row: unknown,
+  closeField: string,
+  parseClose: (value: string) => number,
+  label: string,
+  index: number,
+): KisDailyRangePricePoint {
+  if (typeof row !== 'object' || row === null) {
+    throw new KisDailyRangeRequestError(`${label} row ${index} is not an object`);
+  }
+  const record = row as Record<string, unknown>;
+  const rawDate = record.stck_bsop_date;
+  const rawClose = record[closeField];
+  if (typeof rawDate !== 'string' || typeof rawClose !== 'string') {
+    throw new KisDailyRangeRequestError(`${label} row ${index} is missing date/close fields`);
+  }
 
-  const volume = parseInt(row.acml_vol, 10);
-  return { date, close, volume: Number.isFinite(volume) ? volume : null };
+  const date = toIsoDate(rawDate);
+  const close = parseClose(rawClose);
+  if (!date || !Number.isFinite(close) || close <= 0) {
+    throw new KisDailyRangeRequestError(`${label} row ${index} has an invalid date/close`);
+  }
+
+  const rawVolume = record.acml_vol;
+  let volume: number | null = null;
+  if (rawVolume !== undefined && rawVolume !== null && rawVolume !== '') {
+    if (typeof rawVolume !== 'string') {
+      throw new KisDailyRangeRequestError(`${label} row ${index} has a non-string volume`);
+    }
+    volume = Number.parseInt(rawVolume, 10);
+    if (!Number.isFinite(volume) || volume < 0) {
+      throw new KisDailyRangeRequestError(`${label} row ${index} has an invalid volume`);
+    }
+  }
+
+  return { date, close, volume };
+}
+
+async function parseDailyRangeResponse(
+  response: Response,
+  label: string,
+): Promise<readonly unknown[]> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error: unknown) {
+    throw new KisDailyRangeRequestError(`${label} returned invalid JSON`, {
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new KisDailyRangeRequestError(`${label} failed with HTTP ${response.status}`);
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    throw new KisDailyRangeRequestError(`${label} returned a non-object payload`);
+  }
+
+  const data = payload as { readonly rt_cd?: unknown; readonly output2?: unknown };
+  if (data.rt_cd !== '0') {
+    throw new KisDailyRangeRequestError(`${label} returned a non-success KIS result`);
+  }
+  if (!Array.isArray(data.output2)) {
+    throw new KisDailyRangeRequestError(`${label} returned no output2 array`);
+  }
+  return data.output2;
 }
 
 /**
@@ -413,41 +622,37 @@ export async function getDailyRangeClosePrices(
   startDate: string,
   endDate: string
 ): Promise<KisDailyRangePricePoint[]> {
-  try {
-    const config = getKisConfig();
-    const token = await getAccessToken();
+  const config = getKisConfig();
+  const cleanedTicker = cleanTicker(ticker);
+  const label = `KIS stock daily range ${cleanedTicker}`;
 
-    const params = new URLSearchParams({
-      FID_COND_MRKT_DIV_CODE: 'J',
-      FID_INPUT_ISCD: cleanTicker(ticker),
-      FID_INPUT_DATE_1: startDate,
-      FID_INPUT_DATE_2: endDate,
-      FID_PERIOD_DIV_CODE: 'D',
-      FID_ORG_ADJ_PRC: '0',
-    });
+  const params = new URLSearchParams({
+    FID_COND_MRKT_DIV_CODE: 'J',
+    FID_INPUT_ISCD: cleanedTicker,
+    FID_INPUT_DATE_1: startDate,
+    FID_INPUT_DATE_2: endDate,
+    FID_PERIOD_DIV_CODE: 'D',
+    FID_ORG_ADJ_PRC: '0',
+  });
 
-    const res = await fetchWithTimeout(
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
       `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
       {
         headers: {
           'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${accessToken}`,
           appkey: config.KIS_APP_KEY,
           appsecret: config.KIS_APP_SECRET,
           tr_id: 'FHKST03010100',
         },
-      }
-    );
+      },
+    ),
+  );
 
-    const data = await res.json();
-    if (!res.ok || data.rt_cd !== '0' || !Array.isArray(data.output2)) return [];
-
-    return data.output2
-      .map((row: Record<string, string>) => parseRangePriceRow(row, 'stck_clpr', (v) => parseInt(v, 10)))
-      .filter((point: KisDailyRangePricePoint | null): point is KisDailyRangePricePoint => point !== null);
-  } catch {
-    return [];
-  }
+  const rows = await parseDailyRangeResponse(response, label);
+  return rows.map((row, index) =>
+    parseRangePriceRow(row, 'stck_clpr', (value) => Number.parseInt(value, 10), label, index));
 }
 
 /**
@@ -461,40 +666,35 @@ export async function getIndexDailyRangeClosePrices(
   startDate: string,
   endDate: string
 ): Promise<KisDailyRangePricePoint[]> {
-  try {
-    const config = getKisConfig();
-    const token = await getAccessToken();
+  const config = getKisConfig();
+  const label = `KIS index daily range ${indexCode}`;
 
-    const params = new URLSearchParams({
-      FID_COND_MRKT_DIV_CODE: 'U',
-      FID_INPUT_ISCD: indexCode,
-      FID_INPUT_DATE_1: startDate,
-      FID_INPUT_DATE_2: endDate,
-      FID_PERIOD_DIV_CODE: 'D',
-    });
+  const params = new URLSearchParams({
+    FID_COND_MRKT_DIV_CODE: 'U',
+    FID_INPUT_ISCD: indexCode,
+    FID_INPUT_DATE_1: startDate,
+    FID_INPUT_DATE_2: endDate,
+    FID_PERIOD_DIV_CODE: 'D',
+  });
 
-    const res = await fetchWithTimeout(
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
       `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
       {
         headers: {
           'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${accessToken}`,
           appkey: config.KIS_APP_KEY,
           appsecret: config.KIS_APP_SECRET,
           tr_id: 'FHKUP03500100',
         },
-      }
-    );
+      },
+    ),
+  );
 
-    const data = await res.json();
-    if (!res.ok || data.rt_cd !== '0' || !Array.isArray(data.output2)) return [];
-
-    return data.output2
-      .map((row: Record<string, string>) => parseRangePriceRow(row, 'bstp_nmix_prpr', (v) => parseFloat(v)))
-      .filter((point: KisDailyRangePricePoint | null): point is KisDailyRangePricePoint => point !== null);
-  } catch {
-    return [];
-  }
+  const rows = await parseDailyRangeResponse(response, label);
+  return rows.map((row, index) =>
+    parseRangePriceRow(row, 'bstp_nmix_prpr', (value) => Number.parseFloat(value), label, index));
 }
 
 /**

--- a/app/archive/_utils/api/kis/token-storage.ts
+++ b/app/archive/_utils/api/kis/token-storage.ts
@@ -1,5 +1,6 @@
 /**
- * KIS 토큰 Supabase 저장/조회 서비스
+ * KIS 토큰 Supabase 저장/조회 서비스.
+ * kis_tokens는 service-role 전용 서버 자산이며 anon fallback을 허용하지 않는다.
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
@@ -9,77 +10,82 @@ const TOKEN_ID = 'kis_access_token';
 
 let supabaseClient: SupabaseClient<Database> | null = null;
 
-/**
- * Supabase 클라이언트 초기화 (lazy initialization)
- */
-function getSupabase(): SupabaseClient<Database> {
-  if (!supabaseClient) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    // kis_tokens는 RLS로 service_role 전용. 서버(API 라우트)에서만 실행되므로 service_role 우선.
-    const supabaseKey =
-      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export class KisTokenStorageError extends Error {
+  readonly name = 'KisTokenStorageError';
 
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error(
-        'Supabase credentials not configured. ' +
-          'Please set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables.'
-      );
-    }
-
-    supabaseClient = createClient<Database>(supabaseUrl, supabaseKey);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
   }
+}
+
+/** Supabase service-role client lazy initialization. */
+function getSupabase(): SupabaseClient<Database> {
+  if (supabaseClient) return supabaseClient;
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new KisTokenStorageError(
+      'KIS token storage requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY',
+    );
+  }
+
+  supabaseClient = createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
   return supabaseClient;
 }
 
-/**
- * Supabase에서 토큰 조회
- */
+/** Supabase에서 유효한 토큰 조회. 저장소 오류는 cache miss로 위장하지 않는다. */
 export async function getTokenFromStorage(): Promise<KisToken | null> {
-  try {
-    const supabase = getSupabase();
-    const { data: tokenData } = await supabase
-      .from('kis_tokens')
-      .select('*')
-      .eq('id', TOKEN_ID)
-      .single();
+  const supabase = getSupabase();
+  const { data: tokenData, error } = await supabase
+    .from('kis_tokens')
+    .select('*')
+    .eq('id', TOKEN_ID)
+    .maybeSingle();
 
-    if (!tokenData) {
-      return null;
-    }
+  if (error) {
+    throw new KisTokenStorageError(`Failed to read KIS token storage: ${error.message}`);
+  }
+  if (!tokenData) return null;
 
-    const row = tokenData as KisTokenRow;
-    const now = Date.now();
+  const row = tokenData as KisTokenRow;
+  if (row.expires_at <= Date.now()) return null;
 
-    // 토큰이 만료되었으면 null 반환
-    if (row.expires_at <= now) {
-      return null;
-    }
+  return {
+    access_token: row.access_token,
+    expires_at: row.expires_at,
+  };
+}
 
-    return {
-      access_token: row.access_token,
-      expires_at: row.expires_at,
-    };
-  } catch (error) {
-    // Supabase 조회 실패 시 null 반환 (캐시 미스로 처리)
-    console.error('[KIS Token Storage] Failed to get token from Supabase:', error);
-    return null;
+/** Supabase에 토큰 저장. 실패를 삼키지 않아 반복 발급을 방지한다. */
+export async function saveTokenToStorage(token: KisToken): Promise<void> {
+  const supabase = getSupabase();
+  const tokenRow: KisTokenInsert = {
+    id: TOKEN_ID,
+    access_token: token.access_token,
+    expires_at: token.expires_at,
+    updated_at: new Date().toISOString(),
+  };
+  const { error } = await supabase.from('kis_tokens').upsert(tokenRow);
+  if (error) {
+    throw new KisTokenStorageError(`Failed to persist KIS token: ${error.message}`);
   }
 }
 
-/**
- * Supabase에 토큰 저장 (upsert)
- */
-export async function saveTokenToStorage(token: KisToken): Promise<void> {
-  try {
-    const supabase = getSupabase();
-    const tokenRow: KisTokenInsert = {
-      id: TOKEN_ID,
-      access_token: token.access_token,
-      expires_at: token.expires_at,
-      updated_at: new Date().toISOString(),
-    };
-    await supabase.from('kis_tokens').upsert(tokenRow);
-  } catch (error) {
-    console.error('[KIS Token Storage] Failed to save token to Supabase:', error);
+/** 401/403으로 거절된 정확한 저장 토큰만 삭제한다. 새로 갱신된 토큰은 보존한다. */
+export async function invalidateTokenInStorage(rejectedAccessToken: string): Promise<void> {
+  if (!rejectedAccessToken) {
+    throw new KisTokenStorageError('Rejected KIS access token is required for invalidation');
+  }
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from('kis_tokens')
+    .delete()
+    .eq('id', TOKEN_ID)
+    .eq('access_token', rejectedAccessToken);
+  if (error) {
+    throw new KisTokenStorageError(`Failed to invalidate KIS token: ${error.message}`);
   }
 }

--- a/app/archive/_utils/cache/stock-price.ts
+++ b/app/archive/_utils/cache/stock-price.ts
@@ -1,5 +1,12 @@
+import 'server-only';
+
 /**
- * 주식 가격 Supabase 캐시 저장/조회 서비스
+ * 주식 가격 Supabase 캐시 저장/조회 서비스 (SERVER-ONLY)
+ *
+ * Architecture:
+ * - Both reads and writes use service_role key (server-side only)
+ * - This module must NOT be imported from client-side code
+ * - Cache failures are non-poisoning: read failures return empty, write failures are logged
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
@@ -10,44 +17,31 @@ import type {
   StockPriceCacheInsert,
 } from './types';
 
-let supabaseClient: SupabaseClient<StockPriceCacheDatabase> | null = null;
-
 /**
  * 캐시 에러 로깅 (프로덕션 관찰성 확보)
  */
 function logCacheError(message: string, error: unknown): void {
-  console.error(`[StockPriceCache] ${message}:`, error);
+  console.error(`[StockPriceCache] ${message}:`, error instanceof Error ? error.message : error);
 }
 
 /**
  * 주식 가격 데이터 기본 검증
  */
-function validateStockPrice(price: StockPriceCache): void {
-  if (!price.ticker || price.currentPrice <= 0 || price.previousClose <= 0) {
-    throw new Error(`Invalid stock price for ${price.ticker}`);
-  }
+function validateStockPrice(price: StockPriceCache): boolean {
+  return !!(price.ticker && price.currentPrice > 0 && price.previousClose > 0);
 }
 
 /**
- * Supabase 클라이언트 초기화 (lazy initialization)
- *
- * @throws {Error} 환경 변수 미설정 시
+ * Service-role Supabase client (server-side only).
+ * Returns null if service role key is not configured.
  */
-function getSupabase(): SupabaseClient<StockPriceCacheDatabase> {
-  if (!supabaseClient) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error(
-        'Supabase credentials not configured. ' +
-          'Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.'
-      );
-    }
-
-    supabaseClient = createClient<StockPriceCacheDatabase>(supabaseUrl, supabaseKey);
-  }
-  return supabaseClient;
+function getServiceClient(): SupabaseClient<StockPriceCacheDatabase> | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient<StockPriceCacheDatabase>(url, key, {
+    auth: { persistSession: false },
+  });
 }
 
 /**
@@ -82,23 +76,21 @@ function mapCacheToInsert(price: StockPriceCache): StockPriceCacheInsert {
 }
 
 /**
- * Supabase에서 여러 주식 가격 캐시 일괄 조회
+ * Supabase에서 여러 주식 가격 캐시 일괄 조회 (service-role)
  *
- * @param tickers - 조회할 티커 배열
- * @returns Map<ticker, StockPriceCache> (만료되지 않은 캐시만)
+ * Non-poisoning: returns empty on error.
  */
 export async function getBatchPricesFromCache(
   tickers: string[]
 ): Promise<Map<string, StockPriceCache>> {
   const results = new Map<string, StockPriceCache>();
-
-  if (tickers.length === 0) {
-    return results;
-  }
+  if (tickers.length === 0) return results;
 
   try {
-    const supabase = getSupabase();
-    const { data: cacheData, error } = await supabase
+    const client = getServiceClient();
+    if (!client) return results;
+
+    const { data: cacheData, error } = await client
       .from('stock_price_cache')
       .select('*')
       .in('ticker', tickers);
@@ -108,16 +100,11 @@ export async function getBatchPricesFromCache(
       return results;
     }
 
-    if (!cacheData || cacheData.length === 0) {
-      return results;
-    }
+    if (!cacheData || cacheData.length === 0) return results;
 
     const now = Date.now();
-
     cacheData.forEach((row) => {
       const cache = mapRowToCache(row);
-
-      // 만료되지 않은 캐시만 반환
       if (cache.expires_at > now) {
         results.set(cache.ticker, cache);
       }
@@ -131,23 +118,22 @@ export async function getBatchPricesFromCache(
 }
 
 /**
- * Supabase에 여러 주식 가격 캐시 일괄 저장 (upsert)
+ * Supabase에 여러 주식 가격 캐시 일괄 저장 (upsert, service-role only)
  *
- * @param prices - 저장할 가격 데이터 배열
+ * Non-poisoning: silently fails on error.
  */
 export async function saveBatchPricesToCache(prices: StockPriceCache[]): Promise<void> {
-  if (prices.length === 0) {
-    return;
-  }
+  if (prices.length === 0) return;
+
+  const client = getServiceClient();
+  if (!client) return;
 
   try {
-    // 모든 가격 데이터 검증
-    prices.forEach((price) => validateStockPrice(price));
+    const validPrices = prices.filter(validateStockPrice);
+    if (validPrices.length === 0) return;
 
-    const supabase = getSupabase();
-    const cacheRows = prices.map((price) => mapCacheToInsert(price));
-
-    const { error } = await supabase.from('stock_price_cache').upsert(cacheRows);
+    const cacheRows = validPrices.map(mapCacheToInsert);
+    const { error } = await client.from('stock_price_cache').upsert(cacheRows);
 
     if (error) {
       logCacheError('Failed to save batch prices', error);

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
   Loader2,
@@ -27,7 +28,119 @@ const subscribeSchema = z.object({
   name: z.string().max(100, '이름 길이 제한 초과').optional(),
 });
 
+/**
+ * Confirmation sub-component shown when ?confirm=<token> is present.
+ * Requires explicit user action (POST) — no GET mutation.
+ */
+function ConfirmSection({ token }: { token: string }) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  const handleConfirm = async () => {
+    setStatus('loading');
+    try {
+      const res = await fetch('/api/subscribe/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json().catch(() => ({})) as { status?: string; error?: string; message?: string };
+      if (res.ok) {
+        setStatus('success');
+        setMessage(data.message || '구독이 확인되었습니다!');
+      } else {
+        setStatus('error');
+        setMessage(data.error || '확인 처리에 실패했습니다.');
+      }
+    } catch {
+      setStatus('error');
+      setMessage('네트워크 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white relative overflow-hidden mt-20">
+      <AnimatedBackground />
+      <main className="pt-20 pb-24 px-6 lg:px-8 relative z-10">
+        <motion.div
+          initial={{ opacity: 0, y: 60 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.9, ease: [0.19, 1, 0.22, 1] }}
+          className="max-w-lg mx-auto"
+        >
+          <div className="glass-morphism rounded-3xl p-8 lg:p-12 border border-emerald-500/20 text-center">
+            <h1 className="text-3xl font-light text-emerald-500/80 mb-6">구독 확인</h1>
+            {status === 'idle' && (
+              <>
+                <p className="text-slate-300 mb-8">아래 버튼을 클릭하여 구독을 확인해주세요.</p>
+                <button
+                  onClick={handleConfirm}
+                  className="px-8 py-3 bg-emerald-600 text-white rounded-xl font-medium hover:bg-emerald-500 transition-colors"
+                  aria-label="Confirm subscription"
+                >
+                  구독 확인하기
+                </button>
+              </>
+            )}
+            {status === 'loading' && (
+              <div className="flex items-center justify-center gap-2 text-slate-300">
+                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+                확인 중...
+              </div>
+            )}
+            {status === 'success' && (
+              <div className="flex items-center justify-center gap-3 text-emerald-400">
+                <CheckCircle className="w-6 h-6" aria-hidden="true" />
+                <span>{message}</span>
+              </div>
+            )}
+            {status === 'error' && (
+              <div className="flex items-center justify-center gap-3 text-red-400">
+                <XCircle className="w-6 h-6" aria-hidden="true" />
+                <span>{message}</span>
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+function SubscribeContent() {
+  const searchParams = useSearchParams();
+  const confirmToken = searchParams.get('confirm');
+
+  // If a confirm token is present, show the confirmation UI
+  if (confirmToken) {
+    return <ConfirmSection token={confirmToken} />;
+  }
+
+  return <SubscribeForm />;
+}
+
 export default function SubscribePage() {
+  return (
+    <React.Suspense
+      fallback={
+        <div
+          className="min-h-screen bg-black text-white flex items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="flex items-center gap-3 text-slate-300">
+            <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+            구독 페이지를 불러오는 중...
+          </span>
+        </div>
+      }
+    >
+      <SubscribeContent />
+    </React.Suspense>
+  );
+}
+
+function SubscribeForm() {
   const { formatted } = useCountdownToTomorrow();
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,56 +1,126 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, Suspense } from 'react';
 import { motion } from 'framer-motion';
 import { useSearchParams } from 'next/navigation';
-import { CheckCircle, XCircle, Loader2, AlertCircle } from 'lucide-react';
+import { CheckCircle, XCircle, Loader2, AlertCircle, Mail } from 'lucide-react';
 import Link from 'next/link';
-import { z } from 'zod';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import AnimatedBackground from '@/components/animated-background';
 
-const emailSchema = z.string().pipe(z.email({ message: '잘못된 이메일 형식' }));
+/**
+ * Recovery form for subscribers whose link is missing, legacy (`?email=`) or
+ * expired. Requesting a link never opts anyone out on its own — the mailed link
+ * still requires explicit confirmation.
+ */
+function RequestLinkForm({ initialEmail }: { initialEmail: string }) {
+  const [email, setEmail] = useState(initialEmail);
+  const [state, setState] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
 
-function UnsubscribeContent() {
-  const searchParams = useSearchParams();
-  const email = searchParams.get('email');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-
-  useEffect(() => {
-    if (email && emailSchema.safeParse(email).success) {
-      handleUnsubscribe();
-    } else if (email) {
-      setStatus('error');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [email]);
-
-  const handleUnsubscribe = async () => {
-    if (!email) return;
-
-    setStatus('loading');
-
+  const handleRequest = async () => {
+    setState('sending');
     try {
-      const res = await fetch('/api/unsubscribe', {
+      const res = await fetch('/api/unsubscribe/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       });
+      setState(res.ok ? 'sent' : 'error');
+    } catch {
+      setState('error');
+    }
+  };
+
+  if (state === 'sent') {
+    return (
+      <div
+        className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-emerald-500/20 bg-emerald-500/5 text-left"
+        role="status"
+        aria-live="polite"
+      >
+        <CheckCircle className="w-5 h-5 text-emerald-400 mt-0.5 flex-shrink-0" aria-hidden="true" />
+        <p className="text-base text-slate-300 font-light tracking-wide leading-relaxed">
+          해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto text-left">
+      <label htmlFor="unsubscribe-email" className="block text-sm text-slate-400 mb-3 tracking-wide">
+        구독하신 이메일 주소를 입력하시면 구독 취소 링크를 보내드립니다
+      </label>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Input
+          id="unsubscribe-email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="you@example.com"
+          className="bg-black/50 border-emerald-500/30 text-slate-200 placeholder:text-slate-600 rounded-lg px-4 py-6"
+        />
+        <Button
+          onClick={handleRequest}
+          disabled={state === 'sending' || email.trim().length === 0}
+          className="bg-emerald-600 text-black hover:bg-emerald-500 rounded-lg px-6 py-6 font-semibold disabled:opacity-50 cursor-pointer"
+        >
+          {state === 'sending' ? (
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <span className="whitespace-nowrap">링크 받기</span>
+          )}
+        </Button>
+      </div>
+      {state === 'error' && (
+        <p className="mt-3 text-sm text-red-300/90" role="alert">
+          요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function UnsubscribeContent() {
+  const searchParams = useSearchParams();
+  // Token-only for the mutation itself. A legacy `?email=` link only prefills the
+  // recovery form — it never unsubscribes directly.
+  const token = searchParams.get('token');
+  const legacyEmail = searchParams.get('email') ?? '';
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error' | 'expired'>('idle');
+
+  const hasValidParam = !!token;
+
+  const handleUnsubscribe = async () => {
+    setStatus('loading');
+
+    try {
+      const payload = { token };
+      const res = await fetch('/api/unsubscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (res.status === 410) {
+        setStatus('expired');
+        return;
+      }
 
       if (!res.ok) {
-        console.error('Unsubscribe error:', await res.text().catch(() => ''));
         setStatus('error');
         return;
       }
 
       setStatus('success');
-    } catch (error) {
-      console.error('Unsubscribe error:', error);
+    } catch {
       setStatus('error');
     }
   };
 
-  if (!email || !emailSchema.safeParse(email).success) {
+  if (!hasValidParam) {
     return (
       <motion.div
         initial={{ opacity: 0, y: 60 }}
@@ -65,28 +135,84 @@ function UnsubscribeContent() {
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
             transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
-            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
             aria-hidden="true"
           >
-            <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
+            <Mail className="w-10 lg:w-12 h-10 lg:h-12 text-emerald-400" />
           </motion.div>
           <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
-            Invalid Request
+            Unsubscribe
           </p>
           <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
-            유효하지 않은 이메일 주소입니다
+            구독 취소 링크를 받아 진행해주세요
           </p>
         </div>
-        <Link href="/">
-          <Button
-            variant="outline"
-            className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
-            aria-label="Back to home page"
+
+        <RequestLinkForm initialEmail={legacyEmail} />
+
+        <div className="mt-10">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+              aria-label="Back to home page"
+            >
+              <span className="relative z-10 font-medium">Back to Home</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
+      </motion.div>
+    );
+  }
+
+  if (status === 'idle') {
+    // Explicit confirmation — no page-load mutation
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 60 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+        className="max-w-2xl mx-auto text-center w-full"
+      >
+        <div className="mb-12 lg:mb-16">
+          <motion.div
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
+            aria-hidden="true"
           >
-            <span className="relative z-10 font-medium">Back to Home</span>
-            <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
-          </Button>
-        </Link>
+            <AlertCircle className="w-10 lg:w-12 h-10 lg:h-12 text-emerald-400" />
+          </motion.div>
+          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+            Unsubscribe
+          </p>
+          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+            뉴스레터 구독을 취소하시겠습니까?
+          </p>
+        </div>
+
+        <Button
+          onClick={handleUnsubscribe}
+          className="group relative overflow-hidden bg-red-600 text-white hover:bg-red-500 rounded-lg px-10 py-6 lg:px-12 lg:py-7 font-semibold shadow-lg hover:shadow-xl transition-all duration-700 ease-out-expo focus:ring-2 focus:ring-red-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide cursor-pointer"
+          aria-label="구독 취소 확인"
+        >
+          <span className="relative z-10">구독 취소 확인</span>
+        </Button>
+
+        <div className="mt-6">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-8 py-4 transition-all duration-500 ease-out-expo tracking-wide"
+              aria-label="취소하고 홈으로"
+            >
+              <span className="relative z-10 font-medium">취소</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
       </motion.div>
     );
   }
@@ -108,6 +234,52 @@ function UnsubscribeContent() {
         <p className="text-2xl text-slate-300 font-light tracking-wide">
           구독 취소 요청을 처리하고 있습니다...
         </p>
+      </motion.div>
+    );
+  }
+
+  if (status === 'expired') {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 60 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+        className="max-w-2xl mx-auto text-center w-full"
+        role="alert"
+        aria-live="assertive"
+      >
+        <div className="mb-12 lg:mb-16">
+          <motion.div
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
+            aria-hidden="true"
+          >
+            <AlertCircle className="w-10 lg:w-12 h-10 lg:h-12 text-yellow-400" />
+          </motion.div>
+          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+            Link Expired
+          </p>
+          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+            구독 취소 링크가 만료되었습니다. 새 링크를 받아 진행해주세요.
+          </p>
+        </div>
+
+        <RequestLinkForm initialEmail={legacyEmail} />
+
+        <div className="mt-10">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+              aria-label="Back to home page"
+            >
+              <span className="relative z-10 font-medium">Back to Home</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
       </motion.div>
     );
   }
@@ -140,35 +312,11 @@ function UnsubscribeContent() {
           </p>
         </div>
 
-        {/* Info Card */}
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
-          className="glass-morphism rounded-3xl p-8 lg:p-10 border border-emerald-500/20 mb-8 lg:mb-10 text-center relative overflow-hidden"
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 via-transparent to-emerald-500/5 pointer-events-none" aria-hidden="true" />
-          <div className="relative z-10 space-y-6">
-            <div>
-              <div className="text-sm text-slate-300 mb-3 font-light tracking-wider">Email Address</div>
-              <div className="text-lg text-emerald-300/90 break-all font-light tracking-wide">{email}</div>
-            </div>
-            <div className="h-px bg-gradient-to-r from-transparent via-emerald-500/20 to-transparent" aria-hidden="true" />
-            <div>
-              <div className="text-sm text-slate-300 mb-3 font-light tracking-wider">Status</div>
-              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-lg glass-morphism border border-emerald-500/20">
-                <div className="w-2 h-2 rounded-lg bg-emerald-500/60 animate-[matrix-pulse_2s_ease-in-out_infinite]" aria-hidden="true" />
-                <span className="text-base text-emerald-300/90 font-light tracking-wide">Inactive</span>
-              </div>
-            </div>
-          </div>
-        </motion.div>
-
         {/* Notice */}
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.6, ease: [0.19, 1, 0.22, 1] }}
+          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
           className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-emerald-500/20 bg-emerald-500/5 mb-10 lg:mb-12 text-left"
           role="note"
         >
@@ -182,7 +330,7 @@ function UnsubscribeContent() {
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.8, ease: [0.19, 1, 0.22, 1] }}
+          transition={{ duration: 0.8, delay: 0.6, ease: [0.19, 1, 0.22, 1] }}
           className="flex flex-col sm:flex-row gap-4 justify-center"
         >
           <Link href="/" className="w-full sm:w-auto">
@@ -209,59 +357,56 @@ function UnsubscribeContent() {
     );
   }
 
-  if (status === 'error') {
-    return (
-      <motion.div
-        initial={{ opacity: 0, y: 60 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
-        className="max-w-2xl mx-auto text-center"
-      >
-        <div className="mb-12 lg:mb-16">
-          <motion.div
-            initial={{ scale: 0.8 }}
-            animate={{ scale: 1 }}
-            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
-            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
-            aria-hidden="true"
-          >
-            <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
-          </motion.div>
-          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
-            Error
-          </p>
-          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
-            구독 취소 처리 중 오류가 발생했습니다
-          </p>
-        </div>
-
+  // status === 'error'
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 60 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+      className="max-w-2xl mx-auto text-center"
+    >
+      <div className="mb-12 lg:mb-16">
         <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
-          className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-red-500/30 bg-red-500/5 mb-10 lg:mb-12 text-left"
+          initial={{ scale: 0.8 }}
+          animate={{ scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+          className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
+          aria-hidden="true"
         >
-          <AlertCircle className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" />
-          <p className="text-base text-red-100/80 font-light tracking-wide leading-relaxed">
-            시스템 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
-          </p>
+          <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
         </motion.div>
+        <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+          Error
+        </p>
+        <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+          구독 취소 처리 중 오류가 발생했습니다
+        </p>
+      </div>
 
-        <Link href="/">
-          <Button
-            variant="outline"
-            className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
-            aria-label="Back to home page"
-          >
-            <span className="relative z-10 font-medium">Back to Home</span>
-            <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
-          </Button>
-        </Link>
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
+        className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-red-500/30 bg-red-500/5 mb-10 lg:mb-12 text-left"
+      >
+        <AlertCircle className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" />
+        <p className="text-base text-red-100/80 font-light tracking-wide leading-relaxed">
+          시스템 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
       </motion.div>
-    );
-  }
 
-  return null;
+      <Link href="/">
+        <Button
+          variant="outline"
+          className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+          aria-label="Back to home page"
+        >
+          <span className="relative z-10 font-medium">Back to Home</span>
+          <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+        </Button>
+      </Link>
+    </motion.div>
+  );
 }
 
 export default function UnsubscribePage() {

--- a/docs/PR111_REVIEW_2026-07-31.md
+++ b/docs/PR111_REVIEW_2026-07-31.md
@@ -1,0 +1,202 @@
+# PR #111 프로덕션 레디 전수 리뷰 (2026-07-31)
+
+PR #111은 리뷰 없이 `main`에 squash merge되었다(`21c0866`, +12,245 / −2,358, 138 files).
+`main`은 `e69beae`로 revert했고, 변경분은 태스크별 PR로 분할해 다시 올린다.
+
+검증 기준선: `tsc --noEmit` 0 errors, `eslint` 0 errors(기존 warning 23), `vitest` 3553/3553 pass,
+`next build --turbopack` 성공. **원본 PR은 이 게이트를 모두 통과했다** — 아래 결함은 게이트가
+잡지 못하는 종류다.
+
+---
+
+## 분할 계획
+
+| PR | 범위 | 마이그레이션 |
+|---|---|---|
+| 1 | 보안 격리 (SEC-001/002/003/005) | 056b, 057 |
+| 2 | 뉴스레터 발송 상태머신 (COR-002/003/004/005) | 058, 059 |
+| 3 | TLI 데이터 정합성 (DATA-001/003, ARC-001, COR-001) | 061, 062 |
+| 4 | 조회 성능 (COR-016, PERF-004) | 063 |
+| 5 | UI/UX 회귀 (COR-017/018, ML-002/003, PERF-007) | — |
+| 보류 | **LLM/AI 파이프라인 + provenance** | 060 |
+
+**LLM 설정 변경은 전부 원복하고 별도 태스크로 분리한다.** `lib/llm/**`, `lib/market-data/**`,
+`app/blog/**`(gemini-client 경유 결합), `scripts/prepare-newsletter.ts`, 마이그레이션 060이
+여기 해당한다.
+
+---
+
+## Blocker
+
+### B-1. LLM 실행 예산이 잘못된 실행 환경 기준으로 산정됨
+
+`lib/llm/_config/pipeline-config.ts`
+
+원 지적(AI-003)은 "stage timeout 20분이 Vercel `maxDuration=300`과 불일치"였다. 적용된 수정은
+Vercel 기준 예산을 **전역**에 적용했다.
+
+| 항목 | 변경 전 | 변경 후 | 비율 |
+|---|---|---|---|
+| `STAGE_TIMEOUT` | 1,200,000ms (20분) | 45,000ms | 1/26 |
+| `GLOBAL_DEADLINE_MS` | — | 270,000ms (7 stage 전체) | 신규 |
+| `OUTER_MAX_RETRY` | 3 | 1 | |
+| `STAGE_MAX_RETRY` | 5 | 2 | |
+| `GLOBAL_MAX_CALLS` | — | 12 | 신규 |
+
+실제 프로덕션 뉴스레터 생성은 `scripts/prepare-newsletter.ts` → GitHub Actions
+(`prepare-newsletter.yml`, step `timeout-minutes: 55`)에서 실행된다. 270초 예산의 근거인
+Vercel 300초 제약은 `app/api/cron/send-recommendations/route.ts` 경로에만 적용된다.
+변경 전 주석은 20분 timeout이 "gemini + Google Search 포함 복잡한 분석에 충분한 시간"이라고
+명시하고 있었다.
+
+`LlmExecutionBudgetError`는 `executeStage`에서 재시도 없이 즉시 throw된다
+(`gemini-pipeline.ts`). 즉 deadline 도달 = 당일 뉴스레터 생성 전면 실패.
+
+### B-2. 모델·생성 파라미터가 문서화 없이 다운그레이드됨
+
+`lib/llm/_config/pipeline-config.ts`. PR 본문·리뷰 문서 어디에도 언급이 없고, 대응하는 finding도
+없다.
+
+| 항목 | 변경 전 | 변경 후 |
+|---|---|---|
+| `MODEL` | `gemini-3-flash-preview` | `gemini-2.5-flash` |
+| `MAX_OUTPUT_TOKENS` | 65,536 | 8,192 |
+| `TEMPERATURE` | 1.0 | 0.2 |
+| `TOP_P` / `TOP_K` | 0.95 / 64 | 0.9 / 40 |
+
+출력 토큰 8배 축소는 다단계 분석 출력이 `FinishReason.MAX_TOKENS`로 잘릴 위험이 있다.
+
+### B-3. 종목 claim 검증 실패가 당일 뉴스레터를 전면 중단시킴
+
+`lib/llm/korea/stock-claims-verifier.ts:79`
+
+```
+if (unique.size !== 1) throw new Error(`Stock identity is missing or conflicting for ${symbol}`)
+```
+
+추천 종목이 `theme_stocks`(`source='naver'`)에 없으면 throw한다. Gemini는 KOSPI/KOSDAQ 전체에서
+고르지만 `theme_stocks`는 네이버 테마 편입 종목만 담는다. `OUTER_MAX_RETRY: 1`이라 복구 경로도
+없다 → 당일 발송 실패.
+
+### B-4. 기 발송 뉴스레터의 구독취소 링크가 전부 무효화됨
+
+변경 전 `lib/sendgrid.ts`는 `/unsubscribe?email=<email>` 링크를 심었다. PR은 페이지·API 모두
+token 전용으로 바꿔 **이미 발송된 모든 메일의 구독취소 링크가 "Invalid Request"로 끝난다.**
+신규 토큰도 TTL 30일이라 그 이후 발송분도 동일해진다.
+
+정보통신망법 제50조(수신거부 조치) 위반 소지.
+
+→ **PR 1에서 수정함** (아래 F-1).
+
+---
+
+## High
+
+### H-1. 구독 재신청이 영구 불가
+
+`app/api/subscribe/route.ts` — `pending_subscribers` upsert가 `confirmed_at`을 초기화하지 않는다.
+확인 완료 → 구독취소 → 재신청 시 이전 `confirmed_at`이 남아 `confirm_subscription`이
+`already_confirmed`를 반환하고(057:169), 라우트는 **200 "이미 확인된 구독입니다"** 를 돌려준다.
+`subscribers.is_active`는 `false`인 채로 남아 사용자는 다시는 메일을 받지 못한다.
+
+→ **PR 1에서 수정함** (F-2).
+
+### H-2. `stock_price_cache`가 완전히 고아화됨
+
+- 056b가 테이블을 `TRUNCATE`
+- 클라이언트 캐시 접근 제거(정당한 SEC-005 수정)
+- **그러나 서버 쪽 대체 경로를 넣지 않음** — `getBatchPricesFromCache` / `saveBatchPricesToCache`
+  호출자 0개, `getBatchStockPrices`는 캐시를 참조하지 않음
+
+결과: 아카이브 조회마다 KIS 직접 호출(티커당 순차 + 100ms sleep), 방어는 CDN 60초뿐.
+런북의 "cache refill 이후 정상 동작"은 성립하지 않는다(채우는 주체가 없음).
+
+→ **PR 1에서 수정함** (F-3).
+
+### H-3. `/api/tli/compare` sparkline이 시간 역순으로 렌더됨
+
+`app/api/tli/compare/route.ts:86-93`. 변경 전 쿼리는 `.order('calculated_at', ascending: true)`
+였다. RPC `load_theme_score_windows`는 `ORDER BY calculated_at DESC`(063:113)로 반환하는데,
+compare 라우트는 그대로 push한다. `ranking-helpers.ts:198`은 같은 상황에서 `.reverse()`를
+호출하지만 compare에는 없다.
+
+→ PR 4에서 수정 예정.
+
+### H-4. 배포 설정 오류가 `ambiguous`로 오분류되어 발송이 영구 정지
+
+`lib/delivery/service.ts:536-552`. `sendSingleRecipient`는 네트워크 호출 **이전에**
+`initSendGrid()`(SENDGRID_* 누락 시 throw)와 unsubscribe 토큰 생성
+(`UNSUBSCRIBE_TOKEN_SECRET` 누락/32자 미만 시 throw)을 수행한다. 이 throw는 catch되어
+`ambiguous`로 기록되는데, `ambiguous`는 설계상 **자동 재시도되지 않는다**.
+
+즉 환경변수 하나 누락 = 전 수신자 `ambiguous` = 수동 DB 개입 없이는 복구 불가.
+"발송됐을 수도 있음"이 아니라 "확실히 발송 안 됨"이므로 분류 자체가 틀렸다.
+
+→ PR 2에서 수정 예정 (발송 시작 전 preflight 검증).
+
+### H-5. OG 배경 이미지 런타임 로드가 Vercel에서 실패할 수 있음
+
+`lib/og-template.tsx` — `readFileSync(join(process.cwd(), 'public', 'og-background-v1.png'))`.
+`next.config.ts`에 `outputFileTracingIncludes` 설정이 없다. `public/`은 CDN 서빙 대상이지
+서버리스 함수 번들에 자동 포함되지 않는다. PR 본문의 검증("로컬에서 확인")은 이 실패 모드를
+재현하지 못한다.
+
+→ PR 5에서 수정 예정.
+
+---
+
+## Medium
+
+| # | 항목 | 위치 |
+|---|---|---|
+| M-1 | `withRetry`가 `\b4\d{2}\b` 문자열 매칭으로 4xx 판정 → "Timeout after 450ms" 같은 메시지에서 재시도가 조용히 비활성화 | `scripts/tli/shared/utils.ts` |
+| M-2 | 056b의 비가드 REVOKE 3건(`clean_expired_stock_price_cache`, `v_prediction_v4_serving`, `increment_blog_view_count`) → 객체 부재 시 마이그레이션 전체 중단 (`insert_mcp_analytics`만 가드됨) | `056b` |
+| M-3 | `SCORE_QUERY_BATCH_SIZE`(=10) / `SCORE_QUERY_WINDOW_DAYS`(=14)가 export·테스트 단언은 유지되지만 호출부는 500/14를 하드코딩 → SSOT 붕괴, 테스트가 죽은 값을 검증 | `ranking-helpers.ts`, `ranking/route.ts`, `get-ranking-server.ts` |
+| M-4 | `resolveUnknownMarkets`가 첫 KIS 실패에서 throw → 테마 종목 수집 전체 중단. TLI 파이프라인에 KIS 경성 의존 + 종목당 100ms 직렬화 신규 도입 | `naver-finance-themes.ts` |
+| M-5 | `loadLatestPublishedComparisonRuns` 100개 초과 시 error 반환하나 호출부가 `if (!runsError && ...)`로 삼켜 pairwise similarity가 조용히 사라짐 | `compare/route.ts` |
+| M-6 | 신규 커스텀 Error 클래스 4종 — `conventions.md` anti-pattern #6(custom Error class 금지) 위반 | `execution-budget.ts`, `token-storage.ts`, `naver-finance-themes.ts` |
+| M-7 | rate limiter가 `x-real-ip`만 신뢰 + fail-closed → Vercel 외 경로(로컬/자체 호스팅/프록시)에서 `/api/stock/*`, `/api/subscribe`, `/api/unsubscribe` 전부 503 | `rate-limit.ts` |
+| M-8 | `lib/security/index.ts` barrel export — 소비자 0개 + anti-pattern #3 위반 | `lib/security/index.ts` |
+
+---
+
+## Low
+
+| # | 항목 |
+|---|---|
+| L-1 | `isValidTicker`의 `KOREAN_TICKER_PATTERN`은 `GENERAL_TICKER_PATTERN`에 포함됨 — 죽은 분기 |
+| L-2 | `/api/stock/price` 응답 `metadata` → `meta` 파괴적 개명 (외부 소비자는 확인되지 않음) |
+| L-3 | `security.test.ts` 헤더 주석이 실제보다 넓은 커버리지를 주장 (route 테스트·`vi.mock` 없음) |
+| L-4 | 발송 메일에 RFC 8058 `List-Unsubscribe` 헤더 없음 (기존 이슈) |
+
+---
+
+## 확인된 정상 사항
+
+원본 PR에서 다음은 검토 결과 문제없다.
+
+- 삭제 파일 5종(`types/newsletter.ts`, `crash-alert-to-image.ts`, `ui/badge.tsx`, `ui/card.tsx`,
+  `og-background.ts`) — 잔존 import 0건, 실제 사용되지 않던 코드
+- `snapshot_delivery_recipients`가 `s.is_active = true`로 필터 — 기존 구독자 회귀 없음
+- 마이그레이션 057의 rate limit / double opt-in RPC — 원자성·권한 경계 적절
+- 발송 상태머신의 terminal run 보호, snapshot 불변성, worker ID 검증
+- next.config.ts 보안 헤더 강화(HSTS, `object-src`, `base-uri`)
+- `lifecycle-score.tsx` 접근성 개선(`role`, `aria-label`, confidence 사유 노출)
+
+---
+
+## PR 1에서 적용한 수정
+
+- **F-1** (B-4): `/unsubscribe`에 이메일 입력 폴백 추가. 토큰이 없거나 만료·레거시 `?email=`
+  링크인 경우 새 토큰을 메일로 재발급한다. `POST /api/unsubscribe/request`는 구독 중인 주소일
+  때만 발송하고 응답은 항상 동일하다(열거 방지). 링크 요청 자체는 해지가 아니며 메일의 링크에서
+  명시적 확인을 거친다.
+- **F-2** (H-1): 구독 upsert에 `confirmed_at: null` 추가 — 재신청 시 이전 확인 상태 초기화.
+- **F-3** (H-2): `/api/stock/price`가 service_role로 캐시를 읽고 쓰도록 재연결. 미스 티커만 KIS로
+  넘기고, 응답에서 내부 필드 `expires_at`은 제거한다.
+- **F-4** (M-2): 056b의 REVOKE 3건을 존재 확인 가드로 감쌈.
+- **F-5** (M-8): `lib/security/index.ts` barrel 제외.
+- **F-6** (L-1): 라우트 인라인 중복 검증을 `lib/security/validators.ts`로 통합.
+
+회귀 테스트: `app/api/__tests__/subscription-lifecycle.test.ts`,
+`app/api/stock/__tests__/price-cache-wiring.test.ts`.

--- a/docs/deploy/01-security-containment.md
+++ b/docs/deploy/01-security-containment.md
@@ -1,0 +1,59 @@
+# 배포 런북 — PR 1: 보안 격리
+
+마이그레이션: `056b`, `057`. 앱 배포와 DB 적용을 하나의 변경 창으로 다룬다.
+
+## 1. 필수 설정
+
+배포 전에 모든 Vercel 환경과 뉴스레터 GitHub Actions 환경에 아래 값을 넣는다.
+**이 값들이 없으면 관련 라우트는 fail-closed로 503을 반환한다.**
+
+- `RATE_LIMIT_HMAC_SECRET` — 32자 이상 독립 난수
+- `UNSUBSCRIBE_TOKEN_SECRET` — 32자 이상 독립 난수 (AEAD 토큰 키)
+- `UNSUBSCRIBE_TOKEN_SECRET_PREV` — 회전 기간에만 사용. 구 토큰이 모두 만료된 뒤 제거
+- 기존 값: `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`,
+  `SENDGRID_API_KEY`, SendGrid 발신자 정보
+
+`CRON_SECRET`, Supabase 키, SendGrid 키를 신규 시크릿으로 재사용하지 않는다. 소유자와 회전
+일자는 Git이 아니라 프로덕션 시크릿 매니저에 기록한다.
+
+## 2. 사전 게이트
+
+1. 복구 가능한 DB 백업 확인 및 복구 지점 기록
+2. 클린 체크아웃에서 `tsc --noEmit`, `eslint .`, `vitest run`, `next build --turbopack` 통과
+3. Supabase CLI 마이그레이션 dry-run으로 생성 SQL 확인
+4. 적용 순서 확인: `056_drop_unused_indexes` (기존) → `056b` → `057`
+5. **KRX 장 시간 외로 일정 조정** — `056b`가 `stock_price_cache`를 `TRUNCATE`한다.
+   이후 첫 조회부터 `/api/stock/price`가 service_role로 캐시를 다시 채운다.
+
+## 3. 적용 순서
+
+1. 시크릿 주입 및 검증 (값이 로그에 남지 않도록 주의)
+2. 마이그레이션 적용. 첫 오류에서 즉시 중단하고 이후 파일을 수동으로 이어 적용하지 않는다.
+3. 검증된 커밋을 Vercel에 배포
+
+구 애플리케이션은 익명 캐시 쓰기에 의존하고, 신 애플리케이션은 rate-limit RPC가 없으면
+fail-closed다. DB 적용과 앱 승격 사이 간격을 최소화하고, 보안 권한을 되돌리는 대신 점검 창을
+사용한다.
+
+## 4. 스모크 체크
+
+- `/subscribe` 정상 렌더 및 `?confirm=<valid-test-token>` 플로우 동작. 확인은 명시적 POST
+- 신규 구독 → 확인 → 구독취소 → **재신청 → 재확인**이 끝까지 성공 (H-1 회귀 확인)
+- `/unsubscribe?token=<valid-test-token>` 렌더 및 명시적 확인 후에만 상태 변경
+- `/unsubscribe` (토큰 없음) 및 `/unsubscribe?email=<addr>` (레거시 링크)에서 이메일 입력 폼이
+  뜨고, 구독 중인 주소로 새 링크 메일이 도착
+- 미구독 주소로 링크 요청 시 메일이 가지 않으면서 응답 본문은 구독 중인 경우와 동일
+- 잘못된/없는 토큰은 이메일 주소나 토큰 값 노출 없이 일반 오류 반환
+- rate limit 초과 시 `429`, rate-limit 저장소/설정 부재 시 `503`
+- `/api/stock/price` 최초 호출이 KIS로 나가고, 동일 티커 재호출은 캐시에서 응답
+  (`stock_price_cache` 행 수 증가로 확인)
+- daily-close 라우트 정상 동작
+
+## 5. 롤백
+
+- 앱 스모크 체크 실패 시 직전 검증 배포로 롤백
+- **익명 캐시 쓰기를 되살리는 방식의 롤백은 하지 않는다.** 보안 경계를 유지한 채 service_role
+  설정을 진단한다.
+- 추가된 테이블/함수는 앱 롤백 시에도 남겨둘 수 있다(additive). 데이터 파괴나 스키마 실패에
+  대해서는 임시 역방향 SQL 대신 기록해 둔 복구 지점으로 복원한다.
+- 배포·마이그레이션 로그는 보존하되 이메일 주소와 토큰 값은 제외한다.

--- a/lib/security/__tests__/rate-limit-client-cache.test.ts
+++ b/lib/security/__tests__/rate-limit-client-cache.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, rpcMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  rpcMock: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock,
+}))
+
+const originalEnv = process.env
+
+beforeEach(() => {
+  vi.resetModules()
+  createClientMock.mockReset()
+  rpcMock.mockReset()
+  rpcMock.mockResolvedValue({
+    data: {
+      limited: false,
+      request_count: 1,
+      window_start: 1_800_000_000,
+      window_seconds: 60,
+    },
+    error: null,
+  })
+  createClientMock.mockReturnValue({ rpc: rpcMock })
+  process.env = {
+    ...originalEnv,
+    RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32),
+    NEXT_PUBLIC_SUPABASE_URL: 'https://rate-limit-test.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-key-v1',
+  }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('rate-limit Supabase client lifecycle', () => {
+  it('reuses a client while its URL and service key are unchanged', async () => {
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit')
+
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+    await checkRateLimit('203.0.113.11', RATE_LIMITS.subscribe)
+
+    expect(createClientMock).toHaveBeenCalledTimes(1)
+    expect(rpcMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a fresh client after service-key rotation', async () => {
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit')
+
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key-v2'
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+
+    expect(createClientMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/security/__tests__/security.test.ts
+++ b/lib/security/__tests__/security.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Behavioral security tests (mocked, deterministic).
+ *
+ * Replaces source-string assertions with direct utility/route tests:
+ * - Rate unavailable => 503
+ * - Atomic RPC shape
+ * - Subscribe send failure cleanup
+ * - Confirmation POST transaction
+ * - Unsubscribe no email body
+ * - Cron missing secret/service key
+ * - Cache server orchestration
+ * - Invalid Feb 30 / tickers
+ * - Token confidentiality/tamper/expiry/purpose
+ * - SSRF
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ================================================
+// 1. Rate limit unavailable => 503
+// ================================================
+
+describe('rate limit fail-closed behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns unavailable when HMAC secret is missing', async () => {
+    delete process.env.RATE_LIMIT_HMAC_SECRET;
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'hmac_secret_missing_or_short');
+  });
+
+  it('returns unavailable when HMAC secret is too short (<32)', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'short';
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+  });
+
+  it('returns unavailable when IP is null (no trusted x-real-ip)', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'a'.repeat(32);
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit(null, RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'no_trusted_ip');
+  });
+
+  it('returns unavailable when Supabase is not configured', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'a'.repeat(32);
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'supabase_not_configured');
+  });
+
+  it('getTrustedClientIp returns null for missing header', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: () => null };
+    expect(getTrustedClientIp(headers)).toBeNull();
+  });
+
+  it('getTrustedClientIp returns null for empty header', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: (name: string) => name === 'x-real-ip' ? '' : null };
+    expect(getTrustedClientIp(headers)).toBeNull();
+  });
+
+  it('getTrustedClientIp returns valid IP from x-real-ip', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: (name: string) => name === 'x-real-ip' ? '203.0.113.5' : null };
+    expect(getTrustedClientIp(headers)).toBe('203.0.113.5');
+  });
+
+  it('hashClientIp returns null when secret is not configured', async () => {
+    delete process.env.RATE_LIMIT_HMAC_SECRET;
+    const { hashClientIp } = await import('@/lib/security/rate-limit');
+    expect(hashClientIp('1.2.3.4', 'test')).toBeNull();
+  });
+
+  it('hashClientIp produces consistent, different hashes per bucket', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'x'.repeat(32);
+    const { hashClientIp } = await import('@/lib/security/rate-limit');
+    const h1 = hashClientIp('1.2.3.4', 'subscribe');
+    const h2 = hashClientIp('1.2.3.4', 'unsubscribe');
+    expect(h1).not.toBeNull();
+    expect(h2).not.toBeNull();
+    expect(h1).not.toBe(h2);
+    expect(hashClientIp('1.2.3.4', 'subscribe')).toBe(h1);
+  });
+});
+
+// ================================================
+// 2. Atomic RPC shape (check_rate_limit signature)
+// ================================================
+
+describe('rate limit RPC contract', () => {
+  it('RATE_LIMITS presets have valid ranges', async () => {
+    const { RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    for (const [, config] of Object.entries(RATE_LIMITS)) {
+      expect(config.maxRequests).toBeGreaterThanOrEqual(1);
+      expect(config.maxRequests).toBeLessThanOrEqual(10000);
+      expect(config.windowSeconds).toBeGreaterThanOrEqual(1);
+      expect(config.windowSeconds).toBeLessThanOrEqual(86400);
+      expect(config.bucket).toBeTruthy();
+    }
+  });
+});
+
+// ================================================
+// 3. Token confidentiality/tamper/expiry/purpose
+// ================================================
+
+describe('opaque token behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'test-secret-that-is-at-least-32-chars!';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('email is not visible in token (confidentiality)', async () => {
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    const email = 'user@example.com';
+    const token = encryptToken(email, 'unsubscribe', 3600);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(token, 'base64url').toString('utf8');
+    expect(decoded).not.toContain(email);
+  });
+
+  it('detects tampered ciphertext', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'unsubscribe', 3600);
+    const wire = Buffer.from(token, 'base64url');
+    wire[Math.floor(wire.length / 2)] ^= 0xff;
+    const result = decryptToken(wire.toString('base64url'), 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('tampered');
+  });
+
+  it('rejects expired token', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'unsubscribe', -1);
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('expired');
+  });
+
+  it('rejects cross-purpose token', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'confirm', 3600);
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('tampered');
+  });
+
+  it('fail-closed: encrypt throws without secret', async () => {
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    expect(() => encryptToken('x@y.com', 'unsubscribe', 3600)).toThrow();
+  });
+
+  it('fail-closed: encrypt throws with short secret', async () => {
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'short';
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    expect(() => encryptToken('x@y.com', 'unsubscribe', 3600)).toThrow();
+  });
+
+  it('decrypt returns no_secret without valid secret', async () => {
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV;
+    const { decryptToken } = await import('@/lib/security/opaque-token');
+    // A plausible-looking token (right length) but no key to decrypt
+    const fakeWire = Buffer.alloc(1 + 12 + 16 + 16, 0x42);
+    fakeWire[0] = 0x01;
+    const result = decryptToken(fakeWire.toString('base64url'), 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('no_secret');
+  });
+
+  it('roundtrips successfully', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const email = 'test@example.com';
+    const token = encryptToken(email, 'confirm', 3600);
+    const result = decryptToken(token, 'confirm');
+    expect(result.valid).toBe(true);
+    expect(result.payload?.email).toBe(email);
+    expect(result.payload?.purpose).toBe('confirm');
+  });
+
+  it('supports key rotation', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('rotate@example.com', 'unsubscribe', 3600);
+    // Rotate
+    process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV = process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'new-rotated-secret-at-least-32-chars!!!';
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(true);
+    expect(result.payload?.email).toBe('rotate@example.com');
+  });
+});
+
+// ================================================
+// 4. Cron missing secret / service key
+// ================================================
+
+describe('cron auth fail-closed', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('rejects when CRON_SECRET is unset', async () => {
+    delete process.env.CRON_SECRET;
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer any')).toBe(false);
+  });
+
+  it('rejects when CRON_SECRET is empty', async () => {
+    process.env.CRON_SECRET = '';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer any')).toBe(false);
+  });
+
+  it('rejects wrong token', async () => {
+    process.env.CRON_SECRET = 'correct-secret';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer wrong')).toBe(false);
+  });
+
+  it('accepts correct token', async () => {
+    process.env.CRON_SECRET = 'test-secret-123';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer test-secret-123')).toBe(true);
+  });
+
+  it('rejects null auth header', async () => {
+    process.env.CRON_SECRET = 'test';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret(null)).toBe(false);
+  });
+});
+
+// ================================================
+// 5. Ticker/date validation (pure validators)
+// ================================================
+
+describe('ticker validation', () => {
+  it('accepts valid Korean 6-digit ticker', async () => {
+    const { isValidTicker } = await import('@/lib/security/validators');
+    expect(isValidTicker('005930')).toBe(true);
+    expect(isValidTicker('035720')).toBe(true);
+  });
+
+  it('rejects invalid tickers', async () => {
+    const { isValidTicker } = await import('@/lib/security/validators');
+    expect(isValidTicker('')).toBe(false);
+    expect(isValidTicker('0059301')).toBe(true); // 7 digits valid under general pattern
+    expect(isValidTicker('abc')).toBe(true); // valid general
+    expect(isValidTicker('abc!def')).toBe(false); // special chars
+    expect(isValidTicker('12345678901')).toBe(false); // >10 chars
+  });
+
+  it('validates exchange:ticker format', async () => {
+    const { isValidExchangeTicker } = await import('@/lib/security/validators');
+    expect(isValidExchangeTicker('KOSPI:005930')).toBe(true);
+    expect(isValidExchangeTicker('KOSDAQ:035720')).toBe(true);
+    expect(isValidExchangeTicker('005930')).toBe(false); // no exchange
+    expect(isValidExchangeTicker('kospi:005930')).toBe(false); // lowercase exchange
+  });
+});
+
+describe('date validation (real calendar)', () => {
+  it('rejects Feb 30', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240230')).toBe(false);
+  });
+
+  it('rejects Feb 29 in non-leap year', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20230229')).toBe(false);
+  });
+
+  it('accepts Feb 29 in leap year', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240229')).toBe(true);
+  });
+
+  it('rejects Apr 31', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240431')).toBe(false);
+  });
+
+  it('accepts valid dates', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240101')).toBe(true);
+    expect(isValidCalendarDate('20241231')).toBe(true);
+  });
+
+  it('rejects malformed dates', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('2024-01-01')).toBe(false);
+    expect(isValidCalendarDate('abc')).toBe(false);
+    expect(isValidCalendarDate('20241301')).toBe(false); // month 13
+    expect(isValidCalendarDate('20190101')).toBe(false); // before 2020
+  });
+
+  it('isLeapYear correctly identifies leap years', async () => {
+    const { isLeapYear } = await import('@/lib/security/validators');
+    expect(isLeapYear(2024)).toBe(true);
+    expect(isLeapYear(2023)).toBe(false);
+    expect(isLeapYear(2100)).toBe(false);
+    expect(isLeapYear(2000)).toBe(true);
+  });
+});
+
+// ================================================
+// 6. SSRF protection
+// ================================================
+
+describe('SSRF URL validation', () => {
+  it('rejects private IPv4', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://192.168.1.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects 10.x.x.x', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://10.0.0.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects 127.0.0.1', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://127.0.0.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects IPv6 loopback [::1]', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('::1')).toBe(true);
+    expect(isPrivateOrReservedIp('[::1]')).toBe(true);
+  });
+
+  it('rejects IPv6 multicast (ff02::1)', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('ff02::1')).toBe(true);
+  });
+
+  it('rejects IPv6 documentation range (2001:db8::)', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('2001:db8::1')).toBe(true);
+  });
+
+  it('rejects IPv4-mapped IPv6', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateOrReservedIp('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('rejects credentials in URL', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('https://user:pass@example.com/', { checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects file:// scheme', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('file:///etc/passwd');
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects ftp:// scheme by default', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('ftp://example.com/', { checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects cloud metadata endpoint', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://169.254.169.254/latest/', {
+      allowedSchemes: ['http', 'https'],
+      checkDns: false,
+    });
+    expect(result.safe).toBe(false);
+  });
+
+  it('validates redirect hops with SSRF check', async () => {
+    const { validateRedirectHop } = await import('@/lib/security/url-validation');
+    const result = await validateRedirectHop('http://10.0.0.1/admin', 'https://public.com', 1, 5);
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects too many redirect hops', async () => {
+    const { validateRedirectHop } = await import('@/lib/security/url-validation');
+    const result = await validateRedirectHop('https://example.com', 'https://other.com', 4, 3);
+    expect(result.safe).toBe(false);
+  });
+
+  it('allows safe public URLs', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('https://www.google.com/', { checkDns: false });
+    expect(result.safe).toBe(true);
+  });
+});
+
+// ================================================
+// 7. Unsubscribe: no email in response body (behavior check)
+// ================================================
+
+describe('unsubscribe security', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'test-secret-at-least-32-characters!!';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('validateUnsubscribeToken does not expose email on failure', async () => {
+    const { validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth');
+    const result = validateUnsubscribeToken('invalid-token');
+    expect(result.valid).toBe(false);
+    expect(result.email).toBeUndefined();
+  });
+
+  it('unsubscribe token validates correctly', async () => {
+    const { generateUnsubscribeToken, validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth');
+    const token = generateUnsubscribeToken('test@example.com');
+    const result = validateUnsubscribeToken(token);
+    expect(result.valid).toBe(true);
+    expect(result.email).toBe('test@example.com');
+  });
+});

--- a/lib/security/opaque-token.ts
+++ b/lib/security/opaque-token.ts
@@ -1,0 +1,162 @@
+/**
+ * Opaque authenticated-encryption tokens (AES-256-GCM).
+ *
+ * Properties:
+ * - Email is encrypted inside ciphertext; never exposed in URL.
+ * - Purpose-bound (unsubscribe, confirm, etc.) inside AAD.
+ * - Expiry is bound inside ciphertext.
+ * - Random 12-byte nonce prevents reuse attacks.
+ * - Key rotation: supports UNSUBSCRIBE_TOKEN_SECRET and UNSUBSCRIBE_TOKEN_SECRET_PREV.
+ * - Secret must be >= 32 characters (enforced on both encrypt and decrypt).
+ *
+ * Token wire format (base64url):
+ *   <keyId:1><nonce:12><ciphertext+tag:variable>
+ *
+ * Plaintext layout (JSON):
+ *   { "e": email, "exp": epochSec, "p": purpose }
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
+
+export type TokenPurpose = 'unsubscribe' | 'confirm';
+
+export interface TokenPayload {
+  email: string;
+  purpose: TokenPurpose;
+}
+
+export interface TokenDecryptResult {
+  valid: boolean;
+  payload?: TokenPayload;
+  error?: 'expired' | 'tampered' | 'malformed' | 'no_secret';
+}
+
+const ALGORITHM = 'aes-256-gcm';
+const NONCE_LEN = 12;
+const TAG_LEN = 16;
+const KEY_ID_LEN = 1;
+const MIN_SECRET_LENGTH = 32;
+
+// Key IDs: 0x01 = current, 0x02 = previous (for rotation)
+const KEY_ID_CURRENT = 0x01;
+const KEY_ID_PREV = 0x02;
+
+function deriveKey(secret: string): Buffer {
+  return createHash('sha256').update(secret).digest();
+}
+
+function getKeys(): { current?: Buffer; prev?: Buffer } {
+  const currentSecret = process.env.UNSUBSCRIBE_TOKEN_SECRET;
+  const prevSecret = process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV;
+
+  return {
+    current: currentSecret && currentSecret.length >= MIN_SECRET_LENGTH
+      ? deriveKey(currentSecret)
+      : undefined,
+    prev: prevSecret && prevSecret.length >= MIN_SECRET_LENGTH
+      ? deriveKey(prevSecret)
+      : undefined,
+  };
+}
+
+/**
+ * Encrypt a token payload.
+ * Throws if UNSUBSCRIBE_TOKEN_SECRET is not configured or < 32 chars (fail-closed).
+ */
+export function encryptToken(email: string, purpose: TokenPurpose, ttlSeconds: number): string {
+  const { current } = getKeys();
+  if (!current) {
+    throw new Error('UNSUBSCRIBE_TOKEN_SECRET must be configured (>=32 chars) for token generation');
+  }
+
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const plaintext = Buffer.from(JSON.stringify({ e: email, exp, p: purpose }), 'utf8');
+
+  const nonce = randomBytes(NONCE_LEN);
+  const aad = Buffer.from(purpose, 'utf8');
+
+  const cipher = createCipheriv(ALGORITHM, current, nonce, { authTagLength: TAG_LEN });
+  cipher.setAAD(aad);
+
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const wire = Buffer.concat([Buffer.from([KEY_ID_CURRENT]), nonce, encrypted, tag]);
+  return wire.toString('base64url');
+}
+
+/**
+ * Decrypt and validate a token.
+ * Fail-closed: returns error if no valid secret is configured (>=32 chars).
+ */
+export function decryptToken(token: string, expectedPurpose: TokenPurpose): TokenDecryptResult {
+  if (!token || typeof token !== 'string') {
+    return { valid: false, error: 'malformed' };
+  }
+
+  let wire: Buffer;
+  try {
+    wire = Buffer.from(token, 'base64url');
+  } catch {
+    return { valid: false, error: 'malformed' };
+  }
+
+  if (wire.length < KEY_ID_LEN + NONCE_LEN + TAG_LEN + 1) {
+    return { valid: false, error: 'malformed' };
+  }
+
+  const keyId = wire[0];
+  const nonce = wire.subarray(KEY_ID_LEN, KEY_ID_LEN + NONCE_LEN);
+  const ciphertextAndTag = wire.subarray(KEY_ID_LEN + NONCE_LEN);
+  const ciphertext = ciphertextAndTag.subarray(0, ciphertextAndTag.length - TAG_LEN);
+  const tag = ciphertextAndTag.subarray(ciphertextAndTag.length - TAG_LEN);
+
+  const { current, prev } = getKeys();
+
+  // Determine which key(s) to try
+  const keysToTry: Buffer[] = [];
+  if (keyId === KEY_ID_CURRENT && current) keysToTry.push(current);
+  else if (keyId === KEY_ID_PREV && prev) keysToTry.push(prev);
+  // Also try both for robustness during rotation
+  if (current && !keysToTry.includes(current)) keysToTry.push(current);
+  if (prev && !keysToTry.includes(prev)) keysToTry.push(prev);
+
+  if (keysToTry.length === 0) {
+    return { valid: false, error: 'no_secret' };
+  }
+
+  const aad = Buffer.from(expectedPurpose, 'utf8');
+
+  for (const key of keysToTry) {
+    try {
+      const decipher = createDecipheriv(ALGORITHM, key, nonce, { authTagLength: TAG_LEN });
+      decipher.setAAD(aad);
+      decipher.setAuthTag(tag);
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+      let payload: { e?: string; exp?: number; p?: string };
+      try {
+        payload = JSON.parse(decrypted.toString('utf8'));
+      } catch {
+        continue;
+      }
+
+      if (!payload.e || !payload.exp || payload.p !== expectedPurpose) {
+        return { valid: false, error: 'tampered' };
+      }
+
+      if (Math.floor(Date.now() / 1000) > payload.exp) {
+        return { valid: false, error: 'expired' };
+      }
+
+      return {
+        valid: true,
+        payload: { email: payload.e, purpose: expectedPurpose },
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return { valid: false, error: 'tampered' };
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -1,0 +1,167 @@
+/**
+ * Distributed rate limiter backed by Supabase (PostgreSQL).
+ *
+ * Design:
+ * - Atomic fixed-window counter via INSERT ... ON CONFLICT DO UPDATE ... RETURNING.
+ * - IP identifier is HMAC(server-secret, trusted_platform_ip) — never stores raw IP.
+ * - Trusts only `x-real-ip` (set by Vercel edge, not caller-supplied).
+ * - FAIL-CLOSED: returns unavailable when configuration/store/RPC fails.
+ * - Requires RATE_LIMIT_HMAC_SECRET (minimum 32 characters).
+ * - Resolves env per call (no module-load constants).
+ */
+
+import { createHmac } from 'crypto';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface RateLimitConfig {
+  /** Identifier scope/bucket (e.g. 'subscribe', 'stock_price') */
+  bucket: string;
+  /** Maximum requests in the window */
+  maxRequests: number;
+  /** Window size in seconds */
+  windowSeconds: number;
+}
+
+export type RateLimitResult =
+  | { status: 'allowed'; remaining: number; resetAt: number }
+  | { status: 'limited'; remaining: 0; resetAt: number }
+  | { status: 'unavailable'; reason: string };
+
+// ─── Configuration (resolved per call) ───
+
+function getHmacSecret(): string | null {
+  const secret = process.env.RATE_LIMIT_HMAC_SECRET;
+  if (!secret || secret.length < 32) return null;
+  return secret;
+}
+
+interface ServiceClientCache {
+  url: string;
+  key: string;
+  client: SupabaseClient;
+}
+
+let serviceClientCache: ServiceClientCache | null = null;
+
+function getServiceClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+
+  if (serviceClientCache?.url === url && serviceClientCache.key === key) {
+    return serviceClientCache.client;
+  }
+
+  const client = createClient(url, key, { auth: { persistSession: false } });
+  serviceClientCache = { url, key, client };
+  return client;
+}
+
+/**
+ * Hash the client IP with server-side HMAC.
+ * Returns null if HMAC secret is not configured (fail-closed signal).
+ */
+export function hashClientIp(ip: string, bucket: string): string | null {
+  const secret = getHmacSecret();
+  if (!secret) return null;
+  return createHmac('sha256', secret)
+    .update(`${bucket}:${ip}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/**
+ * Extract the trusted client IP from the request.
+ * Only trusts `x-real-ip` which is set by Vercel's edge infrastructure.
+ * Returns null if the header is missing or not a syntactically valid IP.
+ */
+export function getTrustedClientIp(headers: { get(name: string): string | null }): string | null {
+  const ip = headers.get('x-real-ip');
+  if (!ip) return null;
+  // Basic syntax check: IPv4 or IPv6 (including brackets)
+  const trimmed = ip.trim();
+  if (trimmed.length === 0 || trimmed.length > 45) return null;
+  // Must look like an IP (digits/dots/colons/brackets)
+  if (!/^[\d.:a-fA-F[\]]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Check rate limit against the distributed atomic counter.
+ *
+ * FAIL-CLOSED: returns { status: 'unavailable' } when:
+ * - RATE_LIMIT_HMAC_SECRET is missing or < 32 chars
+ * - Supabase URL/service key is missing
+ * - Trusted IP is missing
+ * - RPC call fails
+ */
+export async function checkRateLimit(
+  ip: string | null,
+  config: RateLimitConfig
+): Promise<RateLimitResult> {
+  // Fail-closed: require trusted IP
+  if (!ip) {
+    return { status: 'unavailable', reason: 'no_trusted_ip' };
+  }
+
+  // Fail-closed: require HMAC secret
+  const ipHash = hashClientIp(ip, config.bucket);
+  if (!ipHash) {
+    return { status: 'unavailable', reason: 'hmac_secret_missing_or_short' };
+  }
+
+  // Fail-closed: require Supabase
+  const client = getServiceClient();
+  if (!client) {
+    return { status: 'unavailable', reason: 'supabase_not_configured' };
+  }
+
+  try {
+    const { data, error } = await client.rpc('check_rate_limit', {
+      p_identity_hash: ipHash,
+      p_bucket: config.bucket,
+      p_max_requests: config.maxRequests,
+      p_window_seconds: config.windowSeconds,
+    });
+
+    if (error) {
+      console.error('[rate-limit] RPC error (fail-closed):', error.message);
+      return { status: 'unavailable', reason: 'rpc_error' };
+    }
+
+    const result = data as {
+      limited: boolean;
+      request_count: number;
+      window_start: number;
+      window_seconds: number;
+    } | null;
+
+    if (!result) {
+      return { status: 'unavailable', reason: 'rpc_null_response' };
+    }
+
+    const resetAt = result.window_start + result.window_seconds;
+
+    if (result.limited) {
+      return { status: 'limited', remaining: 0, resetAt };
+    }
+    return {
+      status: 'allowed',
+      remaining: Math.max(0, config.maxRequests - result.request_count),
+      resetAt,
+    };
+  } catch (err) {
+    console.error('[rate-limit] unexpected error (fail-closed):', err instanceof Error ? err.message : 'unknown');
+    return { status: 'unavailable', reason: 'exception' };
+  }
+}
+
+// ─── Preset configurations ───
+
+export const RATE_LIMITS = {
+  subscribe: { bucket: 'subscribe', maxRequests: 5, windowSeconds: 60 } as RateLimitConfig,
+  unsubscribe: { bucket: 'unsubscribe', maxRequests: 10, windowSeconds: 60 } as RateLimitConfig,
+  stockPrice: { bucket: 'stock_price', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
+  dailyClose: { bucket: 'daily_close', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
+  newsletter: { bucket: 'newsletter', maxRequests: 2, windowSeconds: 3600 } as RateLimitConfig,
+} as const;

--- a/lib/security/timing-safe-auth.ts
+++ b/lib/security/timing-safe-auth.ts
@@ -1,0 +1,87 @@
+/**
+ * Timing-safe authentication utilities.
+ * Prevents timing side-channels by using constant-time comparison.
+ *
+ * Token operations delegate to AEAD opaque-token module.
+ * No legacy HMAC token code.
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { encryptToken, decryptToken, type TokenDecryptResult } from './opaque-token';
+
+/**
+ * Constant-time comparison of two strings.
+ * Returns false if either value is empty/undefined.
+ */
+export function timingSafeCompare(a: string | undefined | null, b: string | undefined | null): boolean {
+  if (!a || !b) return false;
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Validate a Bearer token against the expected CRON_SECRET.
+ * Fail-closed: returns false if CRON_SECRET is unset or empty.
+ */
+export function validateCronSecret(authHeader: string | null): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    return false;
+  }
+  if (!authHeader) return false;
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  return timingSafeCompare(token, secret);
+}
+
+// --- Opaque token wrappers (AEAD, no email in URL) ---
+
+/**
+ * Generate an opaque unsubscribe token for a given email.
+ * Throws if UNSUBSCRIBE_TOKEN_SECRET is not configured (>=32 chars, fail-closed).
+ * Default TTL: 30 days.
+ */
+export function generateUnsubscribeToken(email: string, ttlSeconds = 30 * 24 * 60 * 60): string {
+  return encryptToken(email, 'unsubscribe', ttlSeconds);
+}
+
+/**
+ * Generate an opaque confirmation token for double opt-in.
+ * Default TTL: 24 hours.
+ */
+export function generateConfirmToken(email: string, ttlSeconds = 24 * 60 * 60): string {
+  return encryptToken(email, 'confirm', ttlSeconds);
+}
+
+export interface TokenValidationResult {
+  valid: boolean;
+  email?: string;
+  error?: 'expired' | 'tampered' | 'malformed' | 'no_secret';
+}
+
+/**
+ * Validate and decode an unsubscribe token.
+ */
+export function validateUnsubscribeToken(token: string): TokenValidationResult {
+  const result = decryptToken(token, 'unsubscribe');
+  return mapResult(result);
+}
+
+/**
+ * Validate and decode a confirmation token.
+ */
+export function validateConfirmToken(token: string): TokenValidationResult {
+  const result = decryptToken(token, 'confirm');
+  return mapResult(result);
+}
+
+function mapResult(result: TokenDecryptResult): TokenValidationResult {
+  if (result.valid && result.payload) {
+    return { valid: true, email: result.payload.email };
+  }
+  return { valid: false, error: result.error };
+}

--- a/lib/security/url-validation.ts
+++ b/lib/security/url-validation.ts
@@ -1,0 +1,207 @@
+/**
+ * SSRF-safe URL validation.
+ *
+ * Validates a URL against:
+ * - Allowed schemes (http/https only)
+ * - No embedded credentials
+ * - No localhost, private, link-local, or reserved IP ranges
+ * - DNS resolution check (resolved IPs must not be private)
+ * - Redirect-hop validation (configurable max hops)
+ */
+
+import { lookup } from 'dns/promises';
+import { isIPv4 } from 'net';
+
+export interface UrlValidationOptions {
+  /** Allowed schemes. Default: ['https'] */
+  allowedSchemes?: string[];
+  /** Max redirect hops to follow for validation. Default: 3 */
+  maxRedirects?: number;
+  /** Whether to perform DNS resolution check. Default: true */
+  checkDns?: boolean;
+  /** Additional blocked hostnames. Default: [] */
+  blockedHostnames?: string[];
+}
+
+export interface UrlValidationResult {
+  safe: boolean;
+  reason?: string;
+}
+
+const PRIVATE_RANGES_V4: Array<{ prefix: number; mask: number }> = [
+  { prefix: 0x0A000000, mask: 0xFF000000 }, // 10.0.0.0/8
+  { prefix: 0xAC100000, mask: 0xFFF00000 }, // 172.16.0.0/12
+  { prefix: 0xC0A80000, mask: 0xFFFF0000 }, // 192.168.0.0/16
+  { prefix: 0x7F000000, mask: 0xFF000000 }, // 127.0.0.0/8
+  { prefix: 0xA9FE0000, mask: 0xFFFF0000 }, // 169.254.0.0/16 (link-local)
+  { prefix: 0x00000000, mask: 0xFF000000 }, // 0.0.0.0/8
+  { prefix: 0xC0000000, mask: 0xFFFFFFF8 }, // 192.0.0.0/29 (IANA special)
+  { prefix: 0xC0000200, mask: 0xFFFFFF00 }, // 192.0.2.0/24 (TEST-NET-1)
+  { prefix: 0xC6336400, mask: 0xFFFFFF00 }, // 198.51.100.0/24 (TEST-NET-2)
+  { prefix: 0xCB007100, mask: 0xFFFFFF00 }, // 203.0.113.0/24 (TEST-NET-3)
+  { prefix: 0xE0000000, mask: 0xF0000000 }, // 224.0.0.0/4 (multicast)
+  { prefix: 0xF0000000, mask: 0xF0000000 }, // 240.0.0.0/4 (reserved)
+  { prefix: 0xFFFFFFFF, mask: 0xFFFFFFFF }, // 255.255.255.255 (broadcast)
+  { prefix: 0xC6120000, mask: 0xFFFE0000 }, // 198.18.0.0/15 (benchmark)
+];
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split('.');
+  return (
+    ((parseInt(parts[0]) << 24) |
+      (parseInt(parts[1]) << 16) |
+      (parseInt(parts[2]) << 8) |
+      parseInt(parts[3])) >>>
+    0
+  );
+}
+
+export function isPrivateOrReservedIp(ip: string): boolean {
+  // Strip brackets for IPv6 (e.g. [::1])
+  const cleaned = ip.startsWith('[') && ip.endsWith(']') ? ip.slice(1, -1) : ip;
+
+  if (!isIPv4(cleaned)) {
+    // IPv6 checks
+    const lower = cleaned.toLowerCase();
+    if (
+      lower === '::1' ||                     // loopback
+      lower === '::' ||                      // unspecified
+      lower.startsWith('fe80:') ||           // link-local
+      lower.startsWith('fc') ||              // unique-local fc00::/7
+      lower.startsWith('fd') ||              // unique-local fd00::/8
+      lower.startsWith('ff') ||              // multicast ff00::/8
+      lower.startsWith('100:') ||            // discard 100::/64
+      lower.startsWith('2001:db8:') ||       // documentation 2001:db8::/32
+      lower.startsWith('::ffff:')            // IPv4-mapped
+    ) {
+      // For IPv4-mapped, check the mapped address
+      if (lower.startsWith('::ffff:')) {
+        const v4Part = lower.slice(7);
+        if (isIPv4(v4Part)) {
+          return isPrivateOrReservedIp(v4Part);
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  const ipInt = ipv4ToInt(cleaned);
+  return PRIVATE_RANGES_V4.some(({ prefix, mask }) => ((ipInt & mask) >>> 0) === (prefix >>> 0));
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'metadata.google.internal',
+  'metadata',
+  '169.254.169.254', // cloud metadata
+]);
+
+/**
+ * Validate a URL for SSRF safety.
+ * Call before making any outbound request.
+ */
+export async function validateUrlSafety(
+  rawUrl: string,
+  options: UrlValidationOptions = {}
+): Promise<UrlValidationResult> {
+  const {
+    allowedSchemes = ['https'],
+    checkDns = true,
+    blockedHostnames = [],
+  } = options;
+
+  // Parse URL
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { safe: false, reason: 'Invalid URL format' };
+  }
+
+  // Scheme check
+  const scheme = parsed.protocol.replace(':', '');
+  if (!allowedSchemes.includes(scheme)) {
+    return { safe: false, reason: `Scheme '${scheme}' not allowed. Allowed: ${allowedSchemes.join(', ')}` };
+  }
+
+  // Credentials check
+  if (parsed.username || parsed.password) {
+    return { safe: false, reason: 'URLs with embedded credentials are not allowed' };
+  }
+
+  // Hostname checks
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (!hostname || hostname.length === 0) {
+    return { safe: false, reason: 'Empty hostname' };
+  }
+
+  const allBlocked = new Set([...BLOCKED_HOSTNAMES, ...blockedHostnames.map((h) => h.toLowerCase())]);
+  if (allBlocked.has(hostname)) {
+    return { safe: false, reason: `Hostname '${hostname}' is blocked` };
+  }
+
+  // Check if hostname is a raw IP (including bracketed IPv6)
+  const rawHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+
+  if (isIPv4(rawHostname) || rawHostname.includes(':')) {
+    if (isPrivateOrReservedIp(rawHostname)) {
+      return { safe: false, reason: `IP address '${hostname}' is private/reserved` };
+    }
+  }
+
+  // DNS resolution check
+  if (checkDns && !isIPv4(hostname)) {
+    try {
+      const addresses = await lookup(hostname, { all: true });
+      for (const addr of Array.isArray(addresses) ? addresses : [addresses]) {
+        const ip = typeof addr === 'string' ? addr : addr.address;
+        if (isPrivateOrReservedIp(ip)) {
+          return {
+            safe: false,
+            reason: `Hostname '${hostname}' resolves to private/reserved IP '${ip}'`,
+          };
+        }
+      }
+    } catch (err) {
+      return {
+        safe: false,
+        reason: `DNS resolution failed for '${hostname}': ${err instanceof Error ? err.message : 'unknown error'}`,
+      };
+    }
+  }
+
+  return { safe: true };
+}
+
+/**
+ * Validate redirect targets during a multi-hop fetch.
+ * Call this for each redirect location before following it.
+ */
+export async function validateRedirectHop(
+  location: string,
+  baseUrl: string,
+  hopNumber: number,
+  maxRedirects: number = 3
+): Promise<UrlValidationResult> {
+  if (hopNumber > maxRedirects) {
+    return { safe: false, reason: `Exceeded maximum redirect hops (${maxRedirects})` };
+  }
+
+  // Resolve relative redirects against the base
+  let absoluteUrl: string;
+  try {
+    absoluteUrl = new URL(location, baseUrl).toString();
+  } catch {
+    return { safe: false, reason: 'Invalid redirect location' };
+  }
+
+  return validateUrlSafety(absoluteUrl, {
+    allowedSchemes: ['http', 'https'],
+    checkDns: true,
+  });
+}

--- a/lib/security/validators.ts
+++ b/lib/security/validators.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure validators for tickers and dates.
+ * Deterministic, no side-effects — suitable for direct unit testing.
+ */
+
+/** Korean stock ticker: exactly 6 digits */
+export const KOREAN_TICKER_PATTERN = /^[0-9]{6}$/;
+
+/** General ticker: 1-10 alphanumeric characters */
+export const GENERAL_TICKER_PATTERN = /^[A-Za-z0-9]{1,10}$/;
+
+/** Exchange-prefixed ticker: EXCHANGE:TICKER */
+export const TICKER_WITH_EXCHANGE_PATTERN = /^[A-Z]{2,10}:[0-9A-Za-z]{1,10}$/;
+
+/** Date pattern: YYYYMMDD */
+export const DATE_PATTERN = /^\d{8}$/;
+
+/** Days in each month (non-leap year, 0-indexed) */
+export const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] as const;
+
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Validate a ticker string.
+ * Accepts Korean 6-digit or general alphanumeric up to 10 chars.
+ */
+export function isValidTicker(ticker: string): boolean {
+  return KOREAN_TICKER_PATTERN.test(ticker) || GENERAL_TICKER_PATTERN.test(ticker);
+}
+
+/**
+ * Validate a ticker with exchange prefix (e.g. KOSPI:005930).
+ */
+export function isValidExchangeTicker(ticker: string): boolean {
+  return TICKER_WITH_EXCHANGE_PATTERN.test(ticker);
+}
+
+/**
+ * Validate a date string as a real calendar date.
+ * Rejects Feb 30, Apr 31, etc.
+ * Range: 2020-01-01 to 2100-12-31.
+ */
+export function isValidCalendarDate(dateStr: string): boolean {
+  if (!DATE_PATTERN.test(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  if (year < 2020 || year > 2100) return false;
+  if (month < 1 || month > 12) return false;
+
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  if (day < 1 || day > maxDay) return false;
+
+  return true;
+}
+
+/**
+ * Validate a date is not in the far future (tomorrow at most).
+ */
+export function isDateNotFuture(dateStr: string): boolean {
+  if (!isValidCalendarDate(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(23, 59, 59, 999);
+  const inputDate = new Date(year, month - 1, day);
+  return inputDate <= tomorrow;
+}
+
+/** Maximum tickers allowed per request */
+export const MAX_TICKERS_PER_REQUEST = 10;

--- a/lib/sendgrid.ts
+++ b/lib/sendgrid.ts
@@ -1,4 +1,14 @@
 import sgMail from '@sendgrid/mail';
+import { generateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+
+/**
+ * Generate opaque unsubscribe token for a given email.
+ * Fail-closed: throws if UNSUBSCRIBE_TOKEN_SECRET is not configured.
+ * Caller must ensure the secret is set before sending mail.
+ */
+function generateUnsubscribeTokenForEmail(email: string): string {
+  return generateUnsubscribeToken(email);
+}
 
 /**
  * HTML 특수문자 이스케이프 (LLM 출력 삽입 시 XSS 방지)
@@ -10,6 +20,111 @@ function escapeHtml(str: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+/**
+ * Send double opt-in confirmation email.
+ * Token-only HTTPS URL, escaped content, no PII logging.
+ * Throws on send failure (caller must handle cleanup).
+ */
+export async function sendSubscriptionConfirmation(email: string, token: string): Promise<void> {
+  initSendGrid();
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr';
+  const confirmUrl = `${appUrl}/subscribe?confirm=${encodeURIComponent(token)}`;
+  const escapedUrl = escapeHtml(confirmUrl);
+
+  const html = `<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>구독 확인</title></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans KR',sans-serif;background:#F8FAFC;">
+<table role="presentation" width="100%" style="background:#F8FAFC;padding:40px 20px;">
+<tr><td>
+<table role="presentation" width="100%" style="max-width:560px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+<tr><td style="padding:32px 24px;background:#0F172A;border-radius:8px 8px 0 0;text-align:center;">
+<p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#10B981;letter-spacing:0.05em;text-transform:uppercase;">Stock Matrix</p>
+<h1 style="margin:0;font-size:22px;font-weight:700;color:#FFFFFF;">이메일 주소 확인</h1>
+</td></tr>
+<tr><td style="padding:32px 24px;">
+<p style="margin:0 0 16px;font-size:15px;color:#334155;line-height:1.6;">안녕하세요,</p>
+<p style="margin:0 0 24px;font-size:15px;color:#334155;line-height:1.6;">Stock Matrix 뉴스레터 구독을 요청하셨습니다. 아래 링크를 클릭하여 구독을 확인해주세요.</p>
+<table role="presentation" width="100%"><tr><td style="text-align:center;padding:8px 0 24px;">
+<a href="${escapedUrl}" target="_blank" rel="noopener" style="display:inline-block;padding:14px 32px;background:#10B981;color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:6px;">구독 확인하기</a>
+</td></tr></table>
+<p style="margin:0 0 8px;font-size:13px;color:#64748B;line-height:1.5;">이 링크는 24시간 동안 유효합니다.</p>
+<p style="margin:0;font-size:13px;color:#64748B;line-height:1.5;">본인이 요청하지 않았다면 이 이메일을 무시해주세요.</p>
+</td></tr>
+<tr><td style="padding:16px 24px;border-top:1px solid #E2E8F0;text-align:center;">
+<p style="margin:0;font-size:12px;color:#94A3B8;">&copy; Stock Matrix. 모든 권리 보유.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body></html>`;
+
+  await sgMail.send({
+    to: email,
+    from: {
+      email: process.env.SENDGRID_FROM_EMAIL as string,
+      name: process.env.SENDGRID_FROM_NAME as string,
+    },
+    subject: '[Stock Matrix] 이메일 주소 확인',
+    html,
+  });
+}
+
+/**
+ * Send a fresh unsubscribe link.
+ *
+ * Newsletters delivered before opaque tokens existed carry `?email=` links, and
+ * issued tokens expire. Without this path a subscriber holding an old or expired
+ * link has no way to opt out, which 정보통신망법 제50조 does not allow.
+ * Requesting a link is not itself an opt-out — the emailed link still requires
+ * explicit confirmation.
+ */
+export async function sendUnsubscribeLink(email: string, token: string): Promise<void> {
+  initSendGrid();
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr';
+  const unsubscribeUrl = `${appUrl}/unsubscribe?token=${encodeURIComponent(token)}`;
+  const escapedUrl = escapeHtml(unsubscribeUrl);
+
+  const html = `<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>구독 취소</title></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans KR',sans-serif;background:#F8FAFC;">
+<table role="presentation" width="100%" style="background:#F8FAFC;padding:40px 20px;">
+<tr><td>
+<table role="presentation" width="100%" style="max-width:560px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+<tr><td style="padding:32px 24px;background:#0F172A;border-radius:8px 8px 0 0;text-align:center;">
+<p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#10B981;letter-spacing:0.05em;text-transform:uppercase;">Stock Matrix</p>
+<h1 style="margin:0;font-size:22px;font-weight:700;color:#FFFFFF;">구독 취소 링크</h1>
+</td></tr>
+<tr><td style="padding:32px 24px;">
+<p style="margin:0 0 24px;font-size:15px;color:#334155;line-height:1.6;">요청하신 구독 취소 링크입니다. 아래 버튼을 눌러 구독 취소를 완료해주세요.</p>
+<table role="presentation" width="100%"><tr><td style="text-align:center;padding:8px 0 24px;">
+<a href="${escapedUrl}" target="_blank" rel="noopener" style="display:inline-block;padding:14px 32px;background:#DC2626;color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:6px;">구독 취소하기</a>
+</td></tr></table>
+<p style="margin:0 0 8px;font-size:13px;color:#64748B;line-height:1.5;">이 링크는 30일 동안 유효합니다.</p>
+<p style="margin:0;font-size:13px;color:#64748B;line-height:1.5;">본인이 요청하지 않았다면 이 이메일을 무시해주세요. 구독은 그대로 유지됩니다.</p>
+</td></tr>
+<tr><td style="padding:16px 24px;border-top:1px solid #E2E8F0;text-align:center;">
+<p style="margin:0;font-size:12px;color:#94A3B8;">&copy; Stock Matrix. 모든 권리 보유.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body></html>`;
+
+  await sgMail.send({
+    to: email,
+    from: {
+      email: process.env.SENDGRID_FROM_EMAIL as string,
+      name: process.env.SENDGRID_FROM_NAME as string,
+    },
+    subject: '[Stock Matrix] 구독 취소 링크',
+    html,
+  });
 }
 
 // API 키 + 발신자 정보 초기화 함수
@@ -113,13 +228,24 @@ export function parseCrashAlert(jsonString: string): CrashAlertData | null {
 }
 
 /**
- * SendGrid로 주식 뉴스레터 이메일 전송
+ * Result of a single-recipient send attempt.
  */
-export async function sendStockNewsletter(
-  recipients: EmailRecipient[],
-  data: StockNewsletterData
-): Promise<void> {
-  // SendGrid 초기화 (API 키 + 발신자 정보 검증 포함)
+export interface SingleSendResult {
+  accepted: boolean;
+  messageId?: string;
+  retryable?: boolean;
+  error?: string;
+}
+
+/**
+ * Send newsletter to a single recipient. Returns structured outcome.
+ * Does NOT throw on provider rejection — returns a result object.
+ * Only throws on non-recoverable internal errors (missing config, etc).
+ */
+export async function sendSingleRecipient(
+  recipient: EmailRecipient,
+  data: StockNewsletterData,
+): Promise<SingleSendResult> {
   initSendGrid();
 
   const isCrash = parseCrashAlert(data.geminiAnalysis) !== null;
@@ -127,28 +253,103 @@ export async function sendStockNewsletter(
     ? `[Stock Matrix] ${data.date} 긴급 시장 분석`
     : `[Stock Matrix] ${data.date} AI 기술적 분석`;
 
-  try {
-    // 각 수신자별로 개별 이메일 전송 (수신거부 링크 개인화)
-    await Promise.all(
-      recipients.map((recipient) => {
-        const html = generateNewsletterHTML(data, recipient.email);
-        return sgMail.send({
-          to: recipient.email,
-          from: {
-            email: process.env.SENDGRID_FROM_EMAIL as string,
-            name: process.env.SENDGRID_FROM_NAME as string,
-          },
-          subject,
-          html,
-        });
-      })
-    );
+  const html = generateNewsletterHTML(data, recipient.email);
 
-    console.log(`✅ 이메일 전송 완료: ${recipients.length}명`);
-  } catch (error) {
-    console.error('❌ SendGrid 이메일 전송 실패:', error);
-    throw error;
+  try {
+    const [response] = await sgMail.send({
+      to: recipient.email,
+      from: {
+        email: process.env.SENDGRID_FROM_EMAIL as string,
+        name: process.env.SENDGRID_FROM_NAME as string,
+      },
+      subject,
+      html,
+    });
+
+    // SendGrid returns x-message-id in response headers
+    const messageId = response?.headers?.['x-message-id'] as string | undefined;
+
+    if (response?.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+      return { accepted: true, messageId };
+    }
+
+    // Unexpected non-2xx without throw
+    return {
+      accepted: false,
+      retryable: response?.statusCode ? response.statusCode >= 500 : false,
+      error: `Unexpected status ${response?.statusCode}`,
+    };
+  } catch (err: unknown) {
+    // Classify SendGrid errors
+    const error = err as { code?: number; response?: { statusCode?: number; body?: unknown } };
+    const statusCode = error.response?.statusCode || error.code;
+
+    if (statusCode && statusCode >= 400 && statusCode < 500) {
+      // 4xx = permanent (bad email, suppression, etc)
+      return {
+        accepted: false,
+        retryable: false,
+        error: `Provider rejected: ${statusCode}`,
+      };
+    }
+
+    if (statusCode && statusCode >= 500) {
+      // 5xx = retryable
+      return {
+        accepted: false,
+        retryable: true,
+        error: `Provider error: ${statusCode}`,
+      };
+    }
+
+    // Network errors, timeouts — ambiguous
+    throw err;
   }
+}
+
+/**
+ * SendGrid로 주식 뉴스레터 이메일 전송 (bounded concurrency)
+ *
+ * @deprecated Use `executeDelivery` from `@/lib/delivery/service` for
+ * production sends. This function is retained for backward compatibility
+ * but now uses bounded concurrency internally.
+ */
+export async function sendStockNewsletter(
+  recipients: EmailRecipient[],
+  data: StockNewsletterData,
+): Promise<void> {
+  initSendGrid();
+
+  const CONCURRENCY = 10;
+  const executing = new Set<Promise<void>>();
+  const errors: Error[] = [];
+
+  for (const recipient of recipients) {
+    const promise = (async () => {
+      try {
+        const result = await sendSingleRecipient(recipient, data);
+        if (!result.accepted) {
+          console.error(`[sendgrid] Failed for recipient (hash: ${recipient.email.length}chars): ${result.error}`);
+        }
+      } catch (err) {
+        errors.push(err instanceof Error ? err : new Error(String(err)));
+      }
+    })().then(() => { executing.delete(promise); });
+
+    executing.add(promise);
+
+    if (executing.size >= CONCURRENCY) {
+      await Promise.race(executing);
+    }
+  }
+
+  await Promise.all(executing);
+
+  if (errors.length > 0) {
+    throw new Error(`SendGrid delivery failed for ${errors.length} recipient(s)`);
+  }
+
+  console.log(`✅ 이메일 전송 완료: ${recipients.length}명`);
 }
 
 /**
@@ -243,7 +444,7 @@ function generateNewsletterHTML(data: StockNewsletterData, email: string): strin
           <tr>
             <td style="padding: 32px 40px; background-color: #F8FAFC; border-radius: 0 0 8px 8px; text-align: center;">
               <p style="margin: 0 0 16px 0; padding: 0; font-size: 12px; font-weight: 400; color: #94A3B8; line-height: 1.5;">Stock Matrix</p>
-              <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr'}/unsubscribe?email=${encodeURIComponent(email)}" style="display: inline-block; padding: 8px 16px; font-size: 12px; font-weight: 500; color: #64748B; text-decoration: none; border: 1px solid #E2E8F0; border-radius: 6px; transition: all 0.2s;">구독 취소</a>
+              <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr'}/unsubscribe?token=${encodeURIComponent(generateUnsubscribeTokenForEmail(email))}" style="display: inline-block; padding: 8px 16px; font-size: 12px; font-weight: 500; color: #64748B; text-decoration: none; border: 1px solid #E2E8F0; border-radius: 6px; transition: all 0.2s;">구독 취소</a>
             </td>
           </tr>
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,15 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/og-background-v1.png',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
         source: '/:path*',
         headers: [
           {
@@ -37,6 +46,14 @@ const nextConfig: NextConfig = {
             value: 'camera=(), microphone=(), geolocation=()',
           },
           {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Permitted-Cross-Domain-Policies',
+            value: 'none',
+          },
+          {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
@@ -47,6 +64,8 @@ const nextConfig: NextConfig = {
               "connect-src 'self' https://*.supabase.co https://vitals.vercel-insights.com https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com",
               "frame-src https://vercel.live",
               "frame-ancestors 'none'",
+              "object-src 'none'",
+              "base-uri 'self'",
             ].join('; '),
           },
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-rehype": "^11.1.2",
+        "server-only": "0.0.1",
         "tailwind-merge": "^3.4.0",
         "twitter-api-v2": "^1.27.0",
         "undici": "^7.21.0",
@@ -11422,6 +11423,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-rehype": "^11.1.2",
+    "server-only": "0.0.1",
     "tailwind-merge": "^3.4.0",
     "twitter-api-v2": "^1.27.0",
     "undici": "^7.21.0",

--- a/supabase/migrations/056b_lockdown_stock_price_cache_writes.sql
+++ b/supabase/migrations/056b_lockdown_stock_price_cache_writes.sql
@@ -1,0 +1,119 @@
+-- ================================================
+-- Migration: Revoke anonymous INSERT/UPDATE on stock_price_cache
+-- and restrict SECURITY DEFINER function grants
+-- ================================================
+--
+-- Before: anon role could INSERT/UPDATE stock_price_cache rows via RLS policies
+-- After:  Only authenticated (service_role) can write; public can still read
+--
+-- Also restricts clean_expired_stock_price_cache SECURITY DEFINER function
+-- to be executable only by service_role (was previously public).
+-- ================================================
+
+-- 1. Drop overly permissive INSERT/UPDATE policies
+DROP POLICY IF EXISTS "Public insert access" ON public.stock_price_cache;
+DROP POLICY IF EXISTS "Public update access" ON public.stock_price_cache;
+
+-- 2. Create service-role-only write policies
+CREATE POLICY "Service role insert access"
+  ON public.stock_price_cache
+  FOR INSERT
+  WITH CHECK (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  );
+
+CREATE POLICY "Service role update access"
+  ON public.stock_price_cache
+  FOR UPDATE
+  USING (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  )
+  WITH CHECK (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  );
+
+-- 3. Revoke public EXECUTE on SECURITY DEFINER functions.
+-- Guarded: an unqualified REVOKE against a missing object aborts the whole
+-- migration, which would leave the lockdown half-applied.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'clean_expired_stock_price_cache'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM public';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM authenticated';
+    -- Supabase internal cron runs as service_role
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() TO service_role';
+  END IF;
+END $$;
+
+-- ================================================
+-- Notes:
+-- - Existing server-side code using service_role key continues to work
+-- - Client-side/anon reads still work (SELECT policy unchanged)
+-- - The pg_cron job runs as service_role so cleanup continues working
+-- ================================================
+
+-- ================================================
+-- 4. Revoke anon EXECUTE on insert_mcp_analytics
+--    This RPC trusts caller-provided ip_hash for rate-limit enforcement.
+--    Since the function is not called from any current client code,
+--    restrict to service_role only to prevent spoofed ip_hash abuse.
+-- ================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'insert_mcp_analytics'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM authenticated';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM public';
+  END IF;
+END $$;
+
+-- 5. Remove table-level write privileges as defense in depth and clear any
+-- rows that may have been written through the former anonymous policies.
+TRUNCATE TABLE public.stock_price_cache;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM authenticated;
+GRANT SELECT ON TABLE public.stock_price_cache TO anon, authenticated;
+GRANT ALL ON TABLE public.stock_price_cache TO service_role;
+
+-- 6. Keep the scientific prediction containment boundary canonical: callers
+-- must use the validated public scientific RPC, not the legacy v4 view.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = 'v_prediction_v4_serving'
+  ) THEN
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM PUBLIC';
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM anon';
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM authenticated';
+    EXECUTE 'GRANT SELECT ON TABLE public.v_prediction_v4_serving TO service_role';
+  END IF;
+END $$;
+
+-- 7. View counting is performed by the server repository with service_role.
+-- Public execution allowed arbitrary counter inflation.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'increment_blog_view_count'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM PUBLIC';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) TO service_role';
+  END IF;
+END $$;

--- a/supabase/migrations/057_rate_limit_and_double_optin.sql
+++ b/supabase/migrations/057_rate_limit_and_double_optin.sql
@@ -1,0 +1,231 @@
+-- ================================================
+-- Migration 057: Atomic rate limiting + double opt-in
+-- ================================================
+--
+-- Rate limiting: fixed-window counter using INSERT ... ON CONFLICT DO UPDATE ... RETURNING
+-- keyed by (identity_hash, bucket, window_start). Time derived inside PostgreSQL.
+-- Double opt-in: service-role-only transactional confirm_subscription RPC.
+-- ================================================
+
+-- 1. Rate limit table: atomic fixed-window counter
+CREATE TABLE IF NOT EXISTS public.rate_limit_counters (
+  identity_hash TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  window_start BIGINT NOT NULL, -- epoch seconds, derived server-side
+  request_count INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (identity_hash, bucket, window_start)
+);
+
+ALTER TABLE public.rate_limit_counters ENABLE ROW LEVEL SECURITY;
+-- No policies: service_role only (bypasses RLS)
+
+-- 2. Atomic check-and-increment RPC (SECURITY DEFINER)
+-- Derives time inside PostgreSQL; ignores caller-supplied timestamps.
+-- Validates max_requests (1..10000) and window_seconds (1..86400).
+CREATE OR REPLACE FUNCTION public.check_rate_limit(
+  p_identity_hash TEXT,
+  p_bucket TEXT,
+  p_max_requests INTEGER,
+  p_window_seconds INTEGER
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_now BIGINT;
+  v_window_start BIGINT;
+  v_count INTEGER;
+  v_limited BOOLEAN;
+BEGIN
+  -- Validate ranges
+  IF p_max_requests < 1 OR p_max_requests > 10000 THEN
+    RAISE EXCEPTION 'max_requests must be between 1 and 10000';
+  END IF;
+  IF p_window_seconds < 1 OR p_window_seconds > 86400 THEN
+    RAISE EXCEPTION 'window_seconds must be between 1 and 86400';
+  END IF;
+
+  v_now := EXTRACT(EPOCH FROM clock_timestamp())::BIGINT;
+  v_window_start := v_now - (v_now % p_window_seconds);
+
+  -- Atomic upsert: increment or insert
+  INSERT INTO public.rate_limit_counters (identity_hash, bucket, window_start, request_count)
+  VALUES (p_identity_hash, p_bucket, v_window_start, 1)
+  ON CONFLICT (identity_hash, bucket, window_start)
+  DO UPDATE SET request_count = public.rate_limit_counters.request_count + 1
+  RETURNING request_count INTO v_count;
+
+  v_limited := v_count > p_max_requests;
+
+  RETURN json_build_object(
+    'limited', v_limited,
+    'request_count', v_count,
+    'window_start', v_window_start,
+    'window_seconds', p_window_seconds
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM anon;
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) TO service_role;
+
+-- 3. Safe retention cleanup (delete windows older than 2 hours)
+CREATE OR REPLACE FUNCTION public.clean_rate_limit_counters()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_deleted INTEGER;
+  v_cutoff BIGINT;
+BEGIN
+  v_cutoff := EXTRACT(EPOCH FROM clock_timestamp())::BIGINT - 7200;
+  DELETE FROM public.rate_limit_counters WHERE window_start < v_cutoff;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM anon;
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clean_rate_limit_counters() TO service_role;
+
+-- Schedule cleanup if pg_cron exists (safe: checks existence, no unschedule call)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Use upsert-style: schedule only if not already scheduled
+    IF NOT EXISTS (
+      SELECT 1 FROM cron.job WHERE jobname = 'cleanup-rate-limit-counters'
+    ) THEN
+      PERFORM cron.schedule(
+        'cleanup-rate-limit-counters',
+        '*/15 * * * *',
+        $sched$ SELECT public.clean_rate_limit_counters() $sched$
+      );
+    END IF;
+  END IF;
+END $$;
+
+-- 4. Pending subscribers table for double opt-in
+CREATE TABLE IF NOT EXISTS public.pending_subscribers (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL,
+  name TEXT,
+  confirm_token_hash TEXT NOT NULL,
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  confirmed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Unconditional unique constraint on email (suitable for upsert)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'pending_subscribers_email_key'
+  ) THEN
+    ALTER TABLE public.pending_subscribers ADD CONSTRAINT pending_subscribers_email_key UNIQUE (email);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_pending_subscribers_expires
+  ON public.pending_subscribers (expires_at);
+
+ALTER TABLE public.pending_subscribers ENABLE ROW LEVEL SECURITY;
+-- No policies: service_role only
+
+-- 5. Transactional confirm_subscription RPC (SECURITY DEFINER)
+-- Locks pending row, verifies token hash + expiry, activates subscriber atomically.
+CREATE OR REPLACE FUNCTION public.confirm_subscription(
+  p_token_hash TEXT,
+  p_email TEXT
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_pending RECORD;
+BEGIN
+  -- Lock the pending row
+  SELECT id, email, name, expires_at, confirmed_at
+  INTO v_pending
+  FROM public.pending_subscribers
+  WHERE email = p_email
+    AND confirm_token_hash = p_token_hash
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'not_found');
+  END IF;
+
+  IF v_pending.confirmed_at IS NOT NULL THEN
+    RETURN json_build_object('success', false, 'error', 'already_confirmed');
+  END IF;
+
+  IF v_pending.expires_at < NOW() THEN
+    RETURN json_build_object('success', false, 'error', 'expired');
+  END IF;
+
+  -- Mark pending as confirmed (consume the token)
+  UPDATE public.pending_subscribers
+  SET confirmed_at = NOW()
+  WHERE id = v_pending.id;
+
+  -- Upsert into subscribers (activate or create)
+  INSERT INTO public.subscribers (email, name, is_active)
+  VALUES (v_pending.email, v_pending.name, true)
+  ON CONFLICT (email)
+  DO UPDATE SET is_active = true, name = COALESCE(EXCLUDED.name, public.subscribers.name);
+
+  RETURN json_build_object('success', true, 'email', v_pending.email);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.confirm_subscription(TEXT, TEXT) TO service_role;
+
+-- 6. Cleanup expired pending subscriptions
+CREATE OR REPLACE FUNCTION public.clean_expired_pending_subscribers()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  DELETE FROM public.pending_subscribers
+  WHERE expires_at < NOW() AND confirmed_at IS NULL;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM anon;
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clean_expired_pending_subscribers() TO service_role;
+
+-- Revoke table access from public/anon/authenticated
+REVOKE ALL ON TABLE public.rate_limit_counters FROM PUBLIC;
+REVOKE ALL ON TABLE public.rate_limit_counters FROM anon;
+REVOKE ALL ON TABLE public.rate_limit_counters FROM authenticated;
+GRANT ALL ON TABLE public.rate_limit_counters TO service_role;
+
+REVOKE ALL ON TABLE public.pending_subscribers FROM PUBLIC;
+REVOKE ALL ON TABLE public.pending_subscribers FROM anon;
+REVOKE ALL ON TABLE public.pending_subscribers FROM authenticated;
+GRANT ALL ON TABLE public.pending_subscribers TO service_role;
+
+COMMENT ON TABLE public.rate_limit_counters IS 'Atomic fixed-window rate limit counters (service_role only)';
+COMMENT ON TABLE public.pending_subscribers IS 'Double opt-in pending confirmations (service_role only)';

--- a/supabase/migrations/migration-version.test.ts
+++ b/supabase/migrations/migration-version.test.ts
@@ -1,0 +1,37 @@
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MIGRATION_DIR = resolve(process.cwd(), 'supabase', 'migrations')
+const VERSIONED_MIGRATION = /^(\d+[a-z]?)_.+\.sql$/i
+
+describe('Supabase migration file ordering', () => {
+  it('uses unique version prefixes and preserves the 056 hardening sequence', async () => {
+    const files = (await readdir(MIGRATION_DIR)).filter((file) => file.endsWith('.sql'))
+    const versions = files.flatMap((file) => {
+      const match = VERSIONED_MIGRATION.exec(file)
+      return match ? [{ file, version: match[1].toLowerCase() }] : []
+    })
+    const counts = new Map<string, number>()
+
+    for (const { version } of versions) {
+      counts.set(version, (counts.get(version) ?? 0) + 1)
+    }
+
+    const duplicates = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([version]) => version)
+      .sort()
+
+    expect(duplicates).toEqual([])
+
+    const ordered = files.sort((left, right) => left.localeCompare(right, 'en'))
+    const dropIndexes = ordered.indexOf('056_drop_unused_indexes.sql')
+    const lockdown = ordered.indexOf('056b_lockdown_stock_price_cache_writes.sql')
+    const rateLimit = ordered.indexOf('057_rate_limit_and_double_optin.sql')
+
+    expect(dropIndexes).toBeGreaterThanOrEqual(0)
+    expect(lockdown).toBeGreaterThan(dropIndexes)
+    expect(rateLimit).toBeGreaterThan(lockdown)
+  })
+})


### PR DESCRIPTION
PR #111(리뷰 없이 main에 merge됨)을 revert하고 태스크별로 분할해 재제출하는 시리즈의 **1/5**.

- `main` revert: `e69beae`
- 전체 리뷰 결과: [`docs/PR111_REVIEW_2026-07-31.md`](docs/PR111_REVIEW_2026-07-31.md)
- 배포 절차: [`docs/deploy/01-security-containment.md`](docs/deploy/01-security-containment.md)

## 범위

SEC-001/002/003/005 — 보안 격리. 마이그레이션 `056b`, `057`.

| 항목 | 내용 |
|---|---|
| cron 인증 | Bearer `CRON_SECRET` timing-safe 비교, 미설정 시 fail-closed |
| 이중 옵트인 | `pending_subscribers` + 트랜잭셔널 `confirm_subscription` RPC |
| 구독취소 토큰 | AES-256-GCM opaque 토큰, 이메일이 URL에 노출되지 않음, 키 회전 지원 |
| 캐시 잠금 | `stock_price_cache` 익명 INSERT/UPDATE 회수 |
| Rate limit | Supabase 원자적 고정 윈도우 카운터, fail-closed |
| KIS 토큰 | anon fallback 제거, service_role 전용 |
| 보안 헤더 | HSTS, `object-src 'none'`, `base-uri 'self'` |

## 리뷰에서 발견해 수정한 결함

### 1. 기 발송분의 구독취소 링크가 전부 죽음 (Blocker)

원본은 페이지·API를 token 전용으로 바꿨는데, 이미 발송된 모든 뉴스레터의 링크는
`/unsubscribe?email=` 형식이라 전부 "Invalid Request"로 끝났다. 신규 토큰도 TTL 30일이라
그 이후 발송분도 동일해진다. 정보통신망법 제50조 수신거부 조치 요건에 걸린다.

`/unsubscribe`에 이메일 입력 폴백을 추가했다.

```
/unsubscribe            → 이메일 입력 폼
/unsubscribe?token=xxx  → 기존 확인 플로우
/unsubscribe?email=xxx  → 이메일 프리필 + 폼 (즉시 해지 없음)
만료된 토큰               → 이메일 프리필 + 폼
```

`POST /api/unsubscribe/request`는 구독 중인 주소일 때만 새 토큰을 메일로 보내고, 응답 본문은
구독 여부와 무관하게 동일하다(열거 방지). 링크 요청 자체는 해지가 아니며 메일의 링크에서
명시적 확인을 거치므로, 인증 없는 호출자가 타인을 해지시킬 수 없다.

### 2. 구독 재신청이 영구 불가 (High)

`pending_subscribers` upsert가 `confirmed_at`을 초기화하지 않았다. 확인 → 구독취소 → 재신청 시
이전 `confirmed_at`이 남아 `confirm_subscription`이 `already_confirmed`를 반환하고, 라우트는
200 "이미 확인된 구독입니다"를 돌려주지만 `subscribers.is_active`는 `false`인 채로 남는다.
사용자는 다시는 메일을 받지 못하고, 오류도 보지 못한다.

upsert에 `confirmed_at: null`을 추가했다.

### 3. `stock_price_cache` 고아화 (High)

056b가 테이블을 `TRUNCATE`하고 클라이언트 캐시 접근도 제거했는데(정당한 SEC-005 수정),
서버 쪽 대체 경로가 없었다. `getBatchPricesFromCache` / `saveBatchPricesToCache` 호출자가
0개가 되어 아무도 캐시를 채우지 않고, 아카이브 조회마다 KIS를 직접 호출한다(티커당 순차 +
100ms sleep). 런북의 "cache refill 이후 정상 동작"은 성립하지 않았다.

`/api/stock/price`가 service_role로 캐시를 읽고 쓰도록 재연결했다. 미스 티커만 KIS로 넘기고,
내부 필드 `expires_at`은 응답에서 제거한다.

### 4. 마이그레이션 056b 중단 위험 (Medium)

`clean_expired_stock_price_cache`, `v_prediction_v4_serving`, `increment_blog_view_count`에 대한
REVOKE가 가드 없이 실행되어, 객체가 없으면 마이그레이션 전체가 중단되고 lockdown이 절반만
적용된 상태로 남을 수 있었다(`insert_mcp_analytics`만 가드되어 있었다). 존재 확인 가드로 감쌌다.

### 5. 정리 (Low)

- 소비자가 0개인 `lib/security/index.ts` barrel export 제외 (conventions anti-pattern #3)
- 라우트에 인라인 중복돼 있던 티커 검증을 `lib/security/validators.ts`로 통합

## 회귀 테스트

- `app/api/__tests__/subscription-lifecycle.test.ts` — `confirmed_at` 초기화, 링크 재발급 열거
  방지, 발급 토큰이 실제 구독취소 엔드포인트에서 유효한지
- `app/api/stock/__tests__/price-cache-wiring.test.ts` — 캐시 미스 티커만 KIS 호출, 조회 결과
  캐시 기록, 전체 캐시 히트 시 KIS 미호출 및 `expires_at` 미노출

## 검증

- `tsc --noEmit`: 0 errors
- `eslint .`: 0 errors (기존 warning 23건, 신규 없음)
- `vitest run`: 3379/3379 pass (281 files)
- `next build --turbopack`: 성공

## 배포 주의

- `RATE_LIMIT_HMAC_SECRET`, `UNSUBSCRIBE_TOKEN_SECRET`(각 32자 이상)을 **DB 적용 전에** 모든
  대상 환경에 주입해야 한다. 없으면 관련 라우트가 fail-closed로 503을 반환한다.
- `056b`가 `stock_price_cache`를 `TRUNCATE`한다. KRX 장 시간 외에 적용한다.

## 남은 시리즈

| PR | 범위 | 마이그레이션 |
|---|---|---|
| 2 | 뉴스레터 발송 상태머신 | 058, 059 |
| 3 | TLI 데이터 정합성 | 061, 062 |
| 4 | 조회 성능 (sparkline 역순 회귀 수정 포함) | 063 |
| 5 | UI/UX 회귀 | — |
| 보류 | **LLM/AI 파이프라인** — 설정 전면 원복 후 별도 태스크 | 060 |

LLM 설정 변경(모델 `gemini-3-flash-preview`→`gemini-2.5-flash`, 출력 토큰 65536→8192,
stage timeout 20분→45초, 전역 deadline 270초)은 이 시리즈에 포함하지 않는다. 근거였던 Vercel
300초 제약은 실제 프로덕션 경로(GitHub Actions, 55분 예산)에 적용되지 않으며, 모델 다운그레이드는
어떤 finding에도 대응하지 않는다. 상세는 리뷰 문서 B-1/B-2/B-3 참고.
