### PR TITLE
fix(delivery): 멱등 수신자별 발송 상태머신 (PR #111 Task 2/5)

### DIFF
--- a/.github/workflows/daily-newsletter.yml
+++ b/.github/workflows/daily-newsletter.yml
@@ -6,9 +6,18 @@ on:
     - cron: '25 22 * * 0-4'
   workflow_dispatch: # 수동 실행 가능
 
+# Prevent duplicate send jobs from overlapping
+concurrency:
+  group: newsletter-send-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   check-market:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -58,6 +67,7 @@ jobs:
             "2026-05-05"  # 어린이날
             "2026-05-25"  # 부처님오신날 대체공휴일
             "2026-06-03"  # 지방선거일
+            "2026-06-06"  # 현충일
             "2026-07-17"  # 제헌절
             "2026-08-17"  # 광복절 대체공휴일
             "2026-09-24" "2026-09-25"  # 추석
@@ -83,6 +93,7 @@ jobs:
     needs: check-market
     if: needs.check-market.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -97,25 +108,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Setup Google Cloud credentials
-        run: |
-          echo '${{ secrets.GOOGLE_CLOUD_CREDENTIALS }}' > $HOME/gcloud-key.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json" >> $GITHUB_ENV
-
       - name: Send Newsletter
+        timeout-minutes: 12
         env:
-          # API Keys
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}  # 사용 안 함 (Vertex AI 사용)
-
-          # Google Cloud (Vertex AI) - Gemini 전용
-          GOOGLE_CLOUD_PROJECT: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-          GOOGLE_CLOUD_LOCATION: us-central1
-
-          # Supabase
+          # Supabase (service role only — no anon key needed for delivery)
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
           # SendGrid
@@ -137,10 +134,6 @@ jobs:
         run: |
           echo "📧 Starting newsletter sending from prepared content..."
           npx tsx scripts/send-newsletter.ts
-
-      - name: Cleanup credentials
-        if: always()
-        run: rm -f $HOME/gcloud-key.json
 
       - name: Notify on success
         if: success()

--- a/.github/workflows/prepare-newsletter.yml
+++ b/.github/workflows/prepare-newsletter.yml
@@ -6,9 +6,18 @@ on:
     - cron: '0 21 * * 0-4'
   workflow_dispatch: # 수동 실행 가능
 
+# Prevent duplicate prepare jobs from overlapping
+concurrency:
+  group: newsletter-prepare-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   check-market:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -58,6 +67,8 @@ jobs:
             "2026-05-05"  # 어린이날
             "2026-05-25"  # 부처님오신날 대체공휴일
             "2026-06-03"  # 지방선거일
+            "2026-06-06"  # 현충일
+            "2026-07-17"  # 제헌절
             "2026-08-17"  # 광복절 대체공휴일
             "2026-09-24" "2026-09-25"  # 추석
             "2026-09-28"  # 추석 대체공휴일
@@ -82,6 +93,7 @@ jobs:
     needs: check-market
     if: needs.check-market.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -102,7 +114,7 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json" >> $GITHUB_ENV
 
       - name: Prepare Newsletter (AI Analysis)
-        timeout-minutes: 60
+        timeout-minutes: 55
         env:
           # KIS API - 시장 스냅샷 수집용
           KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
@@ -120,9 +132,8 @@ jobs:
           NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
           NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
 
-          # Supabase
+          # Supabase (service role only — no anon key)
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           echo "🚀 Starting AI analysis and content preparation..."

--- a/app/api/cron/send-newsletter/route.ts
+++ b/app/api/cron/send-newsletter/route.ts
@@ -1,95 +1,99 @@
+/**
+ * POST /api/cron/send-newsletter
+ *
+ * Cron endpoint for newsletter delivery.
+ * Requires Bearer CRON_SECRET authorization (timing-safe, fail-closed).
+ * Delegates to the canonical delivery service — no separate generate-and-blast.
+ * Requires an already-prepared, unsent newsletter for today's date.
+ */
+
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { sendStockNewsletter } from '@/lib/sendgrid';
-import { getStockAnalysis } from '@/lib/llm/stock-analysis';
+import { validateCronSecret } from '@/lib/security/timing-safe-auth';
+import { executeDelivery } from '@/lib/delivery/service';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co',
-  process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    'placeholder-key',
-  {
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, {
     auth: { persistSession: false },
     db: { schema: 'public' },
-  }
-);
+  });
+}
 
 export async function POST(request: NextRequest) {
   try {
-    // CRON_SECRET 검증 (선택사항, 보안을 위해 설정 권장)
+    // Fail-closed CRON_SECRET validation.
     const authHeader = request.headers.get('authorization');
-    if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    if (!validateCronSecret(authHeader)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('🚀 뉴스레터 발송 작업 시작...\n');
+    console.log('[newsletter] send job started');
 
-    // 1. 활성 구독자 가져오기
-    const { data: subscribers, error: dbError } = await supabase
-      .from('subscribers')
-      .select('*')
-      .eq('is_active', true)
-      .order('created_at', { ascending: true });
-
-    if (dbError) {
-      console.error('❌ Database error:', dbError);
-      return NextResponse.json(
-        { error: 'Database error', details: dbError.message },
-        { status: 500 }
-      );
+    // Require service_role — fail closed if not configured
+    const supabase = getServiceSupabase();
+    if (!supabase) {
+      console.error('[newsletter] SUPABASE_SERVICE_ROLE_KEY not configured');
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
     }
 
-    if (!subscribers || subscribers.length === 0) {
-      return NextResponse.json(
-        { message: '활성 구독자가 없습니다.', count: 0 },
-        { status: 200 }
-      );
-    }
+    // Determine today's date (KST)
+    const today = new Date().toLocaleDateString('en-CA', {
+      timeZone: 'Asia/Seoul',
+    });
 
-    // 2. Gemini 분석 실행
-    const { geminiAnalysis } = await getStockAnalysis();
+    // Execute delivery via canonical service
+    // 5-minute timeout for Vercel serverless (max 60s on hobby, 300s on pro)
+    const result = await executeDelivery({
+      supabase,
+      newsletterDate: today,
+      timeoutMs: 5 * 60 * 1000,
+    });
 
-    // 3. 뉴스레터 데이터 생성
-    const newsletterData = {
-      geminiAnalysis,
-      date: new Date().toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        timeZone: 'Asia/Seoul',
-      }),
-    };
-
-    // 4. SendGrid로 뉴스레터 전송
-    await sendStockNewsletter(
-      subscribers.map((s) => ({ email: s.email, name: s.name || undefined })),
-      newsletterData
+    // Log count only, no PII
+    console.log(
+      `[newsletter] job completed: ${result.accepted}/${result.total} accepted, ${result.failed} failed, ${result.ambiguous} ambiguous`,
     );
 
-    console.log(`Job completed: ${subscribers.length} subscribers`);
+    if (!result.success) {
+      // Partial delivery or ambiguous outcomes — report as 500 so monitors alert
+      return NextResponse.json(
+        {
+          success: false,
+          message: '뉴스레터 부분 발송 (일부 실패/모호)',
+          runId: result.runId,
+          accepted: result.accepted,
+          failed: result.failed,
+          ambiguous: result.ambiguous,
+          total: result.total,
+        },
+        { status: 500 },
+      );
+    }
 
     return NextResponse.json(
       {
         success: true,
         message: '뉴스레터 발송 완료',
-        subscriberCount: subscribers.length,
-        results: {
-          gemini: geminiAnalysis.startsWith('⚠️') ? 'failed' : 'success',
-        },
+        runId: result.runId,
+        subscriberCount: result.accepted,
+        total: result.total,
       },
-      { status: 200 }
+      { status: 200 },
     );
   } catch (error) {
-    console.error('❌ 뉴스레터 발송 실패:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('[newsletter] send failed:', message);
 
     return NextResponse.json(
       {
         success: false,
         error: '뉴스레터 발송 실패',
-        details: errorMessage,
+        // Do not expose internal details to external callers
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -58,7 +58,7 @@ async function getActiveThemes(): Promise<{ id: string; calculated_at: string | 
     }));
   } catch (error) {
     console.error('[Sitemap] 활성 테마 조회 실패', error);
-    throw error;
+    return [];
   }
 }
 
@@ -76,7 +76,7 @@ async function getPublishedBlogSlugs(): Promise<{ slug: string; published_at: st
     return data || [];
   } catch (error) {
     console.error('[Sitemap] 발행 블로그 조회 실패', error);
-    throw error;
+    return [];
   }
 }
 

--- a/docs/deploy/02-newsletter-delivery.md
+++ b/docs/deploy/02-newsletter-delivery.md
@@ -1,0 +1,51 @@
+# 배포 런북 — PR 2: 뉴스레터 발송 상태머신
+
+마이그레이션: `058`, `059`. **PR 1(`056b`, `057`) 적용 이후에만 진행한다.**
+
+## 1. 필수 설정
+
+PR 1의 시크릿에 더해, 발송 잡이 아래를 모두 받아야 한다. 하나라도 없으면
+`executeDelivery`가 수신자를 claim하기 전에 preflight 단계에서 실패한다(의도된 동작).
+
+- `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `SENDGRID_FROM_NAME`
+- `UNSUBSCRIBE_TOKEN_SECRET` (32자 이상)
+- `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`
+
+## 2. 사전 게이트
+
+1. **진행 중인 발송 run이 없는지 확인.** `newsletter_delivery_runs`에서 `status`가
+   `in_progress`인 행이 없어야 한다.
+2. 발송/준비 스케줄 잡 일시 정지
+3. 클린 체크아웃에서 `tsc`, `eslint`, `vitest`, `next build` 통과
+4. 마이그레이션 dry-run으로 생성 SQL 확인
+5. 적용 순서: `057`(PR 1) → `058` → `059`
+
+`059`는 `058`이 만든 5-인자 `mark_delivery_outcome` 오버로드를 `DROP` 한다. 두 파일은 반드시
+이 순서로, 연속해서 적용한다.
+
+## 3. 적용 순서
+
+1. 마이그레이션 `058` → `059` 적용
+2. 검증된 커밋 배포
+3. 스케줄 잡 재개
+
+## 4. 스모크 체크
+
+- 준비된 뉴스레터 1건에 대해 수동 발송 실행 → run이 terminal 상태로 reconcile되고 수신자
+  중복 발송이 없어야 한다
+- 동일 날짜로 재실행 → 아무것도 발송하지 않고 기존 run 결과를 반환(멱등)
+- `newsletter_recipient_deliveries`의 `status` 분포 확인:
+  `provider_accepted` + `failed` + `skipped` 합이 `total`과 일치하고 `pending`/`claimed`/
+  `retryable`/`ambiguous`가 0이어야 `newsletter_content.is_sent`가 `true`로 전환된다
+- **발송 시크릿 하나를 의도적으로 제거하고 실행** → 수신자가 하나도 claim되지 않은 채
+  `Delivery preflight failed`로 즉시 중단되어야 한다. `ambiguous` 행이 생기면 안 된다.
+- GitHub Actions 발송 잡에서 Google Cloud 자격증명 설정 단계가 사라졌는지 확인
+  (발송 잡은 더 이상 생성을 수행하지 않는다)
+
+## 5. 롤백
+
+- 스케줄 잡부터 정지
+- 앱을 직전 검증 배포로 롤백. `058`/`059`가 추가한 테이블/함수는 additive이므로 남겨둘 수 있다.
+- **provider 응답이 불확실한 발송은 `ambiguous`로 두고 절대 자동 재발송하지 않는다.**
+  재발송 여부는 provider 로그로 실제 수신 여부를 확인한 뒤 수동 판단한다.
+- run/reconciliation 로그는 보존하되 이메일 주소는 제외한다.

--- a/lib/delivery/__tests__/delivery.test.ts
+++ b/lib/delivery/__tests__/delivery.test.ts
@@ -1,0 +1,1469 @@
+/**
+ * Newsletter delivery service — behavioral tests.
+ *
+ * Tests that EXECUTE the service with mocks, verifying actual behavior:
+ * - Atomic run creation/resume without reset
+ * - Immutable snapshot via RPC (no client pagination race)
+ * - Stale claim recovery → ambiguous (never auto-reclaim)
+ * - Active-only subscriber fetch; inactive → skipped
+ * - Retryable resume with max-attempt bound
+ * - Ambiguous never retried
+ * - Conditional sent update: zero rows → no crash
+ * - Composed timeout (internal + external)
+ * - DB mutation false/error → thrown
+ * - Terminal exclusions (completed run returns immediately)
+ * - Option validation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// executeDelivery runs a send-configuration preflight before claiming anyone.
+// These tests exercise the state machine, so give it a valid configuration.
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = {
+    ...originalEnv,
+    SENDGRID_API_KEY: 'SG.test-key',
+    SENDGRID_FROM_EMAIL: 'test@stockmatrix.co.kr',
+    SENDGRID_FROM_NAME: 'Stock Matrix Test',
+    UNSUBSCRIBE_TOKEN_SECRET: 'u'.repeat(32),
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+// ─── Mock Factory ────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/sendgrid', () => ({
+  sendSingleRecipient: vi.fn(),
+}));
+
+import { sendSingleRecipient } from '@/lib/sendgrid';
+const mockSendSingle = vi.mocked(sendSingleRecipient);
+
+interface RpcHandler {
+  (fn: string, params: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
+}
+
+interface FromHandler {
+  (table: string): Record<string, unknown>;
+}
+
+function buildMockSupabase(opts: {
+  rpcHandler: RpcHandler;
+  fromHandler: FromHandler;
+}): SupabaseClient {
+  return {
+    rpc: vi.fn((fn: string, params: Record<string, unknown>) => opts.rpcHandler(fn, params)),
+    from: vi.fn((table: string) => opts.fromHandler(table)),
+  } as unknown as SupabaseClient;
+}
+
+function chainResolving(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.in = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.upsert = vi.fn().mockReturnValue(chain);
+  return chain;
+}
+
+// ─── 1. Atomic run creation/resume without reset ─────────────────────────────
+
+describe('getOrCreateRun atomic semantics', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('resumes existing run without resetting terminal state', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'completed', snapshot_completed: true, is_terminal: true }, error: null };
+        }
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 5, accepted: 5, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+    // Should NOT call snapshot or claim — just return existing terminal state
+    expect(result.success).toBe(true);
+    expect(result.accepted).toBe(5);
+    expect((supabase.rpc as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'snapshot_delivery_recipients'
+    )).toHaveLength(0);
+  });
+
+  it('throws when get_or_create_delivery_run RPC fails', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: null, error: { message: 'connection refused' } };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/get_or_create_delivery_run failed/);
+  });
+});
+
+// ─── 2. Immutable snapshot via RPC ───────────────────────────────────────────
+
+describe('immutable snapshot via RPC', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('calls snapshot_delivery_recipients RPC (not client-side pagination)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const rpcCalls: string[] = [];
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        rpcCalls.push(fn);
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') {
+          return { data: { total: 100, already_completed: false }, error: null };
+        }
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 100, accepted: 100, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: { id: 'x' }, error: null });
+      },
+    });
+
+    await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+    expect(rpcCalls).toContain('snapshot_delivery_recipients');
+    // No from('subscribers') pagination calls
+    expect((supabase.from as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'subscribers'
+    )).toHaveLength(0);
+  });
+
+  it('handles >1000 subscribers in single RPC call (set-based, no pagination)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    let snapshotCallCount = 0;
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') {
+          snapshotCallCount++;
+          // Simulate >1000 subscribers returned in one atomic call
+          return { data: { total: 5200, already_completed: false }, error: null };
+        }
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 5200, accepted: 5200, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: { id: 'x' }, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+    // Only ONE snapshot call — set-based INSERT...SELECT handles any count
+    expect(snapshotCallCount).toBe(1);
+    expect(result.total).toBe(5200);
+    expect(result.success).toBe(true);
+  });
+
+  it('snapshot RPC failure throws (not silently ignored)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') {
+          return { data: null, error: { message: 'deadlock detected' } };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/snapshot_delivery_recipients failed/);
+  });
+});
+
+// ─── 3. Stale claim recovery → ambiguous ─────────────────────────────────────
+
+describe('stale claim recovery to ambiguous', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('calls recover_stale_claims before claiming new batches', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const rpcOrder: string[] = [];
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        rpcOrder.push(fn);
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 1, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 2, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'partial', total: 3, accepted: 1, failed: 0, ambiguous: 2, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    // recover_stale_claims must come before claim_delivery_batch
+    const recoverIdx = rpcOrder.indexOf('recover_stale_claims');
+    const claimIdx = rpcOrder.indexOf('claim_delivery_batch');
+    expect(recoverIdx).toBeGreaterThan(-1);
+    expect(claimIdx).toBeGreaterThan(recoverIdx);
+
+    // Ambiguous remains → not success
+    expect(result.success).toBe(false);
+    expect(result.ambiguous).toBe(2);
+  });
+});
+
+// ─── 4. Active-only subscriber fetch; inactive → skipped ─────────────────────
+
+describe('active-only fetch and skipped status', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('marks inactive subscribers as skipped, not failed', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const markCalls: Array<{ status: string }> = [];
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn, params) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 2, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          // Return batch once, then empty
+          if (markCalls.length === 0) {
+            return { data: [
+              { delivery_id: 'd1', subscriber_id: 'sub-active' },
+              { delivery_id: 'd2', subscriber_id: 'sub-inactive' },
+            ], error: null };
+          }
+          return { data: [], error: null };
+        }
+        if (fn === 'mark_delivery_outcome') {
+          markCalls.push({ status: (params as { p_status: string }).p_status });
+          return { data: true, error: null };
+        }
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 2, accepted: 1, failed: 0, ambiguous: 0, retryable: 0, skipped: 1, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        if (table === 'subscribers') {
+          // Return one active, one inactive
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.in = vi.fn().mockResolvedValue({
+            data: [
+              { id: 'sub-active', email: 'a@x.com', name: null, is_active: true },
+              { id: 'sub-inactive', email: 'b@x.com', name: null, is_active: false },
+            ],
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: { id: 'x' }, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    expect(result.skipped).toBe(1);
+    expect(result.accepted).toBe(1);
+    // Verify mark calls include skipped
+    expect(markCalls.some(c => c.status === 'skipped')).toBe(true);
+    expect(markCalls.some(c => c.status === 'provider_accepted')).toBe(true);
+  });
+});
+
+// ─── 5. Retryable resume with max-attempt bound ──────────────────────────────
+
+describe('retryable resume and max-attempt', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('marks 429/5xx as retryable (not permanent failure)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const markStatuses: string[] = [];
+
+    mockSendSingle.mockResolvedValue({ accepted: false, retryable: true, error: 'Provider error: 503' });
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn, params) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 1, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          if (markStatuses.length === 0) {
+            return { data: [{ delivery_id: 'd1', subscriber_id: 'sub-1' }], error: null };
+          }
+          return { data: [], error: null };
+        }
+        if (fn === 'mark_delivery_outcome') {
+          markStatuses.push((params as { p_status: string }).p_status);
+          return { data: true, error: null };
+        }
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'in_progress', total: 1, accepted: 0, failed: 0, ambiguous: 0, retryable: 1, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        if (table === 'subscribers') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.in = vi.fn().mockResolvedValue({
+            data: [{ id: 'sub-1', email: 'a@x.com', name: null, is_active: true }],
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    expect(markStatuses).toContain('retryable');
+    expect(markStatuses).not.toContain('failed');
+    expect(result.retryable).toBe(1);
+    expect(result.success).toBe(false); // retryable blocks completion
+  });
+});
+
+// ─── 6. Ambiguous never retried ──────────────────────────────────────────────
+
+describe('ambiguous no retry', () => {
+  it('claim_delivery_batch SQL does not include ambiguous status', () => {
+    const sql = readFileSync(
+      resolve(__dirname, '../../../supabase/migrations/059_delivery_hardening.sql'),
+      'utf-8',
+    );
+    // The new claim function only picks pending and retryable
+    const claimFn = sql.substring(
+      sql.indexOf('REPLACE FUNCTION public.claim_delivery_batch'),
+      sql.indexOf('-- ================================================\n-- Replace mark_delivery_outcome'),
+    );
+    expect(claimFn).toContain("nrd.status = 'pending'");
+    expect(claimFn).toContain("nrd.status = 'retryable'");
+    expect(claimFn).not.toContain("'ambiguous'");
+  });
+});
+
+// ─── 7. Conditional sent update: zero rows ───────────────────────────────────
+
+describe('conditional sent update zero rows', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('does not throw when newsletter_content already marked sent (idempotent re-read confirms true)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    let fromCallCount = 0;
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 0, already_completed: true }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 1, accepted: 1, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          fromCallCount++;
+          if (fromCallCount === 1) {
+            // First call: initial load — unsent
+            return chainResolving({
+              data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null },
+              error: null,
+            });
+          }
+          if (fromCallCount === 2) {
+            // Second call: update attempt (returns PGRST116)
+            const updateChain: Record<string, unknown> = {};
+            updateChain.update = vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'no rows' } }),
+                  }),
+                }),
+              }),
+            });
+            updateChain.select = vi.fn().mockReturnValue(updateChain);
+            updateChain.eq = vi.fn().mockReturnValue(updateChain);
+            // Re-read single call: returns is_sent=true (another worker beat us)
+            updateChain.single = vi.fn().mockResolvedValue({
+              data: { id: 'c1', is_sent: true },
+              error: null,
+            });
+            return updateChain;
+          }
+          // Third call (re-read): is_sent=true
+          return chainResolving({
+            data: { id: 'c1', is_sent: true },
+            error: null,
+          });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    // Should NOT throw — re-read confirms is_sent=true
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+    expect(result.success).toBe(true);
+  });
+
+  it('throws when zero-row update re-reads and finds is_sent=false', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    let fromCallCount = 0;
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 0, already_completed: true }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 1, accepted: 1, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          fromCallCount++;
+          if (fromCallCount === 1) {
+            // First call: initial load — unsent
+            return chainResolving({
+              data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null },
+              error: null,
+            });
+          }
+          if (fromCallCount === 2) {
+            // Second call: update attempt (returns PGRST116)
+            const updateChain: Record<string, unknown> = {};
+            updateChain.update = vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  select: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'no rows' } }),
+                  }),
+                }),
+              }),
+            });
+            return updateChain;
+          }
+          // Third call (re-read): is_sent still false! Inconsistent state.
+          return chainResolving({
+            data: { id: 'c1', is_sent: false },
+            error: null,
+          });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/is_sent=false/);
+  });
+
+  it('throws when conditional sent update has a real DB error (non-PGRST116)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 1, already_completed: true }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 1, accepted: 1, failed: 0, ambiguous: 0, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.eq = vi.fn().mockReturnValue(chain);
+          chain.single = vi.fn().mockResolvedValue({
+            data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null },
+            error: null,
+          });
+          // Simulate a real DB error (not PGRST116)
+          chain.update = vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: null, error: { code: '23505', message: 'deadlock detected' } }),
+                }),
+              }),
+            }),
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/Failed to update newsletter_content\.is_sent/);
+  });
+
+  it('does NOT mark sent when ambiguous > 0', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    let updateCalled = false;
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 2, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') return { data: [], error: null };
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'partial', total: 2, accepted: 1, failed: 0, ambiguous: 1, retryable: 0, skipped: 0, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.eq = vi.fn().mockReturnValue(chain);
+          chain.single = vi.fn().mockResolvedValue({
+            data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null },
+            error: null,
+          });
+          chain.update = vi.fn().mockImplementation(() => {
+            updateCalled = true;
+            return chain;
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+    expect(result.success).toBe(false);
+    expect(updateCalled).toBe(false); // Never attempted update
+  });
+});
+
+// ─── 8. Composed timeout ─────────────────────────────────────────────────────
+
+describe('composed timeout (internal + external)', () => {
+  beforeEach(() => { vi.resetAllMocks(); });
+
+  it('aborts when external signal fires even with long internal timeout', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const externalController = new AbortController();
+    // Abort immediately
+    externalController.abort();
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 100, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          // Would return items but signal is already aborted
+          return { data: [{ delivery_id: 'd1', subscriber_id: 's1' }], error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({
+      supabase,
+      newsletterDate: '2026-07-31',
+      signal: externalController.signal,
+      timeoutMs: 600_000, // 10 min internal — should still abort from external
+    })).rejects.toThrow(/aborted/i);
+  });
+});
+
+// ─── 9. DB mutation false/error → thrown ─────────────────────────────────────
+
+describe('DB mutation boolean check', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+  });
+
+  it('throws when mark_delivery_outcome returns false (row not in expected state)', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 1, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          return { data: [{ delivery_id: 'd1', subscriber_id: 'sub-1' }], error: null };
+        }
+        if (fn === 'mark_delivery_outcome') {
+          // Return false — row was not in 'claimed' state for this worker
+          return { data: false, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        if (table === 'subscribers') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.in = vi.fn().mockResolvedValue({
+            data: [{ id: 'sub-1', email: 'a@x.com', name: null, is_active: true }],
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/mark_delivery_outcome returned false/);
+  });
+
+  it('throws when mark_delivery_outcome has DB error', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 1, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          return { data: [{ delivery_id: 'd1', subscriber_id: 'sub-1' }], error: null };
+        }
+        if (fn === 'mark_delivery_outcome') {
+          return { data: null, error: { message: 'connection reset' } };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        if (table === 'subscribers') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.in = vi.fn().mockResolvedValue({
+            data: [{ id: 'sub-1', email: 'a@x.com', name: null, is_active: true }],
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31' }))
+      .rejects.toThrow(/DB state write failed/);
+  });
+});
+
+// ─── 10. Option validation ───────────────────────────────────────────────────
+
+describe('option validation', () => {
+  it('rejects invalid batchSize', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', batchSize: 0 }))
+      .rejects.toThrow(/batchSize/);
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', batchSize: 201 }))
+      .rejects.toThrow(/batchSize/);
+  });
+
+  it('rejects invalid concurrency', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', concurrency: 0 }))
+      .rejects.toThrow(/concurrency/);
+  });
+
+  it('rejects invalid timeoutMs', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', timeoutMs: 500 }))
+      .rejects.toThrow(/timeoutMs/);
+  });
+});
+
+// ─── 11. SQL contract tests ──────────────────────────────────────────────────
+
+describe('SQL migration 059 contracts', () => {
+  const sql = readFileSync(
+    resolve(__dirname, '../../../supabase/migrations/059_delivery_hardening.sql'),
+    'utf-8',
+  );
+
+  it('adds snapshot_completed_at column', () => {
+    expect(sql).toContain('snapshot_completed_at TIMESTAMP WITH TIME ZONE');
+  });
+
+  it('adds skipped and retryable to status CHECK', () => {
+    expect(sql).toContain("'skipped'");
+    expect(sql).toContain("'retryable'");
+  });
+
+  it('get_or_create_delivery_run never mutates terminal state', () => {
+    expect(sql).toContain("v_run.status IN ('completed', 'failed')");
+    expect(sql).toContain("'is_terminal', true");
+  });
+
+  it('get_or_create_delivery_run uses IF NOT FOUND (not record-null)', () => {
+    expect(sql).toContain('IF NOT FOUND THEN');
+    expect(sql).not.toContain('v_run IS NULL');
+  });
+
+  it('snapshot_delivery_recipients uses INSERT...SELECT (not client pagination)', () => {
+    expect(sql).toContain('INSERT INTO public.newsletter_recipient_deliveries');
+    expect(sql).toContain('SELECT p_run_id, s.id');
+    expect(sql).toContain('FROM public.subscribers s');
+    expect(sql).toContain('ON CONFLICT (run_id, subscriber_id) DO NOTHING');
+  });
+
+  it('snapshot refuses to expand a completed snapshot', () => {
+    expect(sql).toContain('v_already_completed IS NOT NULL');
+    expect(sql).toContain("'already_completed', true");
+  });
+
+  it('recover_stale_claims marks ambiguous (not re-pending)', () => {
+    expect(sql).toContain("SET status = 'ambiguous'");
+    expect(sql).toContain("failure_detail = 'stale_claim_recovery'");
+  });
+
+  it('recover_stale_claims validates stale_seconds parameter', () => {
+    expect(sql).toContain('p_stale_seconds < 1 OR p_stale_seconds > 86400');
+  });
+
+  it('mark_delivery_outcome uses integer ROW_COUNT (not BOOLEAN)', () => {
+    // Must declare v_updated as INTEGER, not BOOLEAN
+    expect(sql).toContain('v_updated INTEGER');
+    expect(sql).not.toContain('v_updated BOOLEAN');
+    expect(sql).toContain('GET DIAGNOSTICS v_updated = ROW_COUNT');
+    expect(sql).toContain('RETURN v_updated > 0');
+  });
+
+  it('mark_delivery_outcome requires nonempty p_claimed_by (no NULL bypass)', () => {
+    expect(sql).toContain('p_claimed_by TEXT');
+    expect(sql).toContain('claimed_by = p_claimed_by');
+    // Must reject NULL/empty — exact match only
+    expect(sql).toContain("p_claimed_by IS NULL OR p_claimed_by = ''");
+    // No OR clause that would allow NULL bypass in WHERE
+    expect(sql).not.toContain('p_claimed_by IS NULL OR claimed_by = p_claimed_by');
+  });
+
+  it('drops obsolete 5-argument mark_delivery_outcome overload from 058', () => {
+    expect(sql).toContain('DROP FUNCTION IF EXISTS public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT)');
+  });
+
+  it('reconcile counts retryable and skipped separately', () => {
+    expect(sql).toContain("COUNT(*) FILTER (WHERE status = 'retryable')");
+    expect(sql).toContain("COUNT(*) FILTER (WHERE status = 'skipped')");
+  });
+
+  it('reconcile: terminal requires no pending/claimed/retryable/ambiguous', () => {
+    expect(sql).toContain('v_pending = 0 AND v_claimed = 0 AND v_retryable = 0 AND v_ambiguous = 0');
+  });
+
+  it('reconcile converts exhausted retries to terminal failed at start', () => {
+    expect(sql).toContain("SET status = 'failed'");
+    expect(sql).toContain("failure_detail = 'retry_exhausted'");
+    expect(sql).toContain("failure_category = 'permanent'");
+    expect(sql).toContain('attempt_count >= max_attempts');
+  });
+
+  it('all new RPCs revoke anon/authenticated access', () => {
+    const revokeAnon = (sql.match(/REVOKE ALL ON FUNCTION.*FROM anon/g) || []).length;
+    expect(revokeAnon).toBeGreaterThanOrEqual(4);
+  });
+
+  it('snapshot uses FOR UPDATE lock on run row', () => {
+    expect(sql).toContain('FOR UPDATE');
+  });
+
+  it('adds max_attempts column with default 3', () => {
+    expect(sql).toContain('max_attempts INTEGER NOT NULL DEFAULT 3');
+  });
+});
+
+// ─── 12. Workflow YAML invariants ────────────────────────────────────────────
+
+describe('workflow invariants (hardened)', () => {
+  const sendWf = readFileSync(
+    resolve(__dirname, '../../../.github/workflows/daily-newsletter.yml'),
+    'utf-8',
+  );
+  const prepWf = readFileSync(
+    resolve(__dirname, '../../../.github/workflows/prepare-newsletter.yml'),
+    'utf-8',
+  );
+
+  it('daily-newsletter does NOT have Google Cloud credentials setup', () => {
+    expect(sendWf).not.toContain('GOOGLE_CLOUD_CREDENTIALS');
+    expect(sendWf).not.toContain('GOOGLE_APPLICATION_CREDENTIALS');
+    expect(sendWf).not.toContain('GOOGLE_CLOUD_PROJECT');
+  });
+
+  it('daily-newsletter does NOT have anon key', () => {
+    expect(sendWf).not.toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  });
+
+  it('daily-newsletter has UNSUBSCRIBE_TOKEN_SECRET', () => {
+    expect(sendWf).toContain('UNSUBSCRIBE_TOKEN_SECRET');
+  });
+
+  it('2026 holiday lists are identical between workflows', () => {
+    // Extract 2026 holidays from both
+    const extract2026 = (yml: string) => {
+      const lines = yml.split('\n');
+      const holidays: string[] = [];
+      let in2026 = false;
+      for (const line of lines) {
+        if (line.includes('# — 2026 —')) in2026 = true;
+        if (in2026 && /"\d{4}-\d{2}-\d{2}"/.test(line)) {
+          const match = line.match(/"(\d{4}-\d{2}-\d{2})"/);
+          if (match && match[1].startsWith('2026')) holidays.push(match[1]);
+        }
+        if (in2026 && line.includes('for holiday')) break;
+      }
+      return holidays.sort();
+    };
+
+    const sendHolidays = extract2026(sendWf);
+    const prepHolidays = extract2026(prepWf);
+    expect(sendHolidays).toEqual(prepHolidays);
+    expect(sendHolidays.length).toBeGreaterThan(10);
+  });
+
+  it('both workflows have concurrency groups with cancel-in-progress: false', () => {
+    expect(sendWf).toContain('cancel-in-progress: false');
+    expect(prepWf).toContain('cancel-in-progress: false');
+  });
+
+  it('prepare-newsletter does NOT have anon key', () => {
+    expect(prepWf).not.toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  });
+});
+
+// ─── 13. Service source invariants ───────────────────────────────────────────
+
+describe('service source invariants', () => {
+  const serviceSource = readFileSync(resolve(__dirname, '../service.ts'), 'utf-8');
+
+  it('does not use client-side pagination for snapshot (no keyset pagination loop)', () => {
+    // The old pagination pattern is gone — snapshot is via RPC
+    expect(serviceSource).not.toContain('PAGE_SIZE');
+    expect(serviceSource).not.toContain('lastCreatedAt');
+    expect(serviceSource).not.toContain('lastId');
+    // from('subscribers') is still used for fetching emails in sendBatchBounded (correct)
+    expect(serviceSource).toContain('snapshot_delivery_recipients');
+  });
+
+  it('composes abort signals (internal timeout + external)', () => {
+    expect(serviceSource).toContain('composeAbortSignals');
+    expect(serviceSource).toContain("internal.addEventListener('abort'");
+    expect(serviceSource).toContain("external.addEventListener('abort'");
+  });
+
+  it('normalizeErrorCode returns only fixed allowlisted codes', () => {
+    expect(serviceSource).toContain('normalizeErrorCode');
+    expect(serviceSource).toContain('ALLOWED_ERROR_CODES');
+    // Must return type ErrorCode — never raw text
+    expect(serviceSource).toContain("): ErrorCode");
+    // Must NOT slice/sanitize raw text — all paths return a constant
+    expect(serviceSource).not.toContain('.slice(0,');
+    expect(serviceSource).not.toContain('message.replace(');
+  });
+
+  it('checks mark_delivery_outcome boolean return', () => {
+    expect(serviceSource).toContain('data === false');
+    expect(serviceSource).toContain('mark_delivery_outcome returned false');
+  });
+
+  it('validates options before executing', () => {
+    expect(serviceSource).toContain('validateOptions');
+    expect(serviceSource).toContain('batchSize must be between');
+  });
+
+  it('validates newsletterDate format', () => {
+    expect(serviceSource).toContain('newsletterDate must be a valid YYYY-MM-DD string');
+  });
+
+  it('validates staleLeaseSeconds', () => {
+    expect(serviceSource).toContain('staleLeaseSeconds must be between 1 and 86400');
+  });
+
+  it('validates workerId is non-empty string', () => {
+    expect(serviceSource).toContain('workerId must be a non-empty string');
+  });
+
+  it('uses Promise.allSettled for worker pool (not Set/Promise.race)', () => {
+    expect(serviceSource).toContain('Promise.allSettled');
+    expect(serviceSource).not.toContain('Promise.race');
+    expect(serviceSource).not.toContain('new Set<Promise');
+  });
+
+  it('re-reads newsletter_content after zero-row sent update to verify is_sent', () => {
+    // Never blindly accepts PGRST116/zero-row
+    expect(serviceSource).toContain('reread.is_sent === true');
+    expect(serviceSource).toContain('is_sent=false');
+  });
+
+  it('handles already-sent newsletters as idempotent no-op', () => {
+    expect(serviceSource).toContain('handleAlreadySent');
+    expect(serviceSource).toContain('alreadySent: true');
+    expect(serviceSource).toContain('legacy-no-ledger-');
+  });
+});
+
+// ─── 14. Script source invariants ────────────────────────────────────────────
+
+describe('script source invariants', () => {
+  const sendSource = readFileSync(
+    resolve(__dirname, '../../../scripts/send-newsletter.ts'),
+    'utf-8',
+  );
+
+  it('send-newsletter requires service role (no anon fallback)', () => {
+    expect(sendSource).toContain('SUPABASE_SERVICE_ROLE_KEY is required');
+    expect(sendSource).not.toContain('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  });
+
+  it('send-newsletter uses process.exitCode (not process.exit)', () => {
+    expect(sendSource).toContain('process.exitCode');
+    expect(sendSource).not.toContain('process.exit(');
+  });
+
+  // prepare-newsletter.ts의 service-role 강제, process.exitCode 전환, provenance RPC
+  // 단언은 LLM/AI 파이프라인 PR과 함께 돌아온다. 해당 스크립트는 이 PR 범위 밖이다.
+});
+
+// ─── 14b. Send-configuration preflight ───────────────────────────────────────
+
+describe('send configuration preflight', () => {
+  // A missing send secret throws before the provider is contacted. Inside the
+  // send loop that throw would be recorded as `ambiguous`, which is never
+  // auto-retried — every recipient would be stuck until someone edited the DB.
+  // The preflight must reject the run instead, leaving all rows claimable.
+  it.each([
+    'SENDGRID_API_KEY',
+    'SENDGRID_FROM_EMAIL',
+    'SENDGRID_FROM_NAME',
+  ])('rejects the run when %s is missing', async (missingKey) => {
+    delete process.env[missingKey];
+    const { assertSendConfigured } = await import('../service');
+
+    expect(() => assertSendConfigured()).toThrow(/Delivery preflight failed: missing/);
+  });
+
+  it('rejects the run when the unsubscribe token secret is unusable', async () => {
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    const { assertSendConfigured } = await import('../service');
+
+    expect(() => assertSendConfigured()).toThrow(
+      /unsubscribe token generation unavailable/,
+    );
+  });
+
+  it('rejects a token secret shorter than the 32-char minimum', async () => {
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'too-short';
+    const { assertSendConfigured } = await import('../service');
+
+    expect(() => assertSendConfigured()).toThrow(
+      /unsubscribe token generation unavailable/,
+    );
+  });
+
+  it('passes with a complete configuration', async () => {
+    const { assertSendConfigured } = await import('../service');
+
+    expect(() => assertSendConfigured()).not.toThrow();
+  });
+
+  it('aborts executeDelivery before any recipient is claimed', async () => {
+    delete process.env.SENDGRID_API_KEY;
+    const rpc = vi.fn();
+    const supabase = buildMockSupabase({
+      rpcHandler: rpc,
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+    const { executeDelivery } = await import('../service');
+
+    await expect(
+      executeDelivery({ supabase, newsletterDate: '2026-07-31' }),
+    ).rejects.toThrow(/Delivery preflight failed/);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 15. Required workerId validation ────────────────────────────────────────
+
+describe('workerId validation', () => {
+  it('rejects empty string workerId', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', workerId: '' }))
+      .rejects.toThrow(/workerId/);
+  });
+
+  it('rejects whitespace-only workerId', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', workerId: '   ' }))
+      .rejects.toThrow(/workerId/);
+  });
+});
+
+// ─── 16. Retry exhaustion ────────────────────────────────────────────────────
+
+describe('retry exhaustion in reconciliation', () => {
+  const sql = readFileSync(
+    resolve(__dirname, '../../../supabase/migrations/059_delivery_hardening.sql'),
+    'utf-8',
+  );
+
+  it('reconcile converts exhausted retries before counting', () => {
+    // The UPDATE for retry_exhausted must come BEFORE the aggregate SELECT
+    const exhaustedPos = sql.indexOf("failure_detail = 'retry_exhausted'");
+    const selectPos = sql.indexOf("COUNT(*) FILTER (WHERE status = 'retryable')");
+    expect(exhaustedPos).toBeGreaterThan(-1);
+    expect(selectPos).toBeGreaterThan(exhaustedPos);
+  });
+
+  it('retry_exhausted uses safe code (no raw text)', () => {
+    expect(sql).toContain("failure_detail = 'retry_exhausted'");
+    expect(sql).toContain("failure_category = 'permanent'");
+  });
+});
+
+// ─── 17. Fixed error codes (normalizeErrorCode allowlist) ────────────────────
+
+describe('normalizeErrorCode fixed allowlist', () => {
+  it('returns only allowlisted codes for known patterns', async () => {
+    const { normalizeErrorCode } = await import('@/lib/delivery/service');
+
+    expect(normalizeErrorCode('Connection timeout after 30s')).toBe('timeout');
+    expect(normalizeErrorCode('ECONNREFUSED 127.0.0.1')).toBe('network_error');
+    expect(normalizeErrorCode('ECONNRESET by peer')).toBe('network_error');
+    expect(normalizeErrorCode('ENOTFOUND smtp.example.com')).toBe('network_error');
+    expect(normalizeErrorCode('HTTP 429 Too Many Requests')).toBe('rate_limited');
+    expect(normalizeErrorCode('Server returned 503')).toBe('provider_5xx');
+    expect(normalizeErrorCode('HTTP 500 Internal Server Error')).toBe('provider_5xx');
+    expect(normalizeErrorCode('HTTP 400 Bad Request')).toBe('provider_4xx');
+    expect(normalizeErrorCode('Recipient email bounce detected')).toBe('recipient_rejected');
+    expect(normalizeErrorCode('Email suppression list')).toBe('recipient_rejected');
+  });
+
+  it('returns unknown_error for unrecognized messages and embedded numeric identifiers', async () => {
+    const { normalizeErrorCode } = await import('@/lib/delivery/service');
+
+    const cases = [
+      {
+        message: 'Mailbox user@example.com does not exist - rejected by relay',
+        sensitiveFragments: ['user@', 'example.com', 'relay'],
+      },
+      {
+        message: 'Connection to database port 5432 failed',
+        sensitiveFragments: ['5432'],
+      },
+      {
+        message: 'Operation elapsed 4040ms',
+        sensitiveFragments: ['4040ms'],
+      },
+      {
+        message: 'Provider request id 503991 was not found',
+        sensitiveFragments: ['503991'],
+      },
+    ];
+
+    for (const { message, sensitiveFragments } of cases) {
+      const result = normalizeErrorCode(message);
+      expect(result).toBe('unknown_error');
+      for (const fragment of sensitiveFragments) {
+        expect(result).not.toContain(fragment);
+      }
+    }
+  });
+
+  it('never returns a sanitized substring of raw provider text', async () => {
+    const { normalizeErrorCode } = await import('@/lib/delivery/service');
+
+    const codes = [
+      normalizeErrorCode('Some weird XYZ error with PII inside'),
+      normalizeErrorCode(''),
+      normalizeErrorCode('null pointer exception in provider stack'),
+    ];
+
+    const allowlist = ['timeout', 'network_error', 'rate_limited', 'provider_5xx', 'provider_4xx', 'recipient_rejected', 'unknown_error'];
+    for (const code of codes) {
+      expect(allowlist).toContain(code);
+    }
+  });
+});
+
+// ─── 18. Worker pool rejection propagation ───────────────────────────────────
+
+describe('worker pool (Promise.allSettled) rejection propagation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('propagates first DB error after all sends settle', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    let markCallCount = 0;
+    mockSendSingle.mockResolvedValue({ accepted: true, messageId: 'msg-1' });
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'get_or_create_delivery_run') {
+          return { data: { id: 'run-1', status: 'in_progress', snapshot_completed: false, is_terminal: false }, error: null };
+        }
+        if (fn === 'snapshot_delivery_recipients') return { data: { total: 3, already_completed: false }, error: null };
+        if (fn === 'recover_stale_claims') return { data: 0, error: null };
+        if (fn === 'claim_delivery_batch') {
+          if (markCallCount === 0) {
+            return { data: [
+              { delivery_id: 'd1', subscriber_id: 'sub-1' },
+              { delivery_id: 'd2', subscriber_id: 'sub-2' },
+              { delivery_id: 'd3', subscriber_id: 'sub-3' },
+            ], error: null };
+          }
+          return { data: [], error: null };
+        }
+        if (fn === 'mark_delivery_outcome') {
+          markCallCount++;
+          // Second call fails with DB error
+          if (markCallCount === 2) {
+            return { data: null, error: { message: 'connection reset during mark' } };
+          }
+          return { data: true, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({ data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: false, sent_at: null }, error: null });
+        }
+        if (table === 'subscribers') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.in = vi.fn().mockResolvedValue({
+            data: [
+              { id: 'sub-1', email: 'a@x.com', name: null, is_active: true },
+              { id: 'sub-2', email: 'b@x.com', name: null, is_active: true },
+              { id: 'sub-3', email: 'c@x.com', name: null, is_active: true },
+            ],
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    // Should throw with DB error but all promises settled (no unhandled)
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', concurrency: 3 }))
+      .rejects.toThrow(/DB state write failed/);
+  });
+});
+
+// ─── 19. Already-sent idempotent no-op ───────────────────────────────────────
+
+describe('already-sent newsletter idempotent no-op', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns success with alreadySent=true when run exists', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async (fn) => {
+        if (fn === 'reconcile_delivery_run') {
+          return { data: { status: 'completed', total: 50, accepted: 48, failed: 1, ambiguous: 0, retryable: 0, skipped: 1, pending: 0, claimed: 0 }, error: null };
+        }
+        return { data: null, error: null };
+      },
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          // is_sent=true
+          return chainResolving({
+            data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: true, sent_at: '2026-07-31T10:00:00Z' },
+            error: null,
+          });
+        }
+        if (table === 'newsletter_delivery_runs') {
+          // Existing run found
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.eq = vi.fn().mockReturnValue(chain);
+          chain.maybeSingle = vi.fn().mockResolvedValue({
+            data: { id: 'run-existing' },
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    expect(result.success).toBe(true);
+    expect(result.alreadySent).toBe(true);
+    expect(result.runId).toBe('run-existing');
+    expect(result.accepted).toBe(48);
+    // Must NOT have called get_or_create_delivery_run (no new run)
+    expect((supabase.rpc as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'get_or_create_delivery_run'
+    )).toHaveLength(0);
+  });
+
+  it('returns legacy no-op with stable ID when no ledger exists', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({
+            data: { id: 'content-abc-123', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: true, sent_at: '2026-07-31T10:00:00Z' },
+            error: null,
+          });
+        }
+        if (table === 'newsletter_delivery_runs') {
+          // No existing run
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.eq = vi.fn().mockReturnValue(chain);
+          chain.maybeSingle = vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    const result = await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    expect(result.success).toBe(true);
+    expect(result.alreadySent).toBe(true);
+    // Stable non-PII identifier
+    expect(result.runId).toBe('legacy-no-ledger-content-abc-123');
+    expect(result.total).toBe(0);
+    expect(result.accepted).toBe(0);
+    // No email, no PII in runId
+    expect(result.runId).not.toContain('@');
+  });
+
+  it('never creates a new delivery run when content is_sent=true', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: (table) => {
+        if (table === 'newsletter_content') {
+          return chainResolving({
+            data: { id: 'c1', newsletter_date: '2026-07-31', gemini_analysis: '[]', is_sent: true, sent_at: '2026-07-31T10:00:00Z' },
+            error: null,
+          });
+        }
+        if (table === 'newsletter_delivery_runs') {
+          const chain: Record<string, unknown> = {};
+          chain.select = vi.fn().mockReturnValue(chain);
+          chain.eq = vi.fn().mockReturnValue(chain);
+          chain.maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+          return chain;
+        }
+        return chainResolving({ data: null, error: null });
+      },
+    });
+
+    await executeDelivery({ supabase, newsletterDate: '2026-07-31' });
+
+    // Verify no run creation RPC was called
+    const rpcCalls = (supabase.rpc as ReturnType<typeof vi.fn>).mock.calls;
+    expect(rpcCalls.filter((c: unknown[]) => c[0] === 'get_or_create_delivery_run')).toHaveLength(0);
+    expect(rpcCalls.filter((c: unknown[]) => c[0] === 'snapshot_delivery_recipients')).toHaveLength(0);
+  });
+});
+
+// ─── 20. newsletterDate / staleLeaseSeconds validation ───────────────────────
+
+describe('additional input validation', () => {
+  it('rejects invalid newsletterDate format', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '07-31-2026' }))
+      .rejects.toThrow(/newsletterDate/);
+    await expect(executeDelivery({ supabase, newsletterDate: '' }))
+      .rejects.toThrow(/newsletterDate/);
+    await expect(executeDelivery({ supabase, newsletterDate: '2026/07/31' }))
+      .rejects.toThrow(/newsletterDate/);
+  });
+
+  it('rejects staleLeaseSeconds out of range', async () => {
+    const { executeDelivery } = await import('@/lib/delivery/service');
+    const supabase = buildMockSupabase({
+      rpcHandler: async () => ({ data: null, error: null }),
+      fromHandler: () => chainResolving({ data: null, error: null }),
+    });
+
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', staleLeaseSeconds: 0 }))
+      .rejects.toThrow(/staleLeaseSeconds/);
+    await expect(executeDelivery({ supabase, newsletterDate: '2026-07-31', staleLeaseSeconds: 100000 }))
+      .rejects.toThrow(/staleLeaseSeconds/);
+  });
+});

--- a/lib/delivery/service.ts
+++ b/lib/delivery/service.ts
@@ -1,0 +1,739 @@
+/**
+ * Canonical newsletter delivery service.
+ *
+ * Used by both `scripts/send-newsletter.ts` and `app/api/cron/send-newsletter/route.ts`.
+ * Implements an idempotent, database-backed delivery state machine with:
+ * - Atomic run creation/resume via RPC (never resets terminal state)
+ * - Immutable transactional snapshot via server-side RPC (no client pagination race)
+ * - Stale claims → ambiguous (never auto-reclaimed; explicit recovery step)
+ * - Claim only pending + retryable (within max_attempts)
+ * - Per-recipient outcome tracking with worker ID verification
+ * - Retryable vs permanent failure classification, skipped for inactive
+ * - Bounded retry with max attempts; ambiguous never auto-retried
+ * - Conditional sent update: re-reads row to verify is_sent=true after update
+ * - Composed AbortSignal: internal timeout + external signal
+ * - No raw PII in logs or DB failure_detail
+ * - normalizeErrorCode returns only a fixed allowlist of codes
+ * - Bounded worker pool via Promise.allSettled (no unhandled promises)
+ * - Idempotent no-op for already-sent newsletters (loads existing run)
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { sendSingleRecipient, type SingleSendResult } from '@/lib/sendgrid';
+import { generateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface DeliveryOptions {
+  /** Supabase client with service_role key */
+  supabase: SupabaseClient;
+  /** Newsletter date in YYYY-MM-DD format */
+  newsletterDate: string;
+  /** Worker identifier for lease tracking */
+  workerId?: string;
+  /** Batch size for claiming recipients (1-200) */
+  batchSize?: number;
+  /** Max concurrent sends within a batch */
+  concurrency?: number;
+  /** Stale lease timeout in seconds for recovery step */
+  staleLeaseSeconds?: number;
+  /** AbortSignal for external cancellation */
+  signal?: AbortSignal;
+  /** Process timeout in ms (default: 10 minutes) */
+  timeoutMs?: number;
+}
+
+export interface DeliveryResult {
+  success: boolean;
+  runId: string;
+  total: number;
+  accepted: number;
+  failed: number;
+  ambiguous: number;
+  retryable: number;
+  skipped: number;
+  error?: string;
+  /** Set when an already-sent newsletter is handled as a no-op */
+  alreadySent?: boolean;
+}
+
+interface NewsletterContentRow {
+  id: string;
+  newsletter_date: string;
+  gemini_analysis: string;
+  is_sent: boolean;
+  sent_at: string | null;
+}
+
+interface SubscriberRow {
+  id: string;
+  email: string;
+  name: string | null;
+  is_active: boolean;
+}
+
+interface RunCreationResult {
+  id: string;
+  status: string;
+  snapshot_completed: boolean;
+  is_terminal: boolean;
+}
+
+interface ReconciliationResult {
+  status: string;
+  total: number;
+  accepted: number;
+  failed: number;
+  ambiguous: number;
+  retryable: number;
+  skipped: number;
+  pending: number;
+  claimed: number;
+}
+
+// ─── Fixed allowlist of error codes ──────────────────────────────────────────
+
+type ErrorCode = 'timeout' | 'network_error' | 'rate_limited' | 'provider_5xx' | 'provider_4xx' | 'recipient_rejected' | 'unknown_error';
+
+/** Runtime set of valid error codes for assertion in tests */
+export const ALLOWED_ERROR_CODES: ReadonlySet<ErrorCode> = new Set([
+  'timeout',
+  'network_error',
+  'rate_limited',
+  'provider_5xx',
+  'provider_4xx',
+  'recipient_rejected',
+  'unknown_error',
+]);
+
+// ─── Option Validation ───────────────────────────────────────────────────────
+
+function validateOptions(options: DeliveryOptions): void {
+  const { batchSize = 50, concurrency = 10, timeoutMs = 10 * 60 * 1000, newsletterDate, staleLeaseSeconds = 300, workerId } = options;
+  if (batchSize < 1 || batchSize > 200) {
+    throw new Error('batchSize must be between 1 and 200');
+  }
+  if (concurrency < 1 || concurrency > 100) {
+    throw new Error('concurrency must be between 1 and 100');
+  }
+  if (timeoutMs < 1000 || timeoutMs > 60 * 60 * 1000) {
+    throw new Error('timeoutMs must be between 1000 and 3600000');
+  }
+  // Validate newsletterDate format: YYYY-MM-DD
+  if (!newsletterDate || !/^\d{4}-\d{2}-\d{2}$/.test(newsletterDate)) {
+    throw new Error('newsletterDate must be a valid YYYY-MM-DD string');
+  }
+  // Validate staleLeaseSeconds
+  if (staleLeaseSeconds !== undefined && (staleLeaseSeconds < 1 || staleLeaseSeconds > 86400)) {
+    throw new Error('staleLeaseSeconds must be between 1 and 86400');
+  }
+  // Validate workerId if provided
+  if (workerId !== undefined && (typeof workerId !== 'string' || workerId.trim() === '')) {
+    throw new Error('workerId must be a non-empty string');
+  }
+}
+
+// ─── Send Configuration Preflight ────────────────────────────────────────────
+
+/**
+ * Verify everything `sendSingleRecipient` needs before any recipient is claimed.
+ *
+ * Both `initSendGrid()` and unsubscribe-token generation throw *before* the
+ * provider is contacted. Inside the send loop those throws are caught and
+ * recorded as `ambiguous` — a status that is deliberately never auto-retried
+ * because it means "may already have been delivered". A missing environment
+ * variable is the opposite: nothing was sent, and every recipient would be
+ * parked in a state that only manual DB surgery can clear.
+ *
+ * Checking up front turns that into a clean, resumable abort.
+ */
+export function assertSendConfigured(): void {
+  const missing = (
+    ['SENDGRID_API_KEY', 'SENDGRID_FROM_EMAIL', 'SENDGRID_FROM_NAME'] as const
+  ).filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(`Delivery preflight failed: missing ${missing.join(', ')}`);
+  }
+
+  // Exercises the real token path (secret present and >= 32 chars).
+  try {
+    generateUnsubscribeToken('preflight@example.invalid');
+  } catch (err) {
+    throw new Error(
+      `Delivery preflight failed: unsubscribe token generation unavailable (${
+        err instanceof Error ? err.message : 'unknown'
+      })`,
+    );
+  }
+}
+
+// ─── Main Entry Point ────────────────────────────────────────────────────────
+
+/**
+ * Execute newsletter delivery for a given date.
+ *
+ * Requires an already-prepared newsletter in `newsletter_content`.
+ * Idempotent:
+ *  - Rerunning with the same date resumes an existing run.
+ *  - If already sent (is_sent=true), returns a successful no-op with existing run data
+ *    or explicit no-op result if no ledger exists (legacy row).
+ */
+export async function executeDelivery(options: DeliveryOptions): Promise<DeliveryResult> {
+  validateOptions(options);
+  assertSendConfigured();
+
+  const {
+    supabase,
+    newsletterDate,
+    workerId = `worker-${process.pid}-${Date.now()}`,
+    batchSize = 50,
+    concurrency = 10,
+    staleLeaseSeconds = 300,
+    signal: externalSignal,
+    timeoutMs = 10 * 60 * 1000,
+  } = options;
+
+  // Compose AbortSignal: internal timeout MUST still abort when external signal is supplied
+  const internalController = new AbortController();
+  const timeout = setTimeout(() => internalController.abort(), timeoutMs);
+
+  // Effective signal: aborts when EITHER internal timeout OR external signal fires
+  const effectiveSignal = composeAbortSignals(internalController.signal, externalSignal);
+
+  try {
+    // 1. Load newsletter content
+    const content = await loadUnsentNewsletter(supabase, newsletterDate);
+
+    // 1b. Idempotent no-op: if already sent, load existing run or return explicit no-op
+    if (content.is_sent) {
+      return await handleAlreadySent(supabase, content);
+    }
+
+    // 2. Create or resume delivery run (atomic RPC, never resets terminal)
+    const idempotencyKey = `delivery-${newsletterDate}`;
+    const run = await getOrCreateRun(supabase, content.id, idempotencyKey);
+
+    if (run.is_terminal) {
+      // Run already completed/failed — return its current state
+      const reconciliation = await reconcileRun(supabase, run.id);
+      return {
+        success: reconciliation.status === 'completed',
+        runId: run.id,
+        total: reconciliation.total,
+        accepted: reconciliation.accepted,
+        failed: reconciliation.failed,
+        ambiguous: reconciliation.ambiguous,
+        retryable: reconciliation.retryable,
+        skipped: reconciliation.skipped,
+      };
+    }
+
+    // 3. Snapshot all active subscribers (atomic server-side RPC, immutable once done)
+    await snapshotRecipients(supabase, run.id);
+
+    // 4. Recover stale claims → ambiguous (explicit step, never auto-reclaim)
+    await recoverStaleClaims(supabase, run.id, staleLeaseSeconds);
+
+    // 5. Process batches until done
+    let hasMore = true;
+    while (hasMore) {
+      if (effectiveSignal.aborted) {
+        throw new Error('Delivery aborted by signal/timeout');
+      }
+
+      const batch = await claimBatch(supabase, run.id, workerId, batchSize);
+      if (batch.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      // Send with bounded worker pool (Promise.allSettled)
+      await sendBatchBounded(supabase, batch, content, workerId, concurrency, effectiveSignal);
+    }
+
+    // 6. Reconcile run status
+    const reconciliation = await reconcileRun(supabase, run.id);
+
+    // 7. Update newsletter_content.is_sent based on reconciliation
+    await updateContentSentFlag(supabase, content.id, reconciliation);
+
+    return {
+      success: reconciliation.status === 'completed',
+      runId: run.id,
+      total: reconciliation.total,
+      accepted: reconciliation.accepted,
+      failed: reconciliation.failed,
+      ambiguous: reconciliation.ambiguous,
+      retryable: reconciliation.retryable,
+      skipped: reconciliation.skipped,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ─── Already-Sent Idempotent No-Op ──────────────────────────────────────────
+
+/**
+ * Handle the case where newsletter is already marked as sent.
+ * - If a delivery run exists, load its reconciliation and return success.
+ * - If no run exists (legacy sent row), return explicit no-op result.
+ * Never creates a new run or sends anything.
+ */
+async function handleAlreadySent(
+  supabase: SupabaseClient,
+  content: NewsletterContentRow,
+): Promise<DeliveryResult> {
+  const idempotencyKey = `delivery-${content.newsletter_date}`;
+
+  // Try loading existing run (do NOT create one)
+  const { data: existingRun } = await supabase
+    .from('newsletter_delivery_runs')
+    .select('id')
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle();
+
+  if (existingRun) {
+    // Load reconciliation from existing run
+    const reconciliation = await reconcileRun(supabase, existingRun.id);
+    return {
+      success: true,
+      runId: existingRun.id,
+      total: reconciliation.total,
+      accepted: reconciliation.accepted,
+      failed: reconciliation.failed,
+      ambiguous: reconciliation.ambiguous,
+      retryable: reconciliation.retryable,
+      skipped: reconciliation.skipped,
+      alreadySent: true,
+    };
+  }
+
+  // Legacy: is_sent=true but no delivery ledger exists.
+  // Return explicit successful no-op with stable non-PII identifier.
+  return {
+    success: true,
+    runId: `legacy-no-ledger-${content.id}`,
+    total: 0,
+    accepted: 0,
+    failed: 0,
+    ambiguous: 0,
+    retryable: 0,
+    skipped: 0,
+    alreadySent: true,
+  };
+}
+
+// ─── AbortSignal Composition ─────────────────────────────────────────────────
+
+/**
+ * Compose two AbortSignals: the result aborts when EITHER fires.
+ * Internal timeout must still work when an external signal is supplied.
+ */
+export function composeAbortSignals(
+  internal: AbortSignal,
+  external?: AbortSignal,
+): AbortSignal {
+  if (!external) return internal;
+
+  // If either is already aborted, return it
+  if (external.aborted) return external;
+  if (internal.aborted) return internal;
+
+  const controller = new AbortController();
+
+  const abort = () => controller.abort();
+  internal.addEventListener('abort', abort, { once: true });
+  external.addEventListener('abort', abort, { once: true });
+
+  return controller.signal;
+}
+
+// ─── Internal Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Load newsletter content by date.
+ * Unlike previous implementation, does NOT throw on is_sent=true;
+ * instead returns the row so the caller can handle the idempotent no-op.
+ */
+async function loadUnsentNewsletter(
+  supabase: SupabaseClient,
+  newsletterDate: string,
+): Promise<NewsletterContentRow> {
+  const { data, error } = await supabase
+    .from('newsletter_content')
+    .select('id, newsletter_date, gemini_analysis, is_sent, sent_at')
+    .eq('newsletter_date', newsletterDate)
+    .single();
+
+  if (error || !data) {
+    throw new Error(
+      `Newsletter content for ${newsletterDate} not found. Run prepare-newsletter first.`,
+    );
+  }
+
+  return data as NewsletterContentRow;
+}
+
+/**
+ * Atomic run creation/resume via service-role RPC.
+ * Never resets a terminal (completed/failed) run.
+ */
+async function getOrCreateRun(
+  supabase: SupabaseClient,
+  contentId: string,
+  idempotencyKey: string,
+): Promise<RunCreationResult> {
+  const { data, error } = await supabase.rpc('get_or_create_delivery_run', {
+    p_content_id: contentId,
+    p_idempotency_key: idempotencyKey,
+  });
+
+  if (error || !data) {
+    throw new Error(`get_or_create_delivery_run failed: ${error?.message ?? 'no data returned'}`);
+  }
+
+  return data as RunCreationResult;
+}
+
+/**
+ * Immutable, transactional snapshot via server-side RPC.
+ * INSERT...SELECTs all currently active subscribers in one statement.
+ * ON CONFLICT safe. Records total and completion atomically.
+ * Refuses to expand a completed snapshot (idempotent).
+ */
+async function snapshotRecipients(
+  supabase: SupabaseClient,
+  runId: string,
+): Promise<{ total: number; alreadyCompleted: boolean }> {
+  const { data, error } = await supabase.rpc('snapshot_delivery_recipients', {
+    p_run_id: runId,
+  });
+
+  if (error || !data) {
+    throw new Error(`snapshot_delivery_recipients failed: ${error?.message ?? 'no data returned'}`);
+  }
+
+  const result = data as { total: number; already_completed: boolean };
+  console.log(
+    `[delivery] Snapshot: ${result.total} recipients (${result.already_completed ? 'existing, immutable' : 'newly created'})`,
+  );
+
+  return { total: result.total, alreadyCompleted: result.already_completed };
+}
+
+/**
+ * Explicitly mark stale claimed rows as ambiguous.
+ * Never auto-reclaims: a crashed worker may have received provider acceptance.
+ */
+async function recoverStaleClaims(
+  supabase: SupabaseClient,
+  runId: string,
+  staleSeconds: number,
+): Promise<number> {
+  const { data, error } = await supabase.rpc('recover_stale_claims', {
+    p_run_id: runId,
+    p_stale_seconds: staleSeconds,
+  });
+
+  if (error) {
+    throw new Error(`recover_stale_claims failed: ${error.message}`);
+  }
+
+  const count = data as number;
+  if (count > 0) {
+    console.log(`[delivery] Recovered ${count} stale claims → ambiguous`);
+  }
+  return count;
+}
+
+interface ClaimedRecipient {
+  delivery_id: string;
+  subscriber_id: string;
+}
+
+/**
+ * Claim a batch of pending/retryable recipients.
+ * Does NOT claim stale rows (that's recover_stale_claims).
+ */
+async function claimBatch(
+  supabase: SupabaseClient,
+  runId: string,
+  workerId: string,
+  batchSize: number,
+): Promise<ClaimedRecipient[]> {
+  const { data, error } = await supabase.rpc('claim_delivery_batch', {
+    p_run_id: runId,
+    p_worker_id: workerId,
+    p_batch_size: batchSize,
+    p_stale_seconds: 0, // ignored by new RPC but kept for signature compat
+  });
+
+  if (error) throw new Error(`claim_delivery_batch failed: ${error.message}`);
+  return (data || []) as ClaimedRecipient[];
+}
+
+/**
+ * Send a batch of claimed recipients with a bounded worker pool.
+ * Uses Promise.allSettled so all in-flight sends settle cleanly.
+ * Fetches only active subscribers; marks inactive/missing as skipped.
+ * Propagates the first DB state error encountered.
+ */
+async function sendBatchBounded(
+  supabase: SupabaseClient,
+  batch: ClaimedRecipient[],
+  content: NewsletterContentRow,
+  workerId: string,
+  concurrency: number,
+  signal: AbortSignal,
+): Promise<void> {
+  // Fetch subscriber details — only active ones
+  const subscriberIds = batch.map((b) => b.subscriber_id);
+  const { data: subscribers, error } = await supabase
+    .from('subscribers')
+    .select('id, email, name, is_active')
+    .in('id', subscriberIds);
+
+  if (error || !subscribers) {
+    throw new Error(`Failed to fetch subscriber details for batch: ${error?.message}`);
+  }
+
+  const subscriberMap = new Map<string, SubscriberRow>(
+    subscribers.map((s) => [s.id, s as SubscriberRow]),
+  );
+
+  const newsletterData = {
+    geminiAnalysis: content.gemini_analysis,
+    date: new Date(content.newsletter_date).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'Asia/Seoul',
+    }),
+  };
+
+  // Bounded worker pool using Promise.allSettled
+  // Process items in chunks of `concurrency` size
+  let firstDbError: Error | null = null;
+
+  // Build tasks for each item
+  const tasks: Array<() => Promise<void>> = [];
+  for (const item of batch) {
+    const subscriber = subscriberMap.get(item.subscriber_id);
+
+    // Missing or inactive subscriber → skip (terminal exclusion)
+    if (!subscriber || !subscriber.is_active) {
+      const detail = !subscriber ? 'subscriber_not_found' : 'subscriber_inactive';
+      tasks.push(() => markOutcome(supabase, item.delivery_id, 'skipped', workerId, null, null, detail));
+      continue;
+    }
+
+    tasks.push(() => sendAndMark(supabase, item, subscriber, newsletterData, workerId));
+  }
+
+  // Execute in bounded pool windows
+  for (let i = 0; i < tasks.length; i += concurrency) {
+    if (signal.aborted) throw new Error('Aborted during batch send');
+
+    const chunk = tasks.slice(i, i + concurrency);
+    const results = await Promise.allSettled(chunk.map((fn) => fn()));
+
+    // Propagate first DB state error
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason));
+        if (!firstDbError) {
+          firstDbError = err;
+        }
+      }
+    }
+  }
+
+  // Propagate the first DB state error after all in-flight sends have settled
+  if (firstDbError) {
+    throw firstDbError;
+  }
+}
+
+async function sendAndMark(
+  supabase: SupabaseClient,
+  item: ClaimedRecipient,
+  subscriber: SubscriberRow,
+  newsletterData: { geminiAnalysis: string; date: string },
+  workerId: string,
+): Promise<void> {
+  let result: SingleSendResult;
+
+  try {
+    result = await sendSingleRecipient(
+      { email: subscriber.email, name: subscriber.name || undefined },
+      newsletterData,
+    );
+  } catch (err) {
+    // Network/unknown error — classify as ambiguous (might have been sent)
+    // Do NOT store raw error message (may contain PII like email in URL)
+    const normalizedCode = err instanceof Error
+      ? normalizeErrorCode(err.message)
+      : 'unknown_error';
+    await markOutcome(
+      supabase,
+      item.delivery_id,
+      'ambiguous',
+      workerId,
+      null,
+      'ambiguous',
+      normalizedCode,
+    );
+    return;
+  }
+
+  if (result.accepted) {
+    await markOutcome(supabase, item.delivery_id, 'provider_accepted', workerId, result.messageId);
+  } else if (result.retryable) {
+    // 429/5xx → retryable (will be re-claimed up to max_attempts)
+    const normalizedError = result.error ? normalizeErrorCode(result.error) : 'provider_5xx';
+    await markOutcome(supabase, item.delivery_id, 'retryable', workerId, null, 'retryable', normalizedError);
+  } else {
+    // 4xx permanent rejection
+    const normalizedError = result.error ? normalizeErrorCode(result.error) : 'provider_4xx';
+    await markOutcome(supabase, item.delivery_id, 'failed', workerId, null, 'permanent', normalizedError);
+  }
+}
+
+/**
+ * Normalize error messages to safe codes — never store raw provider messages
+ * that may contain PII (email addresses in bounce messages, etc).
+ *
+ * Returns ONLY a fixed allowlisted code, never sanitized portions of raw provider text.
+ */
+export function normalizeErrorCode(message: string): ErrorCode {
+  if (/timeout/i.test(message)) return 'timeout';
+  if (/ECONNREFUSED|ECONNRESET|ENOTFOUND/i.test(message)) return 'network_error';
+  if (/\b429\b/i.test(message)) return 'rate_limited';
+  if (/\b5\d{2}\b/i.test(message)) return 'provider_5xx';
+  if (/\b4\d{2}\b/i.test(message)) return 'provider_4xx';
+  if (/suppression|bounce|invalid/i.test(message)) return 'recipient_rejected';
+  // Default: never leak raw provider text
+  return 'unknown_error';
+}
+
+async function markOutcome(
+  supabase: SupabaseClient,
+  deliveryId: string,
+  status: 'provider_accepted' | 'failed' | 'ambiguous' | 'skipped' | 'retryable',
+  workerId: string,
+  messageId?: string | null,
+  failureCategory?: string | null,
+  failureDetail?: string | null,
+): Promise<void> {
+  const { data, error } = await supabase.rpc('mark_delivery_outcome', {
+    p_delivery_id: deliveryId,
+    p_status: status,
+    p_provider_message_id: messageId || null,
+    p_failure_category: failureCategory || null,
+    p_failure_detail: failureDetail || null,
+    p_claimed_by: workerId,
+  });
+
+  if (error) {
+    // DB write failure is serious — throw to halt processing
+    console.error(`[delivery] mark_delivery_outcome failed for delivery ${deliveryId}: ${error.message}`);
+    throw new Error(`DB state write failed: ${error.message}`);
+  }
+
+  // Check RPC boolean: false means the row was not in 'claimed' state for this worker
+  if (data === false) {
+    throw new Error(
+      `mark_delivery_outcome returned false for ${deliveryId} — row not in expected claimed state for worker`,
+    );
+  }
+}
+
+async function reconcileRun(
+  supabase: SupabaseClient,
+  runId: string,
+): Promise<ReconciliationResult> {
+  const { data, error } = await supabase.rpc('reconcile_delivery_run', {
+    p_run_id: runId,
+  });
+
+  if (error || !data) {
+    throw new Error(`reconcile_delivery_run failed: ${error?.message}`);
+  }
+
+  return data as ReconciliationResult;
+}
+
+/**
+ * Update newsletter_content.is_sent ONLY when fully terminal:
+ * - No pending, claimed, retryable, or ambiguous rows remain
+ * - accepted + permanent failures + skips are all terminal
+ *
+ * After the update, re-reads the row to verify is_sent=true.
+ * If the re-read shows is_sent=false, throws (never accepts blindly).
+ * PGRST116/zero-row from the update triggers a re-read:
+ *   - is_sent=true → another worker beat us (acceptable idempotent case)
+ *   - is_sent=false → inconsistent state, throw
+ */
+export async function updateContentSentFlag(
+  supabase: SupabaseClient,
+  contentId: string,
+  reconciliation: ReconciliationResult,
+): Promise<void> {
+  // is_sent = true ONLY when:
+  // - No pending/claimed/retryable/ambiguous remain
+  // - status is 'completed' (all terminal: accepted + failed + skipped)
+  const shouldMarkSent =
+    reconciliation.status === 'completed' &&
+    reconciliation.pending === 0 &&
+    reconciliation.claimed === 0 &&
+    reconciliation.retryable === 0 &&
+    reconciliation.ambiguous === 0;
+
+  if (!shouldMarkSent) {
+    // Non-terminal: do NOT mark as sent
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('newsletter_content')
+    .update({
+      is_sent: true,
+      sent_at: new Date().toISOString(),
+      subscriber_count: reconciliation.accepted,
+    })
+    .eq('id', contentId)
+    .eq('is_sent', false)
+    .select('id')
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    // Real DB error (not a "no rows" condition)
+    throw new Error(`Failed to update newsletter_content.is_sent: ${error.message}`);
+  }
+
+  if (!data) {
+    // PGRST116 or zero rows: re-read to verify actual state
+    const { data: reread, error: rereadErr } = await supabase
+      .from('newsletter_content')
+      .select('id, is_sent')
+      .eq('id', contentId)
+      .single();
+
+    if (rereadErr || !reread) {
+      throw new Error(`Failed to re-read newsletter_content after sent update: ${rereadErr?.message}`);
+    }
+
+    if (reread.is_sent === true) {
+      // Another worker already set it — idempotent, acceptable
+      console.log('[delivery] newsletter_content already marked sent (concurrent update or idempotent)');
+      return;
+    }
+
+    // is_sent is still false after the update returned zero rows — inconsistent
+    throw new Error(
+      'Failed to update newsletter_content.is_sent: zero-row update but re-read shows is_sent=false',
+    );
+  }
+}

--- a/scripts/send-newsletter.ts
+++ b/scripts/send-newsletter.ts
@@ -1,154 +1,133 @@
-// 환경변수를 가장 먼저 로드
+/**
+ * send-newsletter.ts — CLI entry point for newsletter delivery.
+ *
+ * Delegates to the canonical delivery service.
+ * Requires an already-prepared, unsent newsletter for today's date.
+ *
+ * Exit codes:
+ *   0 = all recipients terminal (completed)
+ *   1 = failure, retryable remain, or ambiguous remain
+ *
+ * Safety:
+ * - Requires SUPABASE_SERVICE_ROLE_KEY (never anon fallback)
+ * - Uses process.exitCode instead of process.exit to allow cleanup
+ * - Fails immediately for retryable/ambiguous/in-progress (does not endlessly retry permanent bounces)
+ */
+
+// Load env before any other imports
 import { config } from 'dotenv';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 
-// 로컬 환경에서만 .env.local 로드 (GitHub Actions는 환경변수 직접 사용)
 const envPath = resolve(process.cwd(), '.env.local');
 if (existsSync(envPath)) {
   config({ path: envPath });
 }
 
 import { createClient } from '@supabase/supabase-js';
-import { sendStockNewsletter, parseCrashAlert } from '@/lib/sendgrid';
+import { executeDelivery } from '@/lib/delivery/service';
+import { parseCrashAlert } from '@/lib/sendgrid';
 import { postNewsletterToTwitter, postCrashAlertToTwitter } from '@/lib/twitter';
 
-// 환경변수 검증
+// Env validation — fail-closed: require service role key, never anon
 if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+  console.error('FATAL: NEXT_PUBLIC_SUPABASE_URL is not set');
+  process.exitCode = 1;
   throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
 }
-const supabaseKey =
-  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-if (!supabaseKey) {
-  throw new Error('SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY is not set');
+if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('FATAL: SUPABASE_SERVICE_ROLE_KEY is required (anon key not accepted)');
+  process.exitCode = 1;
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is required');
 }
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
-  supabaseKey,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
   {
     auth: { persistSession: false },
     db: { schema: 'public' },
-  }
+  },
 );
 
 async function sendNewsletter() {
   console.log('🚀 뉴스레터 발송 작업 시작...\n');
 
+  const today = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Seoul',
+  });
+
+  console.log(`📅 발송 대상 날짜: ${today}`);
+
+  // Compose abort: 10 minute CLI timeout
+  const controller = new AbortController();
+  const processTimeout = setTimeout(() => {
+    console.error('[delivery] Process timeout reached (10 min)');
+    controller.abort();
+  }, 10 * 60 * 1000);
+
   try {
-    // 1. 활성 구독자 가져오기
-    console.log('📊 Supabase에서 구독자 가져오는 중...');
-    const { data: subscribers, error: dbError } = await supabase
-      .from('subscribers')
-      .select('*')
-      .eq('is_active', true)
-      .order('created_at', { ascending: true });
-
-    if (dbError) {
-      console.error('❌ Database error:', dbError);
-      throw new Error(`Database error: ${dbError.message}`);
-    }
-
-    if (!subscribers || subscribers.length === 0) {
-      console.log('⚠️ 활성 구독자가 없습니다.');
-      return;
-    }
-
-    console.log(`✅ ${subscribers.length}명의 구독자 발견\n`);
-
-    // 2. DB에서 준비된 뉴스레터 가져오기
-    const today = new Date().toLocaleDateString('en-CA', {
-      timeZone: 'Asia/Seoul',
+    const result = await executeDelivery({
+      supabase,
+      newsletterDate: today,
+      signal: controller.signal,
+      timeoutMs: 9 * 60 * 1000, // inner timeout slightly shorter
     });
 
-    console.log(`📅 ${today} 뉴스레터 조회 중...`);
-
-    const { data: newsletterContent, error: contentError } = await supabase
-      .from('newsletter_content')
-      .select('*')
-      .eq('newsletter_date', today)
-      .eq('is_sent', false)
-      .single();
-
-    if (contentError || !newsletterContent) {
-      console.error('❌ Newsletter content not found:', contentError);
-      throw new Error(
-        `Newsletter content for ${today} not found. Please run prepare-newsletter first.`
-      );
-    }
-
-    console.log('✅ 뉴스레터 콘텐츠 로드 완료\n');
-
-    const geminiAnalysis = newsletterContent.gemini_analysis;
-
-    // 3. 뉴스레터 데이터 생성
-    const newsletterData = {
-      geminiAnalysis,
-      date: new Date().toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        timeZone: 'Asia/Seoul',
-      }),
-    };
-
-    console.log('📧 이메일 발송 중...\n');
-
-    // 4. SendGrid로 뉴스레터 전송
-    await sendStockNewsletter(
-      subscribers.map((s) => ({ email: s.email, name: s.name || undefined })),
-      newsletterData
-    );
+    clearTimeout(processTimeout);
 
     console.log('\n━'.repeat(80));
     console.log('✨ 뉴스레터 발송 완료!');
     console.log('━'.repeat(80));
-    console.log(`\n📬 ${subscribers.length}명에게 뉴스레터 발송 완료`);
-    console.log('\n구독자 목록:');
-    subscribers.forEach((sub, index) => {
-      console.log(`  ${index + 1}. ${sub.email}${sub.name ? ` (${sub.name})` : ''}`);
-    });
+    console.log(`\n📬 결과 요약:`);
+    console.log(`  전체: ${result.total}`);
+    console.log(`  수락됨: ${result.accepted}`);
+    console.log(`  실패: ${result.failed}`);
+    console.log(`  재시도 가능: ${result.retryable}`);
+    console.log(`  모호: ${result.ambiguous}`);
+    console.log(`  건너뜀: ${result.skipped}`);
+    console.log(`  Run ID: ${result.runId}`);
 
-    // 5. DB 업데이트 (발송 완료 표시)
-    const { error: updateError } = await supabase
-      .from('newsletter_content')
-      .update({
-        is_sent: true,
-        sent_at: new Date().toISOString(),
-        subscriber_count: subscribers.length,
-      })
-      .eq('newsletter_date', today);
-
-    if (updateError) {
-      console.error('⚠️ DB 업데이트 실패 (뉴스레터는 정상 발송됨):', updateError);
+    if (!result.success) {
+      console.error('\n⚠️ 일부 수신자 전달 실패 또는 모호한 상태가 있습니다.');
+      console.error('   retryable/ambiguous 는 수동 확인 후 재실행 또는 수동 처리가 필요합니다.');
     }
 
-    // 6. X(Twitter) 자동 게시
-    try {
-      console.log('\n━'.repeat(80));
-      console.log('🐦 X(Twitter) 자동 게시 시작...');
-      console.log('━'.repeat(80) + '\n');
+    // Twitter posting (best-effort, non-blocking for exit code)
+    if (result.success) {
+      try {
+        const { data: content } = await supabase
+          .from('newsletter_content')
+          .select('gemini_analysis')
+          .eq('newsletter_date', today)
+          .single();
 
-      const crashAlertData = parseCrashAlert(geminiAnalysis);
-      if (crashAlertData) {
-        // Crash Alert: 텍스트 트윗 게시 (구조 검증 완료)
-        await postCrashAlertToTwitter(crashAlertData);
-      } else {
-        // 일반: 기존 이미지 + 텍스트 트윗
-        const analysisData = JSON.parse(geminiAnalysis);
-        await postNewsletterToTwitter(analysisData);
+        if (content?.gemini_analysis) {
+          console.log('\n🐦 X(Twitter) 자동 게시 시작...');
+          const crashAlertData = parseCrashAlert(content.gemini_analysis);
+          if (crashAlertData) {
+            await postCrashAlertToTwitter(crashAlertData);
+          } else {
+            const analysisData = JSON.parse(content.gemini_analysis);
+            await postNewsletterToTwitter(analysisData);
+          }
+          console.log('✅ X(Twitter) 자동 게시 완료!');
+        }
+      } catch (twitterError) {
+        console.error('⚠️ X(Twitter) 게시 실패 (뉴스레터는 정상 발송됨):', twitterError);
       }
-
-      console.log('✅ X(Twitter) 자동 게시 완료!\n');
-    } catch (twitterError) {
-      console.error('⚠️ X(Twitter) 게시 실패 (뉴스레터는 정상 발송됨):', twitterError);
-      // 트위터 실패해도 프로세스는 성공으로 처리
     }
 
-    process.exit(0);
+    // Exit 1 if any non-terminal outcomes remain
+    if (result.ambiguous > 0 || result.retryable > 0 || !result.success) {
+      process.exitCode = 1;
+    } else {
+      process.exitCode = 0;
+    }
   } catch (error) {
-    console.error('❌ 뉴스레터 발송 실패:', error);
-    process.exit(1);
+    clearTimeout(processTimeout);
+    console.error('❌ 뉴스레터 발송 실패:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
   }
 }
 

--- a/supabase/migrations/058_newsletter_delivery_state_machine.sql
+++ b/supabase/migrations/058_newsletter_delivery_state_machine.sql
@@ -1,0 +1,235 @@
+-- ================================================
+-- Migration 058: Newsletter delivery state machine
+-- ================================================
+--
+-- Replaces boolean is_sent with a database-backed delivery ledger.
+-- Tables:
+--   newsletter_delivery_runs  — one row per send invocation
+--   newsletter_recipient_deliveries — per-recipient outcome ledger
+--
+-- Statuses: pending, claimed, provider_accepted, failed, ambiguous
+-- Concurrency-safe: unique constraints, advisory locks, stale-lease recovery.
+-- RLS enabled, service_role only (no anon/authenticated access).
+-- ================================================
+
+-- 1. Delivery runs (one per invocation of send-newsletter)
+CREATE TABLE IF NOT EXISTS public.newsletter_delivery_runs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  newsletter_content_id UUID NOT NULL REFERENCES public.newsletter_content(id),
+  idempotency_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'in_progress', 'completed', 'failed', 'partial')),
+  total_recipients INTEGER NOT NULL DEFAULT 0,
+  accepted_count INTEGER NOT NULL DEFAULT 0,
+  failed_count INTEGER NOT NULL DEFAULT 0,
+  ambiguous_count INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  completed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT uq_delivery_run_idempotency UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_delivery_runs_content_id
+  ON public.newsletter_delivery_runs (newsletter_content_id);
+CREATE INDEX IF NOT EXISTS idx_delivery_runs_status
+  ON public.newsletter_delivery_runs (status);
+
+ALTER TABLE public.newsletter_delivery_runs ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.newsletter_delivery_runs FROM PUBLIC;
+REVOKE ALL ON TABLE public.newsletter_delivery_runs FROM anon;
+REVOKE ALL ON TABLE public.newsletter_delivery_runs FROM authenticated;
+GRANT ALL ON TABLE public.newsletter_delivery_runs TO service_role;
+
+-- 2. Per-recipient delivery ledger
+CREATE TABLE IF NOT EXISTS public.newsletter_recipient_deliveries (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  run_id UUID NOT NULL REFERENCES public.newsletter_delivery_runs(id),
+  subscriber_id UUID NOT NULL,
+  -- No PII stored directly; subscriber_id references subscribers table
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'claimed', 'provider_accepted', 'failed', 'ambiguous')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  provider_message_id TEXT,
+  failure_category TEXT CHECK (failure_category IN ('retryable', 'permanent', 'ambiguous') OR failure_category IS NULL),
+  failure_detail TEXT,
+  claimed_at TIMESTAMP WITH TIME ZONE,
+  claimed_by TEXT, -- worker/process identifier for lease
+  completed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT uq_recipient_per_run UNIQUE (run_id, subscriber_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_recipient_deliveries_run_status
+  ON public.newsletter_recipient_deliveries (run_id, status);
+CREATE INDEX IF NOT EXISTS idx_recipient_deliveries_claimed_stale
+  ON public.newsletter_recipient_deliveries (status, claimed_at)
+  WHERE status = 'claimed';
+
+ALTER TABLE public.newsletter_recipient_deliveries ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.newsletter_recipient_deliveries FROM PUBLIC;
+REVOKE ALL ON TABLE public.newsletter_recipient_deliveries FROM anon;
+REVOKE ALL ON TABLE public.newsletter_recipient_deliveries FROM authenticated;
+GRANT ALL ON TABLE public.newsletter_recipient_deliveries TO service_role;
+
+-- 3. Atomic claim RPC: claim a batch of pending/stale recipients
+-- Returns claimed recipient IDs. Uses FOR UPDATE SKIP LOCKED for concurrency.
+CREATE OR REPLACE FUNCTION public.claim_delivery_batch(
+  p_run_id UUID,
+  p_worker_id TEXT,
+  p_batch_size INTEGER DEFAULT 50,
+  p_stale_seconds INTEGER DEFAULT 300
+)
+RETURNS TABLE (
+  delivery_id UUID,
+  subscriber_id UUID
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_stale_cutoff TIMESTAMP WITH TIME ZONE;
+BEGIN
+  IF p_batch_size < 1 OR p_batch_size > 200 THEN
+    RAISE EXCEPTION 'batch_size must be between 1 and 200';
+  END IF;
+
+  v_stale_cutoff := NOW() - (p_stale_seconds || ' seconds')::INTERVAL;
+
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT nrd.id, nrd.subscriber_id
+    FROM public.newsletter_recipient_deliveries nrd
+    WHERE nrd.run_id = p_run_id
+      AND (
+        nrd.status = 'pending'
+        OR (nrd.status = 'claimed' AND nrd.claimed_at < v_stale_cutoff)
+      )
+    ORDER BY nrd.created_at
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.newsletter_recipient_deliveries d
+  SET status = 'claimed',
+      claimed_at = NOW(),
+      claimed_by = p_worker_id,
+      attempt_count = d.attempt_count + 1
+  FROM claimable c
+  WHERE d.id = c.id
+  RETURNING d.id AS delivery_id, d.subscriber_id AS subscriber_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_delivery_batch(UUID, TEXT, INTEGER, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.claim_delivery_batch(UUID, TEXT, INTEGER, INTEGER) FROM anon;
+REVOKE ALL ON FUNCTION public.claim_delivery_batch(UUID, TEXT, INTEGER, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_delivery_batch(UUID, TEXT, INTEGER, INTEGER) TO service_role;
+
+-- 4. Mark delivery outcome RPC (atomic single-recipient update)
+CREATE OR REPLACE FUNCTION public.mark_delivery_outcome(
+  p_delivery_id UUID,
+  p_status TEXT,
+  p_provider_message_id TEXT DEFAULT NULL,
+  p_failure_category TEXT DEFAULT NULL,
+  p_failure_detail TEXT DEFAULT NULL
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_status NOT IN ('provider_accepted', 'failed', 'ambiguous') THEN
+    RAISE EXCEPTION 'status must be provider_accepted, failed, or ambiguous';
+  END IF;
+
+  UPDATE public.newsletter_recipient_deliveries
+  SET status = p_status,
+      provider_message_id = COALESCE(p_provider_message_id, provider_message_id),
+      failure_category = p_failure_category,
+      failure_detail = p_failure_detail,
+      completed_at = NOW()
+  WHERE id = p_delivery_id
+    AND status = 'claimed';
+
+  RETURN FOUND;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT) TO service_role;
+
+-- 5. Reconcile run status (call after batch processing)
+CREATE OR REPLACE FUNCTION public.reconcile_delivery_run(p_run_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_total INTEGER;
+  v_accepted INTEGER;
+  v_failed INTEGER;
+  v_ambiguous INTEGER;
+  v_pending INTEGER;
+  v_claimed INTEGER;
+  v_new_status TEXT;
+BEGIN
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'provider_accepted'),
+    COUNT(*) FILTER (WHERE status = 'failed'),
+    COUNT(*) FILTER (WHERE status = 'ambiguous'),
+    COUNT(*) FILTER (WHERE status = 'pending'),
+    COUNT(*) FILTER (WHERE status = 'claimed')
+  INTO v_total, v_accepted, v_failed, v_ambiguous, v_pending, v_claimed
+  FROM public.newsletter_recipient_deliveries
+  WHERE run_id = p_run_id;
+
+  IF v_pending = 0 AND v_claimed = 0 THEN
+    IF v_failed = 0 AND v_ambiguous = 0 THEN
+      v_new_status := 'completed';
+    ELSE
+      v_new_status := 'partial';
+    END IF;
+  ELSE
+    v_new_status := 'in_progress';
+  END IF;
+
+  UPDATE public.newsletter_delivery_runs
+  SET status = v_new_status,
+      accepted_count = v_accepted,
+      failed_count = v_failed,
+      ambiguous_count = v_ambiguous,
+      total_recipients = v_total,
+      completed_at = CASE WHEN v_new_status IN ('completed', 'partial') THEN NOW() ELSE NULL END
+  WHERE id = p_run_id;
+
+  RETURN json_build_object(
+    'run_id', p_run_id,
+    'status', v_new_status,
+    'total', v_total,
+    'accepted', v_accepted,
+    'failed', v_failed,
+    'ambiguous', v_ambiguous,
+    'pending', v_pending,
+    'claimed', v_claimed
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM anon;
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.reconcile_delivery_run(UUID) TO service_role;
+
+-- 6. Comments
+COMMENT ON TABLE public.newsletter_delivery_runs IS 'One row per newsletter send invocation. Tracks overall delivery progress.';
+COMMENT ON TABLE public.newsletter_recipient_deliveries IS 'Per-recipient delivery outcome ledger. No PII stored directly.';
+COMMENT ON FUNCTION public.claim_delivery_batch IS 'Atomically claim a batch of pending/stale recipients for sending (SKIP LOCKED).';
+COMMENT ON FUNCTION public.mark_delivery_outcome IS 'Record provider outcome for a single claimed delivery.';
+COMMENT ON FUNCTION public.reconcile_delivery_run IS 'Reconcile run status from recipient outcomes. Returns summary JSON.';

--- a/supabase/migrations/059_delivery_hardening.sql
+++ b/supabase/migrations/059_delivery_hardening.sql
@@ -1,0 +1,423 @@
+-- ================================================
+-- Migration 059: Delivery hardening (adversarial second-pass)
+-- ================================================
+--
+-- Fixes:
+-- 1. getOrCreateRun must not reset terminal runs (insert-then-select, no upsert that resets status)
+-- 2. Snapshot immutability: snapshot_completed_at column + transactional RPC
+-- 3. Stale claims → ambiguous (never auto-reclaim); claim only pending + retryable
+-- 4. Retryable vs permanent: max_attempts, skipped status, retryable rows
+-- 5. Reconcile counts retryable separately, terminal only when no pending/claimed/retryable/ambiguous
+-- 6. mark_delivery_outcome requires nonempty claimed_by match (no NULL bypass)
+-- 7. Drop obsolete 5-argument mark_delivery_outcome overload from 058
+-- 8. Validate stale_seconds parameter
+-- 9. Retry exhaustion: convert retryable rows at max_attempts into terminal failed/permanent
+-- ================================================
+
+-- 1. Add snapshot_completed_at to runs
+ALTER TABLE public.newsletter_delivery_runs
+  ADD COLUMN IF NOT EXISTS snapshot_completed_at TIMESTAMP WITH TIME ZONE;
+
+-- 2. Expand status CHECK to include 'skipped' and 'retryable'
+-- Drop old constraint, add new one
+ALTER TABLE public.newsletter_recipient_deliveries
+  DROP CONSTRAINT IF EXISTS newsletter_recipient_deliveries_status_check;
+
+ALTER TABLE public.newsletter_recipient_deliveries
+  ADD CONSTRAINT newsletter_recipient_deliveries_status_check
+  CHECK (status IN ('pending', 'claimed', 'provider_accepted', 'failed', 'ambiguous', 'skipped', 'retryable'));
+
+-- 3. Add max_attempts column (default 3)
+ALTER TABLE public.newsletter_recipient_deliveries
+  ADD COLUMN IF NOT EXISTS max_attempts INTEGER NOT NULL DEFAULT 3;
+
+-- ================================================
+-- Drop obsolete 5-argument mark_delivery_outcome overload from migration 058
+-- Only the hardened 6-argument signature (with p_claimed_by) should remain.
+-- ================================================
+DROP FUNCTION IF EXISTS public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT);
+
+-- ================================================
+-- RPC: get_or_create_delivery_run
+-- Atomic insert-then-select. Never mutates a terminal run.
+-- Uses IF NOT FOUND instead of record-null check after SELECT.
+-- ================================================
+CREATE OR REPLACE FUNCTION public.get_or_create_delivery_run(
+  p_content_id UUID,
+  p_idempotency_key TEXT
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_run RECORD;
+BEGIN
+  -- Try insert first (only succeeds for new runs)
+  INSERT INTO public.newsletter_delivery_runs (newsletter_content_id, idempotency_key, status)
+  VALUES (p_content_id, p_idempotency_key, 'pending')
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  -- Select the existing or newly inserted row
+  SELECT id, status, snapshot_completed_at
+  INTO v_run
+  FROM public.newsletter_delivery_runs
+  WHERE idempotency_key = p_idempotency_key;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Failed to get or create delivery run for key %', p_idempotency_key;
+  END IF;
+
+  -- If run is in a terminal state, return it as-is (never reset)
+  IF v_run.status IN ('completed', 'failed') THEN
+    RETURN json_build_object(
+      'id', v_run.id,
+      'status', v_run.status,
+      'snapshot_completed', v_run.snapshot_completed_at IS NOT NULL,
+      'is_terminal', true
+    );
+  END IF;
+
+  -- Transition to in_progress if pending (atomic conditional update)
+  UPDATE public.newsletter_delivery_runs
+  SET status = 'in_progress',
+      started_at = COALESCE(started_at, NOW())
+  WHERE id = v_run.id
+    AND status IN ('pending', 'in_progress', 'partial');
+
+  RETURN json_build_object(
+    'id', v_run.id,
+    'status', 'in_progress',
+    'snapshot_completed', v_run.snapshot_completed_at IS NOT NULL,
+    'is_terminal', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_or_create_delivery_run(UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_or_create_delivery_run(UUID, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.get_or_create_delivery_run(UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_or_create_delivery_run(UUID, TEXT) TO service_role;
+
+-- ================================================
+-- RPC: snapshot_delivery_recipients
+-- Transactional set-based INSERT...SELECT of all active subscribers.
+-- ON CONFLICT safe. Records total and snapshot_completed_at atomically.
+-- Refuses to expand a completed snapshot (idempotent).
+-- ================================================
+CREATE OR REPLACE FUNCTION public.snapshot_delivery_recipients(p_run_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_already_completed TIMESTAMP WITH TIME ZONE;
+  v_total INTEGER;
+  v_existing_count INTEGER;
+BEGIN
+  -- Lock the run row to prevent concurrent snapshots
+  SELECT snapshot_completed_at
+  INTO v_already_completed
+  FROM public.newsletter_delivery_runs
+  WHERE id = p_run_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Run % not found', p_run_id;
+  END IF;
+
+  -- If snapshot already completed, return existing count (immutable)
+  IF v_already_completed IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_existing_count
+    FROM public.newsletter_recipient_deliveries
+    WHERE run_id = p_run_id;
+
+    RETURN json_build_object(
+      'total', v_existing_count,
+      'already_completed', true
+    );
+  END IF;
+
+  -- Single atomic INSERT...SELECT of all currently active subscribers
+  INSERT INTO public.newsletter_recipient_deliveries (run_id, subscriber_id, status)
+  SELECT p_run_id, s.id, 'pending'
+  FROM public.subscribers s
+  WHERE s.is_active = true
+  ON CONFLICT (run_id, subscriber_id) DO NOTHING;
+
+  -- Count total (includes any pre-existing from partial earlier run)
+  SELECT COUNT(*) INTO v_total
+  FROM public.newsletter_recipient_deliveries
+  WHERE run_id = p_run_id;
+
+  -- Atomically record total and completion timestamp
+  UPDATE public.newsletter_delivery_runs
+  SET total_recipients = v_total,
+      snapshot_completed_at = NOW()
+  WHERE id = p_run_id;
+
+  RETURN json_build_object(
+    'total', v_total,
+    'already_completed', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.snapshot_delivery_recipients(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.snapshot_delivery_recipients(UUID) FROM anon;
+REVOKE ALL ON FUNCTION public.snapshot_delivery_recipients(UUID) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.snapshot_delivery_recipients(UUID) TO service_role;
+
+-- ================================================
+-- RPC: recover_stale_claims
+-- Marks stale claimed rows as 'ambiguous'. Never auto-reclaims.
+-- Must be called explicitly before claiming new batches.
+-- Validates p_stale_seconds is a positive integer.
+-- Uses integer ROW_COUNT (not BOOLEAN).
+-- ================================================
+CREATE OR REPLACE FUNCTION public.recover_stale_claims(
+  p_run_id UUID,
+  p_stale_seconds INTEGER DEFAULT 300
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_stale_cutoff TIMESTAMP WITH TIME ZONE;
+  v_count INTEGER;
+BEGIN
+  -- Validate stale_seconds: must be positive
+  IF p_stale_seconds < 1 OR p_stale_seconds > 86400 THEN
+    RAISE EXCEPTION 'p_stale_seconds must be between 1 and 86400, got %', p_stale_seconds;
+  END IF;
+
+  v_stale_cutoff := NOW() - (p_stale_seconds || ' seconds')::INTERVAL;
+
+  UPDATE public.newsletter_recipient_deliveries
+  SET status = 'ambiguous',
+      failure_category = 'ambiguous',
+      failure_detail = 'stale_claim_recovery',
+      completed_at = NOW()
+  WHERE run_id = p_run_id
+    AND status = 'claimed'
+    AND claimed_at < v_stale_cutoff;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.recover_stale_claims(UUID, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.recover_stale_claims(UUID, INTEGER) FROM anon;
+REVOKE ALL ON FUNCTION public.recover_stale_claims(UUID, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.recover_stale_claims(UUID, INTEGER) TO service_role;
+
+-- ================================================
+-- Replace claim_delivery_batch: claim only pending and retryable (within max_attempts).
+-- No stale claim reclamation here.
+-- ================================================
+CREATE OR REPLACE FUNCTION public.claim_delivery_batch(
+  p_run_id UUID,
+  p_worker_id TEXT,
+  p_batch_size INTEGER DEFAULT 50,
+  p_stale_seconds INTEGER DEFAULT 300
+)
+RETURNS TABLE (
+  delivery_id UUID,
+  subscriber_id UUID
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_batch_size < 1 OR p_batch_size > 200 THEN
+    RAISE EXCEPTION 'batch_size must be between 1 and 200';
+  END IF;
+
+  -- p_stale_seconds is now ignored (stale recovery is separate RPC)
+  -- but kept for backward compat signature
+
+  RETURN QUERY
+  WITH claimable AS (
+    SELECT nrd.id, nrd.subscriber_id
+    FROM public.newsletter_recipient_deliveries nrd
+    WHERE nrd.run_id = p_run_id
+      AND (
+        nrd.status = 'pending'
+        OR (nrd.status = 'retryable' AND nrd.attempt_count < nrd.max_attempts)
+      )
+    ORDER BY nrd.created_at
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.newsletter_recipient_deliveries d
+  SET status = 'claimed',
+      claimed_at = NOW(),
+      claimed_by = p_worker_id,
+      attempt_count = d.attempt_count + 1
+  FROM claimable c
+  WHERE d.id = c.id
+  RETURNING d.id AS delivery_id, d.subscriber_id AS subscriber_id;
+END;
+$$;
+
+-- ================================================
+-- Replace mark_delivery_outcome: require nonempty claimed_by match, return boolean.
+-- p_claimed_by is mandatory and must be non-empty; NULL bypass is not allowed.
+-- Uses integer ROW_COUNT declaration (not BOOLEAN).
+-- ================================================
+CREATE OR REPLACE FUNCTION public.mark_delivery_outcome(
+  p_delivery_id UUID,
+  p_status TEXT,
+  p_provider_message_id TEXT DEFAULT NULL,
+  p_failure_category TEXT DEFAULT NULL,
+  p_failure_detail TEXT DEFAULT NULL,
+  p_claimed_by TEXT DEFAULT NULL
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_updated INTEGER;
+BEGIN
+  IF p_status NOT IN ('provider_accepted', 'failed', 'ambiguous', 'skipped', 'retryable') THEN
+    RAISE EXCEPTION 'status must be provider_accepted, failed, ambiguous, skipped, or retryable';
+  END IF;
+
+  -- Require non-empty p_claimed_by: no NULL bypass allowed
+  IF p_claimed_by IS NULL OR p_claimed_by = '' THEN
+    RAISE EXCEPTION 'p_claimed_by is required and must be non-empty';
+  END IF;
+
+  UPDATE public.newsletter_recipient_deliveries
+  SET status = p_status,
+      provider_message_id = COALESCE(p_provider_message_id, provider_message_id),
+      failure_category = p_failure_category,
+      failure_detail = p_failure_detail,
+      completed_at = CASE WHEN p_status IN ('provider_accepted', 'failed', 'ambiguous', 'skipped') THEN NOW() ELSE NULL END
+  WHERE id = p_delivery_id
+    AND status = 'claimed'
+    AND claimed_by = p_claimed_by;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated > 0;
+END;
+$$;
+
+-- ================================================
+-- Replace reconcile_delivery_run: count retryable separately,
+-- terminal only when no pending/claimed/retryable/ambiguous.
+-- At reconciliation start, convert retryable rows whose attempt_count >= max_attempts
+-- into terminal failed/permanent with code 'retry_exhausted'.
+-- ================================================
+CREATE OR REPLACE FUNCTION public.reconcile_delivery_run(p_run_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_total INTEGER;
+  v_accepted INTEGER;
+  v_failed INTEGER;
+  v_ambiguous INTEGER;
+  v_pending INTEGER;
+  v_claimed INTEGER;
+  v_retryable INTEGER;
+  v_skipped INTEGER;
+  v_new_status TEXT;
+  v_exhausted INTEGER;
+BEGIN
+  -- Convert retryable rows that have exhausted their attempts into terminal failed
+  UPDATE public.newsletter_recipient_deliveries
+  SET status = 'failed',
+      failure_category = 'permanent',
+      failure_detail = 'retry_exhausted',
+      completed_at = NOW()
+  WHERE run_id = p_run_id
+    AND status = 'retryable'
+    AND attempt_count >= max_attempts;
+
+  GET DIAGNOSTICS v_exhausted = ROW_COUNT;
+
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'provider_accepted'),
+    COUNT(*) FILTER (WHERE status = 'failed'),
+    COUNT(*) FILTER (WHERE status = 'ambiguous'),
+    COUNT(*) FILTER (WHERE status = 'pending'),
+    COUNT(*) FILTER (WHERE status = 'claimed'),
+    COUNT(*) FILTER (WHERE status = 'retryable'),
+    COUNT(*) FILTER (WHERE status = 'skipped')
+  INTO v_total, v_accepted, v_failed, v_ambiguous, v_pending, v_claimed, v_retryable, v_skipped
+  FROM public.newsletter_recipient_deliveries
+  WHERE run_id = p_run_id;
+
+  -- Terminal: no pending, claimed, retryable, or ambiguous
+  IF v_pending = 0 AND v_claimed = 0 AND v_retryable = 0 AND v_ambiguous = 0 THEN
+    IF v_failed = 0 AND v_skipped = 0 THEN
+      v_new_status := 'completed';
+    ELSE
+      -- Has permanent failures or skips but all are terminal
+      v_new_status := 'completed';
+    END IF;
+  ELSIF v_pending = 0 AND v_claimed = 0 AND v_retryable = 0 AND v_ambiguous > 0 THEN
+    -- Ambiguous blocks full completion but no more work to do
+    v_new_status := 'partial';
+  ELSE
+    v_new_status := 'in_progress';
+  END IF;
+
+  UPDATE public.newsletter_delivery_runs
+  SET status = v_new_status,
+      accepted_count = v_accepted,
+      failed_count = v_failed,
+      ambiguous_count = v_ambiguous,
+      total_recipients = v_total,
+      completed_at = CASE WHEN v_new_status IN ('completed', 'partial') THEN NOW() ELSE NULL END
+  WHERE id = p_run_id;
+
+  RETURN json_build_object(
+    'run_id', p_run_id,
+    'status', v_new_status,
+    'total', v_total,
+    'accepted', v_accepted,
+    'failed', v_failed,
+    'ambiguous', v_ambiguous,
+    'retryable', v_retryable,
+    'skipped', v_skipped,
+    'pending', v_pending,
+    'claimed', v_claimed
+  );
+END;
+$$;
+
+-- Permissions for mark_delivery_outcome (6-arg hardened signature only)
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_delivery_outcome(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) TO service_role;
+
+-- Permissions for reconcile_delivery_run
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM anon;
+REVOKE ALL ON FUNCTION public.reconcile_delivery_run(UUID) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.reconcile_delivery_run(UUID) TO service_role;
+
+-- Index for retryable rows
+CREATE INDEX IF NOT EXISTS idx_recipient_deliveries_retryable
+  ON public.newsletter_recipient_deliveries (run_id, status, attempt_count)
+  WHERE status = 'retryable';
+
+COMMENT ON FUNCTION public.get_or_create_delivery_run IS 'Atomic insert-or-select for delivery runs. Never resets terminal state.';
+COMMENT ON FUNCTION public.snapshot_delivery_recipients IS 'Transactional atomic snapshot of all active subscribers. Immutable once completed.';
+COMMENT ON FUNCTION public.recover_stale_claims IS 'Marks stale claimed rows as ambiguous. Never auto-reclaims. Validates stale seconds.';
+COMMENT ON FUNCTION public.mark_delivery_outcome IS 'Record provider outcome for a claimed delivery. Requires exact worker match.';
+COMMENT ON FUNCTION public.reconcile_delivery_run IS 'Reconcile run status. Converts exhausted retries to terminal failed first.';


### PR DESCRIPTION
PR #111 분할 시리즈 **2/5**. base는 #112 (`pr/01-security-containment`) — **#112 머지 후에 리뷰/머지한다.**

- 전체 리뷰 결과: [`docs/PR111_REVIEW_2026-07-31.md`](docs/PR111_REVIEW_2026-07-31.md)
- 배포 절차: [`docs/deploy/02-newsletter-delivery.md`](docs/deploy/02-newsletter-delivery.md)

## 범위

COR-002/003/004/005 — 뉴스레터 발송 상태머신. 마이그레이션 `058`, `059`.

기존 발송은 "전 구독자에게 한 번에 뿌리고 성공/실패를 집계하지 않는" 구조라, 중간 실패 시
누가 받았는지 알 수 없고 재실행이 중복 발송을 일으켰다.

| 항목 | 내용 |
|---|---|
| run 생성/재개 | 원자적 RPC. `completed`/`failed` run은 절대 리셋하지 않음 |
| 수신자 스냅샷 | 서버 사이드 트랜잭셔널 `INSERT...SELECT`. 완료된 스냅샷은 불변 |
| stale claim | 자동 회수하지 않고 명시적으로 `ambiguous` 전환 (크래시한 워커가 이미 발송했을 수 있음) |
| 재시도 | `retryable`/`permanent` 분류 + `max_attempts` 상한. `ambiguous`는 자동 재시도 안 함 |
| 기록 | worker ID 대조 후에만 outcome 기록. 실패 상세는 고정 allowlist 코드만 저장 |
| 멱등 | 같은 날짜로 재실행 시 기존 run 결과를 반환하고 아무것도 발송하지 않음 |

발송 잡에서 Google Cloud 자격증명 설정을 제거했다 — 발송은 더 이상 콘텐츠 생성을 하지 않고,
준비된 `newsletter_content`만 읽는다.

## 리뷰에서 발견해 수정한 결함

### 배포 설정 오류가 `ambiguous`로 오분류되어 발송이 영구 정지 (High)

`sendSingleRecipient`는 provider를 호출하기 **전에** 두 번 throw할 수 있다.

- `initSendGrid()` — `SENDGRID_*` 누락 시
- 구독취소 토큰 생성 — `UNSUBSCRIBE_TOKEN_SECRET` 누락 또는 32자 미만 시

이 throw는 `sendAndMark`의 catch에 걸려 `ambiguous`로 기록된다. `ambiguous`는 "발송됐을 수도
있으니 함부로 재발송하지 않는다"는 뜻이라 **설계상 자동 재시도되지 않는다.**

즉 환경변수 하나 누락 = 전 수신자 `ambiguous` = 수동 DB 개입 없이는 복구 불가. 실제로는
네트워크에 나가지도 않았으므로 "확실히 발송 안 됨"인데 분류가 정반대였다.

`assertSendConfigured()`를 `executeDelivery` 진입점에 추가했다. 수신자를 하나도 claim하기 전에
깨끗하게 중단되고, 모든 행은 claimable 상태로 남아 설정을 고친 뒤 그대로 재개된다.

```
executeDelivery()
  validateOptions()
  assertSendConfigured()   ← 추가. 여기서 실패하면 DB를 건드리지 않는다
  loadUnsentNewsletter()
  getOrCreateRun()         ← 기존에는 여기까지 진행한 뒤 전 수신자가 ambiguous로 떨어졌다
```

### 정리

소비자가 0개인 `lib/delivery/index.ts` barrel export 제외 (conventions anti-pattern #3).
호출부는 모두 `@/lib/delivery/service`를 직접 import한다.

## 회귀 테스트

`lib/delivery/__tests__/delivery.test.ts`에 preflight 블록 추가:
- 발송 시크릿 3종 각각 누락 시 거부
- 토큰 시크릿 누락 / 32자 미만 시 거부
- 완전한 설정에서는 통과
- `executeDelivery`가 **RPC를 한 번도 호출하지 않고** 중단 (수신자 미claim 확인)

기존 상태머신 테스트에는 유효한 발송 설정을 주입하는 `beforeEach`를 추가했다.

## 범위 밖으로 뺀 것

`prepare-newsletter.ts`의 service-role 강제 / `process.exitCode` 전환 / provenance RPC 단언
3건은 제거했다. 해당 스크립트는 LLM/AI 파이프라인 PR(마이그레이션 `060`)에 속하며, 그 PR과 함께
돌아온다.

## 검증

- `tsc --noEmit`: 0 errors
- `eslint .`: 0 errors (기존 warning 23건, 신규 없음)
- `vitest run`: 3454/3454 pass (282 files)
- `next build --turbopack`: 성공

## 배포 주의

- **PR 1(`056b`, `057`) 적용 이후에만 진행한다.**
- `059`가 `058`의 5-인자 `mark_delivery_outcome` 오버로드를 `DROP` 하므로 두 파일은 반드시
  이 순서로 연속 적용한다.
- 적용 전 `newsletter_delivery_runs`에 `in_progress` run이 없어야 한다.
