### PR TITLE
fix(security): fail-closed 인증·이중 옵트인·토큰 기반 구독취소 (PR #111 Task 1/5)

### DIFF
--- a/.github/workflows/daily-newsletter.yml
+++ b/.github/workflows/daily-newsletter.yml
@@ -123,6 +123,9 @@ jobs:
           SENDGRID_FROM_EMAIL: ${{ secrets.SENDGRID_FROM_EMAIL }}
           SENDGRID_FROM_NAME: ${{ secrets.SENDGRID_FROM_NAME }}
 
+          # 발송 메일의 구독취소 링크 서명에 필요. 없으면 발송이 실패한다.
+          UNSUBSCRIBE_TOKEN_SECRET: ${{ secrets.UNSUBSCRIBE_TOKEN_SECRET }}
+
           # Twitter/X API
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
           TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}

--- a/app/__tests__/sitemap-failure-policy.test.ts
+++ b/app/__tests__/sitemap-failure-policy.test.ts
@@ -1,0 +1,75 @@
+/**
+ * sitemap 조회 실패 정책.
+ *
+ * 파일 상단 주석이 명시하듯, 빈 sitemap을 조용히 배포하면 색인이 유실된다.
+ * 따라서 프로덕션 배포에서는 조회 실패를 던져 빌드를 세운다.
+ * 반대로 preview·로컬은 Supabase 자격증명이 없어 항상 실패하므로, 같은 규칙을
+ * 적용하면 색인과 무관한 빌드가 전부 막힌다 — 그때만 부분 sitemap으로 물러난다.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getServerSupabaseClientMock } = vi.hoisted(() => ({
+  getServerSupabaseClientMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server-client', () => ({
+  getServerSupabaseClient: getServerSupabaseClientMock,
+}))
+
+const originalEnv = process.env
+
+/** 모든 조회가 자격증명 오류로 실패하는 클라이언트 */
+function failingClient() {
+  const failure = { data: null, error: { message: 'Invalid API key' } }
+  const chain: Record<string, unknown> = {}
+  chain.select = vi.fn().mockReturnValue(chain)
+  chain.eq = vi.fn().mockReturnValue(chain)
+  chain.order = vi.fn().mockReturnValue(chain)
+  chain.limit = vi.fn().mockResolvedValue(failure)
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(failure).then(resolve)
+  return { from: vi.fn().mockReturnValue(chain) }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  getServerSupabaseClientMock.mockReset().mockReturnValue(failingClient())
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  process.env = { ...originalEnv }
+})
+
+afterEach(() => {
+  process.env = originalEnv
+  vi.restoreAllMocks()
+})
+
+describe('sitemap 조회 실패 정책', () => {
+  it('프로덕션 배포에서는 실패를 던져 빈 sitemap 배포를 막는다', async () => {
+    process.env.VERCEL_ENV = 'production'
+    const { default: sitemap } = await import('@/app/sitemap')
+
+    await expect(sitemap()).rejects.toBeDefined()
+  })
+
+  it('preview 배포에서는 정적 페이지만 담은 부분 sitemap으로 물러난다', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    const { default: sitemap } = await import('@/app/sitemap')
+
+    const entries = await sitemap()
+
+    expect(entries.length).toBeGreaterThan(0)
+    // 정적 페이지는 남고, DB에서 오는 항목(테마 UUID·블로그 slug)만 빠진다
+    expect(entries.some((e) => e.url.endsWith('/themes'))).toBe(true)
+    expect(entries.some((e) => e.url.endsWith('/themes/methodology'))).toBe(true)
+    const themeDetail = /\/themes\/[0-9a-f]{8}-[0-9a-f]{4}-/i
+    expect(entries.some((e) => themeDetail.test(e.url))).toBe(false)
+    expect(entries.some((e) => e.url.includes('/blog/'))).toBe(false)
+  })
+
+  it('VERCEL_ENV가 없는 로컬 빌드에서도 물러난다', async () => {
+    delete process.env.VERCEL_ENV
+    const { default: sitemap } = await import('@/app/sitemap')
+
+    await expect(sitemap()).resolves.toBeInstanceOf(Array)
+  })
+})

--- a/app/__tests__/subscribe-pending.test.tsx
+++ b/app/__tests__/subscribe-pending.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { trackEventMock, useStateMock } = vi.hoisted(() => ({
+  trackEventMock: vi.fn(),
+  useStateMock: vi.fn(),
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+  return { ...actual, default: actual, useState: useStateMock }
+})
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+}))
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: (_target, tag) => tag }),
+}))
+vi.mock('@/components/animated-background', () => ({ default: () => null }))
+vi.mock('@/hooks/use-countdown-to-tomorrow', () => ({
+  useCountdownToTomorrow: () => ({ formatted: '내일' }),
+}))
+vi.mock('disposable-email-domains-js', () => ({ isDisposableEmail: () => false }))
+vi.mock('@/lib/analytics/ga', () => ({ trackEvent: trackEventMock }))
+
+import SubscribePage from '@/app/subscribe/page'
+
+let states: unknown[]
+let stateCursor: number
+
+function renderSubscribeForm(): React.ReactElement {
+  stateCursor = 0
+  const page = SubscribePage() as React.ReactElement<{ children: React.ReactElement }>
+  const subscribeContent = page.props.children
+  const subscribeForm = (subscribeContent.type as () => React.ReactElement)()
+  return (subscribeForm.type as () => React.ReactElement)()
+}
+
+function findElement(
+  node: unknown,
+  predicate: (element: React.ReactElement<Record<string, unknown>>) => boolean
+): React.ReactElement<Record<string, unknown>> | undefined {
+  if (!React.isValidElement<Record<string, unknown>>(node)) return undefined
+  if (predicate(node)) return node
+
+  return React.Children.toArray(node.props.children as React.ReactNode)
+    .map((child) => findElement(child, predicate))
+    .find(Boolean)
+}
+
+function textContent(node: unknown): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (!React.isValidElement<Record<string, unknown>>(node)) return ''
+  return React.Children.toArray(node.props.children as React.ReactNode).map(textContent).join('')
+}
+
+beforeEach(() => {
+  states = []
+  stateCursor = 0
+  useStateMock.mockImplementation((initialState: unknown) => {
+    const index = stateCursor++
+    if (!(index in states)) states[index] = initialState
+    return [states[index], (nextState: unknown) => { states[index] = nextState }]
+  })
+  trackEventMock.mockReset()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: 'pending' }), { status: 200 })
+    )
+  )
+})
+
+describe('subscribe form double opt-in', () => {
+  it('shows a confirmation-email instruction, not a completed-subscription message, for a pending response', async () => {
+    const initialTree = renderSubscribeForm()
+    const emailInput = findElement(initialTree, (element) => element.props.id === 'email')
+    const onEmailChange = emailInput?.props.onChange
+    if (typeof onEmailChange !== 'function') throw new Error('Email input not found')
+    onEmailChange({ target: { value: 'reader@example.com' } })
+
+    const submittedTree = renderSubscribeForm()
+    const form = findElement(submittedTree, (element) => element.type === 'form')
+    const onSubmit = form?.props.onSubmit
+    if (typeof onSubmit !== 'function') throw new Error('Subscription form not found')
+    await onSubmit({ preventDefault: vi.fn() })
+
+    const resultTree = renderSubscribeForm()
+    const message = textContent(resultTree)
+
+    expect(message).toContain('확인 이메일을 보냈습니다.')
+    expect(message).toContain('확인 링크를 눌러 구독을 확인해주세요.')
+    expect(message).not.toContain('구독이 완료되었습니다!')
+    expect(trackEventMock).toHaveBeenCalledWith('generate_lead', expect.objectContaining({
+      lead_type: 'pending_confirmation',
+    }))
+  })
+})

--- a/app/__tests__/subscribe-suspense.test.tsx
+++ b/app/__tests__/subscribe-suspense.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { useSearchParamsMock } = vi.hoisted(() => ({
+  useSearchParamsMock: vi.fn(() => {
+    throw new Error('useSearchParams must only run below the page Suspense boundary')
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: useSearchParamsMock,
+}))
+
+import SubscribePage from '@/app/subscribe/page'
+
+describe('subscribe page prerender contract', () => {
+  it('places the search-param consumer below an accessible Suspense boundary', () => {
+    const page = SubscribePage() as React.ReactElement<{
+      fallback: React.ReactElement<{ role?: string; 'aria-live'?: string }>
+    }>
+
+    expect(page.type).toBe(React.Suspense)
+    expect(page.props.fallback.props.role).toBe('status')
+    expect(page.props.fallback.props['aria-live']).toBe('polite')
+    expect(useSearchParamsMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/__tests__/subscription-lifecycle.test.ts
+++ b/app/api/__tests__/subscription-lifecycle.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for the double opt-in / opt-out lifecycle.
+ *
+ * Covers two defects found reviewing the original remediation batch:
+ * - a returning subscriber could never re-confirm, because the pending row kept
+ *   its previous confirmed_at and confirm_subscription then reported
+ *   'already_confirmed' while the subscriber stayed inactive.
+ * - a subscriber holding a legacy or expired link had no way to opt out at all.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, upsertMock, sendConfirmationMock, sendUnsubscribeLinkMock, maybeSingleMock } =
+  vi.hoisted(() => ({
+    createClientMock: vi.fn(),
+    upsertMock: vi.fn(),
+    sendConfirmationMock: vi.fn(),
+    sendUnsubscribeLinkMock: vi.fn(),
+    maybeSingleMock: vi.fn(),
+  }))
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
+vi.mock('@/lib/sendgrid', () => ({
+  sendSubscriptionConfirmation: sendConfirmationMock,
+  sendUnsubscribeLink: sendUnsubscribeLinkMock,
+}))
+vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 5, resetAt: 0 }),
+    getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  }
+})
+
+const originalEnv = process.env
+
+function jsonRequest(body: unknown): Request {
+  return new Request('https://stockmatrix.co.kr/api/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-real-ip': '203.0.113.5' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  upsertMock.mockReset().mockResolvedValue({ error: null })
+  sendConfirmationMock.mockReset().mockResolvedValue(undefined)
+  sendUnsubscribeLinkMock.mockReset().mockResolvedValue(undefined)
+  maybeSingleMock.mockReset().mockResolvedValue({ data: null, error: null })
+
+  createClientMock.mockReset().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      upsert: upsertMock,
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({ maybeSingle: maybeSingleMock }),
+          maybeSingle: maybeSingleMock,
+        }),
+      }),
+    }),
+  })
+
+  process.env = {
+    ...originalEnv,
+    NEXT_PUBLIC_SUPABASE_URL: 'https://lifecycle-test.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-key',
+    UNSUBSCRIBE_TOKEN_SECRET: 'u'.repeat(32),
+    RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32),
+  }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('POST /api/subscribe', () => {
+  it('clears confirmed_at so a returning subscriber can confirm again', async () => {
+    const { POST } = await import('@/app/api/subscribe/route')
+
+    const response = await POST(jsonRequest({ email: 'returning@example.com' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(upsertMock).toHaveBeenCalledTimes(1)
+
+    const [payload, options] = upsertMock.mock.calls[0]
+    expect(payload).toMatchObject({ email: 'returning@example.com', confirmed_at: null })
+    expect(options).toEqual({ onConflict: 'email' })
+  })
+})
+
+describe('POST /api/unsubscribe/request', () => {
+  it('mails a fresh link when the address is an active subscriber', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+
+    const response = await POST(jsonRequest({ email: 'active@example.com' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(sendUnsubscribeLinkMock).toHaveBeenCalledTimes(1)
+    const [recipient, token] = sendUnsubscribeLinkMock.mock.calls[0]
+    expect(recipient).toBe('active@example.com')
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(0)
+  })
+
+  it('does not mail unknown addresses but returns an identical response', async () => {
+    maybeSingleMock.mockResolvedValue({ data: null, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+
+    const response = await POST(jsonRequest({ email: 'stranger@example.com' }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(sendUnsubscribeLinkMock).not.toHaveBeenCalled()
+    expect(body).toEqual({
+      status: 'requested',
+      message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+    })
+  })
+
+  it('issues a token the unsubscribe endpoint accepts', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+    await POST(jsonRequest({ email: 'active@example.com' }) as never)
+
+    const [, token] = sendUnsubscribeLinkMock.mock.calls[0]
+    const { validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth')
+
+    expect(validateUnsubscribeToken(token)).toEqual({ valid: true, email: 'active@example.com' })
+  })
+})

--- a/app/api/__tests__/subscription-lifecycle.test.ts
+++ b/app/api/__tests__/subscription-lifecycle.test.ts
@@ -10,14 +10,21 @@
 
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createClientMock, upsertMock, sendConfirmationMock, sendUnsubscribeLinkMock, maybeSingleMock } =
-  vi.hoisted(() => ({
-    createClientMock: vi.fn(),
-    upsertMock: vi.fn(),
-    sendConfirmationMock: vi.fn(),
-    sendUnsubscribeLinkMock: vi.fn(),
-    maybeSingleMock: vi.fn(),
-  }))
+const {
+  createClientMock,
+  upsertMock,
+  sendConfirmationMock,
+  sendUnsubscribeLinkMock,
+  maybeSingleMock,
+  checkRateLimitMock,
+} = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  upsertMock: vi.fn(),
+  sendConfirmationMock: vi.fn(),
+  sendUnsubscribeLinkMock: vi.fn(),
+  maybeSingleMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+}))
 
 vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
 vi.mock('@/lib/sendgrid', () => ({
@@ -28,7 +35,7 @@ vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
   return {
     ...actual,
-    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 5, resetAt: 0 }),
+    checkRateLimit: checkRateLimitMock,
     getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
   }
 })
@@ -49,6 +56,8 @@ beforeEach(() => {
   sendConfirmationMock.mockReset().mockResolvedValue(undefined)
   sendUnsubscribeLinkMock.mockReset().mockResolvedValue(undefined)
   maybeSingleMock.mockReset().mockResolvedValue({ data: null, error: null })
+  // Reset per test: a leaked 'limited' implementation would silently skip sends
+  checkRateLimitMock.mockReset().mockResolvedValue({ status: 'allowed', remaining: 5, resetAt: 0 })
 
   createClientMock.mockReset().mockReturnValue({
     from: vi.fn().mockReturnValue({
@@ -114,6 +123,48 @@ describe('POST /api/unsubscribe/request', () => {
 
     expect(response.status).toBe(200)
     expect(sendUnsubscribeLinkMock).not.toHaveBeenCalled()
+    expect(body).toEqual({
+      status: 'requested',
+      message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+    })
+  })
+
+  it('returns the generic response even when the mail provider fails', async () => {
+    // A 500 only for subscribed addresses would turn a mail outage into a
+    // subscriber oracle.
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    sendUnsubscribeLinkMock.mockRejectedValue(new Error('provider down'))
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+    const response = await POST(jsonRequest({ email: 'active@example.com' }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({
+      status: 'requested',
+      message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('rate limits per address so rotating IPs cannot mail-bomb one subscriber', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { email: 'active@example.com' }, error: null })
+    // per-IP bucket allowed, per-address bucket limited
+    checkRateLimitMock.mockImplementation(async (_identity: string, config: { bucket: string }) =>
+      config.bucket === 'unsubscribe_request_email'
+        ? { status: 'limited', remaining: 0, resetAt: 0 }
+        : { status: 'allowed', remaining: 9, resetAt: 0 },
+    )
+
+    const { POST } = await import('@/app/api/unsubscribe/request/route')
+    const response = await POST(jsonRequest({ email: 'active@example.com' }) as never)
+    const body = await response.json()
+
+    expect(sendUnsubscribeLinkMock).not.toHaveBeenCalled()
+    // Identical to the success body — a distinct 429 would confirm the address is subscribed
+    expect(response.status).toBe(200)
     expect(body).toEqual({
       status: 'requested',
       message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',

--- a/app/api/stock/__tests__/price-cache-wiring.test.ts
+++ b/app/api/stock/__tests__/price-cache-wiring.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for the server-side price cache.
+ *
+ * Migration 056b revokes anonymous writes to stock_price_cache, so the browser
+ * can no longer populate it. This route became the only writer — if it stops
+ * reading and writing the cache, the table stays permanently empty and every
+ * request falls through to KIS.
+ */
+
+import { NextRequest } from 'next/server'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getBatchStockPricesMock, getCacheMock, saveCacheMock } = vi.hoisted(() => ({
+  getBatchStockPricesMock: vi.fn(),
+  getCacheMock: vi.fn(),
+  saveCacheMock: vi.fn(),
+}))
+
+vi.mock('@/app/archive/_utils/api/kis/client', () => ({
+  getBatchStockPrices: getBatchStockPricesMock,
+}))
+vi.mock('@/app/archive/_utils/cache/stock-price', () => ({
+  getBatchPricesFromCache: getCacheMock,
+  saveBatchPricesToCache: saveCacheMock,
+}))
+vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 30, resetAt: 0 }),
+    getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  }
+})
+
+const originalEnv = process.env
+
+function priceRequest(tickers: string): NextRequest {
+  return new NextRequest(`https://stockmatrix.co.kr/api/stock/price?tickers=${tickers}`, {
+    headers: { 'x-real-ip': '203.0.113.5' },
+  })
+}
+
+function livePrice(ticker: string) {
+  return {
+    ticker,
+    currentPrice: 70000,
+    previousClose: 69000,
+    changeRate: 1.45,
+    volume: 1_000_000,
+    timestamp: 1_800_000_000,
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  getCacheMock.mockReset().mockResolvedValue(new Map())
+  saveCacheMock.mockReset().mockResolvedValue(undefined)
+  getBatchStockPricesMock.mockReset().mockResolvedValue({
+    prices: new Map(),
+    failures: new Map<string, string>(),
+  })
+  process.env = { ...originalEnv, RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32) }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('GET /api/stock/price cache wiring', () => {
+  it('only asks KIS for tickers the cache missed', async () => {
+    getCacheMock.mockResolvedValue(
+      new Map([['005930', { ...livePrice('005930'), expires_at: 1_900_000_000 }]])
+    )
+    getBatchStockPricesMock.mockResolvedValue({
+      prices: new Map([['035720', livePrice('035720')]]),
+      failures: new Map<string, string>(),
+    })
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    const response = await GET(priceRequest('005930,035720'))
+    const body = await response.json()
+
+    expect(getBatchStockPricesMock).toHaveBeenCalledWith(['035720'])
+    expect(Object.keys(body.prices).sort()).toEqual(['005930', '035720'])
+    expect(body.meta.success).toBe(2)
+  })
+
+  it('writes freshly fetched prices back to the cache', async () => {
+    getBatchStockPricesMock.mockResolvedValue({
+      prices: new Map([['005930', livePrice('005930')]]),
+      failures: new Map<string, string>(),
+    })
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    await GET(priceRequest('005930'))
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(1)
+    const [rows] = saveCacheMock.mock.calls[0]
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ ticker: '005930', currentPrice: 70000 })
+    expect(typeof rows[0].expires_at).toBe('number')
+  })
+
+  it('skips the KIS call entirely when every ticker is cached', async () => {
+    getCacheMock.mockResolvedValue(
+      new Map([['005930', { ...livePrice('005930'), expires_at: 1_900_000_000 }]])
+    )
+
+    const { GET } = await import('@/app/api/stock/price/route')
+    const response = await GET(priceRequest('005930'))
+    const body = await response.json()
+
+    expect(getBatchStockPricesMock).not.toHaveBeenCalled()
+    expect(saveCacheMock).not.toHaveBeenCalled()
+    // expires_at is an internal cache field and must not leak into the response
+    expect(body.prices['005930']).not.toHaveProperty('expires_at')
+  })
+})

--- a/app/api/stock/__tests__/price-ticker-validation.test.ts
+++ b/app/api/stock/__tests__/price-ticker-validation.test.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getBatchStockPricesMock,
+  getBatchDailyClosePricesMock,
+  getCacheMock,
+  saveCacheMock,
+} = vi.hoisted(() => ({
+  getBatchStockPricesMock: vi.fn(),
+  getBatchDailyClosePricesMock: vi.fn(),
+  getCacheMock: vi.fn(),
+  saveCacheMock: vi.fn(),
+}))
+
+vi.mock('@/app/archive/_utils/api/kis/client', () => ({
+  getBatchStockPrices: getBatchStockPricesMock,
+  getBatchDailyClosePrices: getBatchDailyClosePricesMock,
+}))
+vi.mock('@/app/archive/_utils/cache/stock-price', () => ({
+  getBatchPricesFromCache: getCacheMock,
+  saveBatchPricesToCache: saveCacheMock,
+}))
+vi.mock('@/lib/security/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/security/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ status: 'allowed', remaining: 30, resetAt: 0 }),
+    getTrustedClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  }
+})
+
+function request(path: string): NextRequest {
+  return new NextRequest(`https://stockmatrix.co.kr${path}`, {
+    headers: { 'x-real-ip': '203.0.113.5' },
+  })
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  getCacheMock.mockReset().mockResolvedValue(new Map())
+  saveCacheMock.mockReset().mockResolvedValue(undefined)
+  getBatchStockPricesMock.mockReset().mockResolvedValue({
+    prices: new Map(),
+    failures: new Map<string, string>(),
+  })
+  getBatchDailyClosePricesMock.mockReset().mockResolvedValue(new Map())
+})
+
+describe('GET /api/stock/price ticker validation', () => {
+  it.each(['KOSPI:005930', '005930'])('accepts %s', async (ticker) => {
+    const { GET } = await import('@/app/api/stock/price/route')
+
+    const response = await GET(request(`/api/stock/price?tickers=${ticker}`))
+
+    expect(response.status).toBe(200)
+    expect(getBatchStockPricesMock).toHaveBeenCalledWith([ticker])
+  })
+
+  it('accepts the archive exchange-prefixed ticker that daily-close accepts', async () => {
+    const ticker = 'KOSPI:005930'
+    const { GET: getPrice } = await import('@/app/api/stock/price/route')
+    const { GET: getDailyClose } = await import('@/app/api/stock/daily-close/route')
+
+    const priceResponse = await getPrice(request(`/api/stock/price?tickers=${ticker}`))
+    const dailyCloseResponse = await getDailyClose(
+      request(`/api/stock/daily-close?tickers=${ticker}&date=20250101`)
+    )
+
+    expect(priceResponse.status).toBe(200)
+    expect(dailyCloseResponse.status).toBe(200)
+    expect(getBatchDailyClosePricesMock).toHaveBeenCalledWith([ticker], '20250101')
+  })
+
+  it.each(['', ':005930', 'KOSPI:', 'KOSPI:005930:X', '005930;DROP TABLE', '삼성전자'])(
+    'rejects malformed ticker %j',
+    async (ticker) => {
+      const { GET } = await import('@/app/api/stock/price/route')
+      const response = await GET(request(`/api/stock/price?tickers=${encodeURIComponent(ticker)}`))
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      if (ticker) {
+        expect(body.error).toContain('005930')
+        expect(body.error).toContain('KOSPI:005930')
+      }
+      expect(getBatchStockPricesMock).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/app/api/stock/daily-close/route.ts
+++ b/app/api/stock/daily-close/route.ts
@@ -1,18 +1,98 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBatchDailyClosePrices } from '@/app/archive/_utils/api/kis/client';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
 
-/** GET /api/stock/daily-close?tickers=KOSPI:005930&date=20241220 */
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/stock/daily-close?tickers=KOSPI:005930&date=20241220
+ *
+ * Strict validation:
+ * - Tickers: EXCHANGE:TICKER format (e.g. KOSPI:005930), max 10
+ * - Date: YYYYMMDD, must be a real calendar date within valid range (2020-01-01 to tomorrow)
+ */
+
+const TICKER_WITH_EXCHANGE_PATTERN = /^[A-Z]{2,10}:[0-9A-Za-z]{1,10}$/;
+const DATE_PATTERN = /^\d{8}$/;
+
+/** Days in each month (non-leap year) */
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Validate a date string as a real calendar date.
+ * Rejects Feb 30, Apr 31, etc.
+ */
+function isValidCalendarDate(dateStr: string): boolean {
+  if (!DATE_PATTERN.test(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  if (year < 2020 || year > 2100) return false;
+  if (month < 1 || month > 12) return false;
+
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  if (day < 1 || day > maxDay) return false;
+
+  // Check it's not in the far future (next day at most)
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(23, 59, 59, 999);
+  const inputDate = new Date(year, month - 1, day);
+  return inputDate <= tomorrow;
+}
+
 export async function GET(req: NextRequest) {
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(req.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.dailyClose);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { success: false, error: 'Rate limit exceeded' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { success: false, error: 'Service temporarily unavailable' },
+      { status: 503 }
+    );
+  }
+
   try {
     const tickers = req.nextUrl.searchParams.get('tickers')?.split(',').map((t) => t.trim()).filter(Boolean);
     const date = req.nextUrl.searchParams.get('date');
+
     if (!tickers?.length || tickers.length > 10 || !date) {
-      return NextResponse.json({ success: false, error: 'Invalid params' }, { status: 400 });
+      return NextResponse.json({ success: false, error: 'Invalid params: tickers (max 10) and date required' }, { status: 400 });
     }
-    return NextResponse.json({ success: true, prices: Object.fromEntries(await getBatchDailyClosePrices(tickers, date)) });
+
+    // Strict ticker format validation
+    const invalidTickers = tickers.filter((t) => !TICKER_WITH_EXCHANGE_PATTERN.test(t));
+    if (invalidTickers.length > 0) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid ticker format. Expected EXCHANGE:TICKER (e.g. KOSPI:005930)' },
+        { status: 400 }
+      );
+    }
+
+    // Strict date validation (real calendar date)
+    if (!isValidCalendarDate(date)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid date. Expected YYYYMMDD, a real calendar date within valid range (2020-present)' },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      prices: Object.fromEntries(await getBatchDailyClosePrices(tickers, date)),
+    });
   } catch {
-    return NextResponse.json({ success: false, error: 'Failed' }, { status: 500 });
+    return NextResponse.json({ success: false, error: 'Failed to fetch daily close prices' }, { status: 500 });
   }
 }
-
-export const runtime = 'nodejs';

--- a/app/api/stock/price/route.ts
+++ b/app/api/stock/price/route.ts
@@ -5,14 +5,15 @@ import type { StockPriceCache } from '@/app/archive/_utils/cache/types';
 import { getStockPriceCacheExpiry } from '@/app/archive/_utils/market/hours';
 import { getBatchPricesFromCache, saveBatchPricesToCache } from '@/app/archive/_utils/cache/stock-price';
 import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
-import { isValidTicker, MAX_TICKERS_PER_REQUEST } from '@/lib/security/validators';
+import { isValidExchangeTicker, isValidTicker, MAX_TICKERS_PER_REQUEST } from '@/lib/security/validators';
 
 /**
  * 주식 현재가 조회 API
  * GET /api/stock/price?tickers=005930,035720
  *
  * Validation:
- * - Tickers must be Korean stock format (6-digit numeric) or alphanumeric up to 10 chars
+ * - Tickers must be Korean stock format (6-digit numeric), alphanumeric up to 10 chars,
+ *   or exchange-prefixed (e.g. KOSPI:005930)
  * - Max 10 tickers per request
  * - Distributed rate limiting via Supabase
  *
@@ -81,12 +82,14 @@ export async function GET(request: NextRequest) {
     }
 
     // Strict ticker format validation
-    const invalidTickers = tickers.filter((t) => !isValidTicker(t));
+    const invalidTickers = tickers.filter(
+      (ticker) => !isValidTicker(ticker) && !isValidExchangeTicker(ticker)
+    );
     if (invalidTickers.length > 0) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Invalid ticker format. Korean tickers must be 6 digits (e.g. 005930).',
+          error: 'Invalid ticker format. Use a ticker without an exchange prefix (e.g. 005930) or EXCHANGE:TICKER (e.g. KOSPI:005930).',
           invalid: invalidTickers,
         },
         { status: 400 }

--- a/app/api/stock/price/route.ts
+++ b/app/api/stock/price/route.ts
@@ -1,36 +1,60 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBatchStockPrices } from '@/app/archive/_utils/api/kis/client';
+import type { KisStockPrice } from '@/app/archive/_utils/api/kis/types';
+import type { StockPriceCache } from '@/app/archive/_utils/cache/types';
+import { getStockPriceCacheExpiry } from '@/app/archive/_utils/market/hours';
+import { getBatchPricesFromCache, saveBatchPricesToCache } from '@/app/archive/_utils/cache/stock-price';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { isValidTicker, MAX_TICKERS_PER_REQUEST } from '@/lib/security/validators';
 
 /**
  * 주식 현재가 조회 API
- * GET /api/stock/price?tickers=AAPL,GOOGL,MSFT
+ * GET /api/stock/price?tickers=005930,035720
  *
- * 프로덕션급 엔터프라이즈 API 엔드포인트
- * - 입력 검증 및 sanitization
- * - 에러 핸들링 및 상세 로깅
- * - Rate limiting 보호
- * - 캐싱 전략 적용
+ * Validation:
+ * - Tickers must be Korean stock format (6-digit numeric) or alphanumeric up to 10 chars
+ * - Max 10 tickers per request
+ * - Distributed rate limiting via Supabase
+ *
+ * Caching: the Supabase price cache is read/written with the service role here.
+ * The browser never touches the cache table (SEC-005), so this route is the only
+ * writer that keeps it warm — without it the table stays empty and every request
+ * would hit KIS directly.
  */
+
+type PriceResponseEntry = KisStockPrice | Omit<StockPriceCache, 'expires_at'>;
+
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
+
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.stockPrice);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { success: false, error: 'Rate limit exceeded. Try again later.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { success: false, error: 'Service temporarily unavailable.' },
+      { status: 503 }
+    );
+  }
 
   try {
     const searchParams = request.nextUrl.searchParams;
     const tickersParam = searchParams.get('tickers');
 
-    // 입력 검증
-    if (!tickersParam) {
+    if (!tickersParam || tickersParam.trim().length === 0) {
       return NextResponse.json(
-        {
-          success: false,
-          error: 'tickers parameter is required',
-          message: 'Please provide tickers as comma-separated values',
-        },
+        { success: false, error: 'tickers parameter is required' },
         { status: 400 }
       );
     }
 
-    // 티커 파싱 및 sanitization
+    // 티커 파싱 및 strict validation
     const tickers = tickersParam
       .split(',')
       .map((t) => t.trim())
@@ -38,38 +62,74 @@ export async function GET(request: NextRequest) {
 
     if (tickers.length === 0) {
       return NextResponse.json(
-        {
-          success: false,
-          error: 'At least one valid ticker is required',
-          message: 'Tickers must be non-empty strings',
-        },
+        { success: false, error: 'At least one valid ticker is required' },
         { status: 400 }
       );
     }
 
-    // 최대 10개로 제한 (API 호출 최적화 및 rate limiting 보호)
-    if (tickers.length > 10) {
+    // 최대 10개로 제한
+    if (tickers.length > MAX_TICKERS_PER_REQUEST) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Maximum 10 tickers allowed per request',
-          message: 'Please split your request into multiple calls',
+          error: `Maximum ${MAX_TICKERS_PER_REQUEST} tickers allowed per request`,
           requested: tickers.length,
-          max: 10,
+          max: MAX_TICKERS_PER_REQUEST,
         },
         { status: 400 }
       );
     }
 
-    // KIS API 호출
-    const result = await getBatchStockPrices(tickers);
+    // Strict ticker format validation
+    const invalidTickers = tickers.filter((t) => !isValidTicker(t));
+    if (invalidTickers.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid ticker format. Korean tickers must be 6 digits (e.g. 005930).',
+          invalid: invalidTickers,
+        },
+        { status: 400 }
+      );
+    }
 
-    const successCount = result.prices.size;
-    const failedCount = result.failures.size;
+    // 캐시 우선 조회 — 미스인 티커만 KIS로 넘긴다
+    const cached = await getBatchPricesFromCache(tickers);
+    const uncachedTickers = tickers.filter((ticker) => !cached.has(ticker));
 
-    // Map을 객체로 변환
-    const pricesObject = Object.fromEntries(result.prices);
-    const failuresObject = Object.fromEntries(result.failures);
+    const fetched = uncachedTickers.length > 0
+      ? await getBatchStockPrices(uncachedTickers)
+      : { prices: new Map<string, KisStockPrice>(), failures: new Map<string, string>() };
+
+    if (fetched.prices.size > 0) {
+      const expiresAt = getStockPriceCacheExpiry();
+      await saveBatchPricesToCache(
+        [...fetched.prices.values()].map((price) => ({
+          ticker: price.ticker,
+          currentPrice: price.currentPrice,
+          previousClose: price.previousClose,
+          changeRate: price.changeRate,
+          volume: price.volume,
+          timestamp: price.timestamp,
+          expires_at: expiresAt,
+        }))
+      );
+    }
+
+    // expires_at은 캐시 내부 필드이므로 응답 형태를 균일하게 유지하기 위해 제외한다
+    const merged = new Map<string, PriceResponseEntry>();
+    for (const [ticker, { expires_at: _expiresAt, ...price }] of cached) {
+      merged.set(ticker, price);
+    }
+    for (const [ticker, price] of fetched.prices) {
+      merged.set(ticker, price);
+    }
+
+    const successCount = merged.size;
+    const failedCount = fetched.failures.size;
+
+    const pricesObject = Object.fromEntries(merged);
+    const failuresObject = Object.fromEntries(fetched.failures);
 
     const duration = Date.now() - startTime;
 
@@ -78,17 +138,15 @@ export async function GET(request: NextRequest) {
         success: true,
         prices: pricesObject,
         failures: failedCount > 0 ? failuresObject : undefined,
-        metadata: {
-          requested: tickers.length,
+        meta: {
+          total: tickers.length,
           success: successCount,
           failed: failedCount,
           duration_ms: duration,
-          timestamp: new Date().toISOString(),
         },
       },
       {
         headers: {
-          // 1분 캐싱 (Vercel Edge에서도 캐싱)
           'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
           'X-Response-Time': `${duration}ms`,
         },
@@ -97,50 +155,21 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     const duration = Date.now() - startTime;
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    const errorName = error instanceof Error ? error.name : 'Error';
 
-    console.error('[API] Stock price API error:', {
-      name: errorName,
-      message: errorMessage,
-      duration_ms: duration,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-
-    // 프로덕션에서는 민감한 정보 숨김
-    const isProduction = process.env.NODE_ENV === 'production';
+    console.error('[stock/price] API error:', errorMessage);
 
     return NextResponse.json(
       {
         success: false,
         error: 'Failed to fetch stock prices',
-        message: isProduction
-          ? 'An error occurred while fetching stock prices. Please try again later.'
-          : errorMessage,
-        details: !isProduction
-          ? {
-              name: errorName,
-              message: errorMessage,
-            }
-          : undefined,
+        message: 'An error occurred while fetching stock prices. Please try again later.',
       },
       {
         status: 500,
-        headers: {
-          'X-Response-Time': `${duration}ms`,
-        },
+        headers: { 'X-Response-Time': `${duration}ms` },
       }
     );
   }
 }
 
-// Route segment config for Vercel
-export const runtime = 'nodejs'; // KIS API는 Node.js runtime 필요
-
-// 🔧 캐싱 전략:
-// - force-dynamic 제거: Cache-Control 헤더가 제대로 작동하도록 함
-// - 장 중: 1분 캐싱 (실시간성 유지)
-// - 장 마감 후: Supabase 캐시가 다음 영업일 09:00까지 유지됨
-// - CDN 캐싱: s-maxage=60으로 Vercel Edge에서 1분간 캐시
-
-// Rate limiting은 Vercel Pro 이상에서 자동 적용됨
-// 무료 플랜에서는 애플리케이션 레벨에서 관리
+export const runtime = 'nodejs';

--- a/app/api/stock/price/route.ts
+++ b/app/api/stock/price/route.ts
@@ -118,8 +118,15 @@ export async function GET(request: NextRequest) {
 
     // expires_at은 캐시 내부 필드이므로 응답 형태를 균일하게 유지하기 위해 제외한다
     const merged = new Map<string, PriceResponseEntry>();
-    for (const [ticker, { expires_at: _expiresAt, ...price }] of cached) {
-      merged.set(ticker, price);
+    for (const [ticker, cachedPrice] of cached) {
+      merged.set(ticker, {
+        ticker: cachedPrice.ticker,
+        currentPrice: cachedPrice.currentPrice,
+        previousClose: cachedPrice.previousClose,
+        changeRate: cachedPrice.changeRate,
+        volume: cachedPrice.volume,
+        timestamp: cachedPrice.timestamp,
+      });
     }
     for (const [ticker, price] of fetched.prices) {
       merged.set(ticker, price);

--- a/app/api/subscribe/confirm/route.ts
+++ b/app/api/subscribe/confirm/route.ts
@@ -58,6 +58,14 @@ export async function POST(request: NextRequest) {
   // Validate token (AEAD decrypt, purpose=confirm)
   const tokenResult = validateConfirmToken(token);
   if (!tokenResult.valid || !tokenResult.email) {
+    // 'no_secret' is a server misconfiguration, not a bad link. Falling through to
+    // the 400 below told every user their link was invalid while the real cause was
+    // an unset token secret — the same class of error the SUPABASE_SERVICE_ROLE_KEY
+    // check below already reports as a 5xx.
+    if (tokenResult.error === 'no_secret') {
+      console.error('[subscribe/confirm] token secret not configured');
+      return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 503 });
+    }
     const status = tokenResult.error === 'expired' ? 410 : 400;
     const message = tokenResult.error === 'expired'
       ? '확인 링크가 만료되었습니다. 다시 구독 신청해주세요.'

--- a/app/api/subscribe/confirm/route.ts
+++ b/app/api/subscribe/confirm/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { validateConfirmToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+
+/**
+ * POST /api/subscribe/confirm
+ *
+ * Confirms a subscription via opaque token.
+ * POST-only: confirmation must NOT mutate on GET.
+ * Uses transactional confirm_subscription RPC.
+ */
+
+const confirmSchema = z.object({
+  token: z.string().min(1, '토큰이 필요합니다'),
+});
+
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function POST(request: NextRequest) {
+  // Rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.subscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
+  }
+
+  const parsed = confirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: '유효하지 않은 확인 요청입니다.' }, { status: 400 });
+  }
+
+  const { token } = parsed.data;
+
+  // Validate token (AEAD decrypt, purpose=confirm)
+  const tokenResult = validateConfirmToken(token);
+  if (!tokenResult.valid || !tokenResult.email) {
+    const status = tokenResult.error === 'expired' ? 410 : 400;
+    const message = tokenResult.error === 'expired'
+      ? '확인 링크가 만료되었습니다. 다시 구독 신청해주세요.'
+      : '유효하지 않은 확인 링크입니다.';
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[subscribe/confirm] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
+
+  const tokenHash = createHash('sha256').update(token).digest('hex');
+
+  // Use transactional RPC (locks row, verifies, activates atomically)
+  const { data, error } = await supabase.rpc('confirm_subscription', {
+    p_token_hash: tokenHash,
+    p_email: tokenResult.email,
+  });
+
+  if (error) {
+    console.error('[subscribe/confirm] RPC error:', error.message);
+    return NextResponse.json({ error: '확인 처리 중 오류가 발생했습니다.' }, { status: 500 });
+  }
+
+  const result = data as { success: boolean; error?: string } | null;
+  if (!result || !result.success) {
+    const rpcError = result?.error;
+    if (rpcError === 'expired') {
+      return NextResponse.json({ error: '확인 링크가 만료되었습니다.' }, { status: 410 });
+    }
+    if (rpcError === 'already_confirmed') {
+      return NextResponse.json({ status: 'confirmed', message: '이미 확인된 구독입니다.' });
+    }
+    return NextResponse.json({ error: '유효하지 않거나 이미 확인된 요청입니다.' }, { status: 400 });
+  }
+
+  return NextResponse.json({ status: 'confirmed', message: '구독이 확인되었습니다!' });
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { isDisposableEmail } from 'disposable-email-domains-js';
-import { getServerSupabaseClient } from '@/lib/supabase/server-client';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { generateConfirmToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { sendSubscriptionConfirmation } from '@/lib/sendgrid';
 
 const subscribeSchema = z.object({
   email: z
@@ -13,7 +17,34 @@ const subscribeSchema = z.object({
   name: z.string().max(100, '이름 길이 제한 초과').optional(),
 });
 
+/**
+ * Get a service-role Supabase client.
+ * Fail-closed: returns null if service role key is not configured.
+ */
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
 export async function POST(request: NextRequest) {
+  // Rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.subscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -26,42 +57,67 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
 
-  const { email, name } = parsed.data;
-  const supabase = getServerSupabaseClient();
+  // Normalize email (lowercase, trim)
+  const email = parsed.data.email.toLowerCase().trim();
+  const name = parsed.data.name?.trim() || null;
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[subscribe] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
 
   try {
-    const { data: existing } = await supabase
-      .from('subscribers')
-      .select('name')
-      .eq('email', email)
-      .maybeSingle();
+    // Generate a confirmation token (opaque, AEAD encrypted)
+    const confirmToken = generateConfirmToken(email);
+    const tokenHash = createHash('sha256').update(confirmToken).digest('hex');
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
-    if (existing) {
-      const { error: updateError } = await supabase
-        .from('subscribers')
-        .update({ is_active: true, name: name || existing.name })
-        .eq('email', email);
+    // Upsert pending subscriber.
+    // confirmed_at MUST be reset: a returning subscriber (previously confirmed,
+    // then unsubscribed) would otherwise keep the old confirmed_at, and
+    // confirm_subscription would reject the fresh token as 'already_confirmed' —
+    // leaving them permanently unable to re-subscribe.
+    const { error: upsertError } = await supabase
+      .from('pending_subscribers')
+      .upsert(
+        { email, name, confirm_token_hash: tokenHash, expires_at: expiresAt, confirmed_at: null },
+        { onConflict: 'email' }
+      );
 
-      if (updateError) {
-        console.error('Resubscribe error:', updateError);
-        return NextResponse.json({ error: '구독 처리 중 오류가 발생했습니다. 다시 시도해주세요.' }, { status: 500 });
-      }
-
-      return NextResponse.json({ status: 'resubscribed' });
+    if (upsertError) {
+      console.error('[subscribe] pending upsert error:', upsertError.message);
+      return NextResponse.json(
+        { error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
+        { status: 500 }
+      );
     }
 
-    const { error: insertError } = await supabase
-      .from('subscribers')
-      .insert({ email, name: name || null });
+    // Send confirmation email
+    try {
+      await sendSubscriptionConfirmation(email, confirmToken);
+    } catch (sendError) {
+      // Clean up the pending row if sending fails
+      console.error('[subscribe] email send failed:', sendError instanceof Error ? sendError.message : 'unknown');
+      await supabase
+        .from('pending_subscribers')
+        .delete()
+        .eq('email', email)
+        .is('confirmed_at', null);
 
-    if (insertError) {
-      console.error('Subscribe error:', insertError);
-      return NextResponse.json({ error: '구독 처리 중 오류가 발생했습니다. 다시 시도해주세요.' }, { status: 500 });
+      return NextResponse.json(
+        { error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
+        { status: 500 }
+      );
     }
 
-    return NextResponse.json({ status: 'subscribed' });
+    // Always return same response to prevent account enumeration
+    return NextResponse.json({
+      status: 'pending',
+      message: '확인 이메일을 발송했습니다. 이메일을 확인해주세요.',
+    });
   } catch (error) {
-    console.error('Subscribe error:', error);
+    console.error('[subscribe] unexpected error:', error instanceof Error ? error.message : 'unknown');
     return NextResponse.json({ error: '시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' }, { status: 500 });
   }
 }

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -97,12 +97,17 @@ export async function POST(request: NextRequest) {
     try {
       await sendSubscriptionConfirmation(email, confirmToken);
     } catch (sendError) {
-      // Clean up the pending row if sending fails
+      // Clean up the pending row if sending fails.
+      // Scoped to this request's own token: two concurrent subscribes for the same
+      // address both upsert the single row, and without the hash predicate the one
+      // whose send failed would delete the row the other had already mailed a
+      // working link for.
       console.error('[subscribe] email send failed:', sendError instanceof Error ? sendError.message : 'unknown');
       await supabase
         .from('pending_subscribers')
         .delete()
         .eq('email', email)
+        .eq('confirm_token_hash', tokenHash)
         .is('confirmed_at', null);
 
       return NextResponse.json(

--- a/app/api/unsubscribe/request/route.ts
+++ b/app/api/unsubscribe/request/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
+import { generateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
+import { sendUnsubscribeLink } from '@/lib/sendgrid';
+
+/**
+ * POST /api/unsubscribe/request
+ *
+ * Mails a fresh opaque unsubscribe token to the address supplied by the user.
+ *
+ * This is the recovery path for links that predate opaque tokens (`?email=`) and
+ * for tokens that have expired. It never unsubscribes on its own — the mailed
+ * link still goes through the normal confirm step — so an unauthenticated caller
+ * cannot opt someone else out.
+ *
+ * The response is identical whether or not the address is subscribed, so this
+ * endpoint cannot be used to enumerate subscribers.
+ */
+
+const requestSchema = z.object({
+  email: z
+    .string()
+    .min(1, '이메일을 입력해주세요')
+    .max(255, '이메일 길이 제한 초과')
+    .pipe(z.email({ message: '잘못된 이메일 형식' })),
+});
+
+const GENERIC_RESPONSE = {
+  status: 'requested',
+  message: '해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.',
+} as const;
+
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function POST(request: NextRequest) {
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.unsubscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+
+  const email = parsed.data.email.toLowerCase().trim();
+
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[unsubscribe/request] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
+
+  try {
+    // Only mail addresses that are actually subscribed — otherwise this endpoint
+    // becomes an open relay for sending mail to arbitrary addresses.
+    const { data: subscriber, error } = await supabase
+      .from('subscribers')
+      .select('email')
+      .eq('email', email)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[unsubscribe/request] db error');
+      return NextResponse.json({ error: '요청 처리 중 오류가 발생했습니다.' }, { status: 500 });
+    }
+
+    if (subscriber) {
+      await sendUnsubscribeLink(email, generateUnsubscribeToken(email));
+    }
+
+    return NextResponse.json(GENERIC_RESPONSE);
+  } catch (err) {
+    console.error(
+      '[unsubscribe/request] unexpected error:',
+      err instanceof Error ? err.message : 'unknown'
+    );
+    return NextResponse.json({ error: '시스템 오류가 발생했습니다.' }, { status: 500 });
+  }
+}

--- a/app/api/unsubscribe/request/route.ts
+++ b/app/api/unsubscribe/request/route.ts
@@ -90,6 +90,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(GENERIC_RESPONSE);
   }
 
+  // Minted before the subscriber lookup on purpose. generateUnsubscribeToken throws
+  // fail-closed when UNSUBSCRIBE_TOKEN_SECRET is unset, and inside the `if (subscriber)`
+  // block below that throw was caught by the send-failure handler and reported as the
+  // generic success body — leaving the endpoint permanently inert with no signal.
+  // Minting here makes a misconfiguration answer 503 for every address alike, so it
+  // still reveals nothing about who is subscribed.
+  let unsubscribeToken: string;
+  try {
+    unsubscribeToken = generateUnsubscribeToken(email);
+  } catch (tokenError) {
+    console.error(
+      '[unsubscribe/request] token secret not configured:',
+      tokenError instanceof Error ? tokenError.message : 'unknown'
+    );
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
   try {
     // Only mail addresses that are actually subscribed — otherwise this endpoint
     // becomes an open relay for sending mail to arbitrary addresses.
@@ -107,7 +127,7 @@ export async function POST(request: NextRequest) {
 
     if (subscriber) {
       try {
-        await sendUnsubscribeLink(email, generateUnsubscribeToken(email));
+        await sendUnsubscribeLink(email, unsubscribeToken);
       } catch (sendError) {
         // Must not surface as a distinct status: a 500 only for subscribed
         // addresses would turn a mail outage into a subscriber oracle.

--- a/app/api/unsubscribe/request/route.ts
+++ b/app/api/unsubscribe/request/route.ts
@@ -75,6 +75,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
   }
 
+  // Per-address limit on top of the per-IP limit. Every allowed request sends real
+  // mail, so a per-IP limit alone lets rotating IPs mail-bomb one subscriber.
+  const perEmailResult = await checkRateLimit(email, RATE_LIMITS.unsubscribeRequestEmail);
+  if (perEmailResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+  if (perEmailResult.status === 'limited') {
+    // Deliberately the success body: a distinct 429 here would confirm the
+    // address is subscribed, which is exactly what the generic response hides.
+    return NextResponse.json(GENERIC_RESPONSE);
+  }
+
   try {
     // Only mail addresses that are actually subscribed — otherwise this endpoint
     // becomes an open relay for sending mail to arbitrary addresses.
@@ -91,7 +106,16 @@ export async function POST(request: NextRequest) {
     }
 
     if (subscriber) {
-      await sendUnsubscribeLink(email, generateUnsubscribeToken(email));
+      try {
+        await sendUnsubscribeLink(email, generateUnsubscribeToken(email));
+      } catch (sendError) {
+        // Must not surface as a distinct status: a 500 only for subscribed
+        // addresses would turn a mail outage into a subscriber oracle.
+        console.error(
+          '[unsubscribe/request] send failed:',
+          sendError instanceof Error ? sendError.message : 'unknown'
+        );
+      }
     }
 
     return NextResponse.json(GENERIC_RESPONSE);

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,12 +1,44 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getServerSupabaseClient } from '@/lib/supabase/server-client';
+import { createClient } from '@supabase/supabase-js';
+import { validateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+import { checkRateLimit, getTrustedClientIp, RATE_LIMITS } from '@/lib/security/rate-limit';
 
-const bodySchema = z.object({
-  email: z.string().min(1).max(255).pipe(z.email({ message: '잘못된 이메일 형식' })),
+/**
+ * Unsubscribe API — POST only (no GET side-effects).
+ *
+ * Requires an opaque AEAD token. No email-based fallback.
+ * Missing or invalid tokens are rejected (fail-closed).
+ */
+
+const tokenBodySchema = z.object({
+  token: z.string().min(1),
 });
 
+function getServiceSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
 export async function POST(request: NextRequest) {
+  // Distributed rate limiting (fail-closed)
+  const clientIp = getTrustedClientIp(request.headers);
+  const rateResult = await checkRateLimit(clientIp, RATE_LIMITS.unsubscribe);
+  if (rateResult.status === 'limited') {
+    return NextResponse.json(
+      { error: '너무 많은 요청입니다. 잠시 후 다시 시도해주세요.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+  if (rateResult.status === 'unavailable') {
+    return NextResponse.json(
+      { error: '서비스를 일시적으로 사용할 수 없습니다.' },
+      { status: 503 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -14,27 +46,52 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: '잘못된 요청 형식' }, { status: 400 });
   }
 
-  const parsed = bodySchema.safeParse(body);
+  // Token is required — no email fallback
+  const parsed = tokenBodySchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+    return NextResponse.json({ error: '유효하지 않은 구독 취소 요청입니다.' }, { status: 400 });
   }
 
-  const supabase = getServerSupabaseClient();
+  const result = validateUnsubscribeToken(parsed.data.token);
+
+  if (!result.valid || !result.email) {
+    if (result.error === 'expired') {
+      return NextResponse.json(
+        { error: '구독 취소 링크가 만료되었습니다. 최신 뉴스레터의 링크를 사용해주세요.' },
+        { status: 410 }
+      );
+    }
+    if (result.error === 'no_secret') {
+      console.error('[unsubscribe] UNSUBSCRIBE_TOKEN_SECRET not configured');
+      return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+    }
+    return NextResponse.json({ error: '유효하지 않은 구독 취소 링크입니다.' }, { status: 400 });
+  }
+
+  return await performUnsubscribe(result.email);
+}
+
+async function performUnsubscribe(email: string): Promise<NextResponse> {
+  const supabase = getServiceSupabase();
+  if (!supabase) {
+    console.error('[unsubscribe] SUPABASE_SERVICE_ROLE_KEY not configured');
+    return NextResponse.json({ error: '시스템 설정 오류입니다.' }, { status: 500 });
+  }
 
   try {
     const { error } = await supabase
       .from('subscribers')
       .update({ is_active: false })
-      .eq('email', parsed.data.email);
+      .eq('email', email);
 
     if (error) {
-      console.error('Unsubscribe error:', error);
+      console.error('[unsubscribe] db error');
       return NextResponse.json({ error: '구독 해지 처리 중 오류가 발생했습니다.' }, { status: 500 });
     }
 
     return NextResponse.json({ status: 'unsubscribed' });
   } catch (error) {
-    console.error('Unsubscribe error:', error);
+    console.error('[unsubscribe] unexpected error:', error instanceof Error ? error.message : 'unknown');
     return NextResponse.json({ error: '시스템 오류가 발생했습니다.' }, { status: 500 });
   }
 }

--- a/app/archive/_hooks/use-stock-prices.ts
+++ b/app/archive/_hooks/use-stock-prices.ts
@@ -1,14 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { MAX_BUSINESS_DAYS } from '../_utils/formatting/date';
 import {
-  getStockPriceCacheExpiry,
   getPreviousBusinessDate,
   getNthBusinessDateAfter,
   calculateBusinessDays,
   isTodayMarketClosed,
 } from '../_utils/market/hours';
-import { getBatchPricesFromCache, saveBatchPricesToCache } from '../_utils/cache/stock-price';
-import type { StockPriceCache } from '../_utils/cache/types';
 import type { DateString } from '../_types/archive.types';
 
 /** 주식 가격 정보 */
@@ -28,13 +25,10 @@ export type PriceUnavailableReason = 'api_error';
 interface UseStockPricesResult {
   prices: Map<string, StockPrice>;
   historicalClosePrices: Map<string, number>;
-  /** 7영업일 후 확정 종가 (tracking 만료 시) */
   settledClosePrices: Map<string, number>;
   loading: boolean;
   unavailableReason: PriceUnavailableReason | null;
-  /** 오늘이 휴장일인지 여부 (직전 개장일 종가 표시용) */
   isMarketClosed: boolean;
-  /** 실시간 추적 기간이 만료되었는지 여부 */
   isTrackingExpired: boolean;
 }
 
@@ -77,12 +71,6 @@ function isHistoricalPriceAPIResponse(data: unknown): data is HistoricalPriceAPI
   return r.success === true && typeof r.prices === 'object' && r.prices !== null;
 }
 
-/**
- * 재시도 로직을 포함한 fetch (모듈 레벨)
- *
- * - ok 응답만 반환, 4xx는 즉시 실패, 5xx는 재시도
- * - AbortError는 즉시 전파 (컴포넌트 언마운트 대응)
- */
 async function fetchWithRetry(
   url: string,
   options: RequestInit,
@@ -116,52 +104,35 @@ async function fetchWithRetry(
   throw lastError ?? new Error('Failed after retries');
 }
 
-/**
- * 실시간 추적 기간 만료 여부 확인
- * @returns true면 7영업일 초과 (확정 종가 조회 필요)
- */
 function isTrackingPeriodExpired(newsletterDate: DateString): boolean {
   const recommendDate = new Date(newsletterDate);
   recommendDate.setHours(0, 0, 0, 0);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const businessDays = calculateBusinessDays(recommendDate, today);
-
   return businessDays > MAX_BUSINESS_DAYS;
 }
 
 /**
- * 실시간 주식 시세 조회 훅 (2-tier 캐싱)
+ * 실시간 주식 시세 조회 훅
  *
- * 캐싱 전략:
- * - Supabase 캐시 우선 조회 (~50ms)
- * - 캐시 미스 시 KIS API 호출
- *
- * TTL 전략:
- * - 장 중: 1분
- * - 장 마감 후: 다음 영업일 09:00까지
+ * All price data is fetched from /api/stock/price (authoritative, server-cached).
+ * No direct Supabase/cache access from the client.
  */
 export default function useStockPrices(
   tickers: string[],
   newsletterDate: DateString | null
 ): UseStockPricesResult {
   const [prices, setPrices] = useState<Map<string, StockPrice>>(new Map());
-  const [historicalClosePrices, setHistoricalClosePrices] = useState<Map<string, number>>(
-    new Map()
-  );
+  const [historicalClosePrices, setHistoricalClosePrices] = useState<Map<string, number>>(new Map());
   const [settledClosePrices, setSettledClosePrices] = useState<Map<string, number>>(new Map());
   const [loading, setLoading] = useState(true);
   const [unavailableReason, setUnavailableReason] = useState<PriceUnavailableReason | null>(null);
   const [isMarketClosed, setIsMarketClosed] = useState(false);
   const [isExpired, setIsExpired] = useState(false);
 
-  // React 19: 단순 연산은 useMemo 불필요
   const tickersKey = tickers.join(',');
 
-  // ── 레이스 컨디션 방지: 의존성 변경 시 렌더 단계에서 즉시 loading 리셋 ──
-  // useEffect는 paint 이후 실행되므로, 의존성이 바뀐 첫 렌더에서
-  // loading=false(이전 값) + prices=이전Map 조합이 한 프레임 노출될 수 있다.
-  // useRef로 이전 의존성을 추적하고, 변경 감지 시 paint 전에 loading=true로 전환한다.
   const prevDepsRef = useRef(`${newsletterDate}:${tickersKey}`);
   const currentDeps = `${newsletterDate}:${tickersKey}`;
 
@@ -192,7 +163,7 @@ export default function useStockPrices(
         setSettledClosePrices(new Map());
         setPrices(new Map());
 
-        // 추천일 전일 종가 조회 (비핵심 — 실패해도 newsletter 종가로 fallback)
+        // Historical close price (non-critical)
         const prevDate = getPreviousBusinessDate(currentDate);
         try {
           const historicalRes = await fetchWithRetry(
@@ -214,10 +185,9 @@ export default function useStockPrices(
         } catch (histErr) {
           if (histErr instanceof Error && histErr.name === 'AbortError') throw histErr;
           if (histErr instanceof DOMException && histErr.name === 'AbortError') throw histErr;
-          // 비핵심 데이터 — 무시하고 계속 진행
         }
 
-        // 추적 기간 만료 시 7영업일 후 확정 종가 조회
+        // Tracking period expired: fetch settled close
         const expired = isTrackingPeriodExpired(currentDate);
         if (expired) {
           if (isMounted) setIsExpired(true);
@@ -250,51 +220,24 @@ export default function useStockPrices(
           return;
         }
 
-        // 캐시 조회
-        const results = new Map<string, StockPrice>();
-        const cached = await getBatchPricesFromCache(tickers);
-        const uncachedTickers: string[] = [];
-
-        for (const ticker of tickers) {
-          const cachedPrice = cached.get(ticker);
-          if (cachedPrice) {
-            results.set(ticker, cachedPrice);
-          } else {
-            uncachedTickers.push(ticker);
-          }
-        }
-
-        // 모든 티커가 캐시에 있으면 종료
-        if (uncachedTickers.length === 0) {
-          if (isMounted) {
-            setPrices(results);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // API 호출 (재시도 로직 적용)
+        // Fetch current prices from /api/stock/price (server handles caching)
         const response = await fetchWithRetry(
-          `/api/stock/price?tickers=${uncachedTickers.join(',')}`,
+          `/api/stock/price?tickers=${tickersKey}`,
           { signal: controller.signal },
-          3,  // 최대 3회 재시도
-          300 // 기본 대기 시간 300ms
+          3,
+          300
         );
 
         const data: unknown = await response.json();
         if (!isStockPriceAPIResponse(data)) throw new Error('Invalid API response');
 
-        const expiresAt = getStockPriceCacheExpiry();
-        const cachePrices: StockPriceCache[] = [];
-
+        const results = new Map<string, StockPrice>();
         for (const price of Object.values(data.prices)) {
           if (isStockPrice(price)) {
             results.set(price.ticker, price);
-            cachePrices.push({ ...price, expires_at: expiresAt });
           }
         }
 
-        saveBatchPricesToCache(cachePrices).catch(() => {});
         if (isMounted) setPrices(results);
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
@@ -311,7 +254,6 @@ export default function useStockPrices(
       isMounted = false;
       controller.abort();
     };
-    // tickersKey가 tickers 내용을 대표하므로 tickers 배열 참조 불필요
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newsletterDate, tickersKey]);
 

--- a/app/archive/_utils/api/kis/__tests__/client-auth-refresh.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/client-auth-refresh.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tokenStorage = vi.hoisted(() => ({
+  getTokenFromStorage: vi.fn(),
+  saveTokenToStorage: vi.fn(),
+  invalidateTokenInStorage: vi.fn(),
+}))
+
+vi.mock('../token-storage', () => tokenStorage)
+vi.mock('@/lib/_utils/env-validator', () => ({
+  validateKisEnv: () => ({
+    KIS_BASE_URL: 'https://kis.example.test',
+    KIS_APP_KEY: 'app-key',
+    KIS_APP_SECRET: 'app-secret',
+  }),
+}))
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const VALID_STOCK_RESPONSE = {
+  rt_cd: '0',
+  output: {
+    stck_prpr: '70000',
+    stck_sdpr: '69000',
+    prdy_ctrt: '1.45',
+    acml_vol: '100000',
+  },
+}
+
+const TOKEN_ISSUANCE_RESPONSE = {
+  access_token: 'fresh-token-xyz',
+  token_type: 'Bearer',
+  expires_in: 86400,
+}
+
+describe('KIS client auth refresh (AI-006)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'stale-token',
+      expires_at: Date.now() + 60_000,
+    })
+    tokenStorage.saveTokenToStorage.mockResolvedValue(undefined)
+    tokenStorage.invalidateTokenInStorage.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('retries exactly once on 401 with a fresh token for getStockPrice', async () => {
+    const fetchMock = vi.fn()
+      // First call: 401 from the API
+      .mockResolvedValueOnce(jsonResponse({ msg1: 'token expired' }, 401))
+      // Token issuance call
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      // Retry call: success
+      .mockResolvedValueOnce(jsonResponse(VALID_STOCK_RESPONSE))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    const result = await getStockPrice('005930')
+    expect(result.currentPrice).toBe(70000)
+
+    // Verify: original request, token refresh, retry — exactly 3 calls
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    // Token was invalidated from storage
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(1)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledWith('stale-token')
+    expect(tokenStorage.saveTokenToStorage).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: 'fresh-token-xyz' }),
+    )
+  })
+
+  it('retries exactly once on 403 for getDailyRangeClosePrices', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ msg1: 'forbidden' }, 403))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_bsop_date: '20260701', stck_clpr: '70000', acml_vol: '1234' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    const result = await getDailyRangeClosePrices('005930', '20260701', '20260701')
+    expect(result).toEqual([{ date: '2026-07-01', close: 70_000, volume: 1_234 }])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries exactly once on 401 for getIndexDailyRangeClosePrices', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_bsop_date: '20260701', bstp_nmix_prpr: '2750.50', acml_vol: '5000' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getIndexDailyRangeClosePrices } = await import('../client')
+
+    const result = await getIndexDailyRangeClosePrices('0001', '20260701', '20260701')
+    expect(result).toEqual([{ date: '2026-07-01', close: 2750.50, volume: 5_000 }])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not loop: second 401 after refresh propagates the error', async () => {
+    const fetchMock = vi.fn()
+      // First call: 401
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      // Token issuance
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      // Retry also returns 401 — must NOT loop
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    await expect(getStockPrice('005930')).rejects.toThrow(/401/)
+    // Exactly 3 calls: original, token issuance, retry — no further attempts
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('invalidates only the rejected token, not a concurrently refreshed one', async () => {
+    // Simulate: cache already has a different (newer) token when invalidation runs
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'already-refreshed-by-other-caller',
+      expires_at: Date.now() + 60_000,
+    })
+
+    let callCount = 0
+    const fetchMock = vi.fn().mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        // First API call with the cached stale-token gets 401
+        return Promise.resolve(jsonResponse({}, 401))
+      }
+      if (callCount === 2) {
+        // Token issuance
+        return Promise.resolve(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      }
+      // Retry succeeds
+      return Promise.resolve(jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    const result = await getStockPrice('005930')
+    expect(result.currentPrice).toBe(70000)
+  })
+
+  it('shares concurrent token issuance (single-flight)', async () => {
+    // No cached token — force issuance
+    tokenStorage.getTokenFromStorage.mockResolvedValue(null)
+
+    let tokenIssuanceCalls = 0
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/oauth2/tokenP')) {
+        tokenIssuanceCalls++
+        return Promise.resolve(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      }
+      return Promise.resolve(jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+
+    // Launch two concurrent requests
+    const [r1, r2] = await Promise.all([
+      getStockPrice('005930'),
+      getStockPrice('000660'),
+    ])
+
+    expect(r1.currentPrice).toBe(70000)
+    expect(r2.currentPrice).toBe(70000)
+    // Only ONE token issuance, not two
+    expect(tokenIssuanceCalls).toBe(1)
+  })
+
+  it('shares one refresh across concurrent 401 responses without deleting the new token', async () => {
+    let resolveIssuance: ((response: Response) => void) | undefined
+    const issuanceResponse = new Promise<Response>((resolve) => { resolveIssuance = resolve })
+    let issuanceCalls = 0
+    const fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/oauth2/tokenP')) {
+        issuanceCalls += 1
+        return issuanceResponse
+      }
+      const authorization = (options?.headers as Record<string, string> | undefined)?.authorization
+      return Promise.resolve(authorization === 'Bearer stale-token'
+        ? jsonResponse({}, 401)
+        : jsonResponse(VALID_STOCK_RESPONSE))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getStockPrice } = await import('../client')
+    const requests = Promise.all([getStockPrice('005930'), getStockPrice('000660')])
+    await vi.waitFor(() => expect(issuanceCalls).toBe(1))
+    resolveIssuance?.(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+
+    const results = await requests
+    expect(results.map((result) => result.currentPrice)).toEqual([70_000, 70_000])
+    expect(issuanceCalls).toBe(1)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenCalledTimes(2)
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenNthCalledWith(1, 'stale-token')
+    expect(tokenStorage.invalidateTokenInStorage).toHaveBeenNthCalledWith(2, 'stale-token')
+    expect(tokenStorage.saveTokenToStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a second auth rejection as terminal for outer batch retries', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getBatchStockPrices } = await import('../client')
+    const result = await getBatchStockPrices(['005930'])
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.prices.size).toBe(0)
+    expect(result.failures.get('005930')).toMatch(/after one token refresh/)
+  })
+
+  it('retries on 401 for getAuthoritativeStockMarket (market path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output: { rprs_mrkt_kor_name: '코스피' },
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getAuthoritativeStockMarket } = await import('../client')
+
+    const market = await getAuthoritativeStockMarket('005930')
+    expect(market).toBe('KOSPI')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries on 403 for getDailyClosePrice (daily close path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 403))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ stck_clpr: '68000' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getDailyClosePrice } = await import('../client')
+
+    const price = await getDailyClosePrice('005930', '20260730')
+    expect(price).toBe(68000)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries on 401 for getIndexDailyClosePrice (index close path)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse(TOKEN_ISSUANCE_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({
+        rt_cd: '0',
+        output2: [{ bstp_nmix_prpr: '2750.50' }],
+      }))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { getIndexDailyClosePrice } = await import('../client')
+
+    const price = await getIndexDailyClosePrice('0001', '20260730')
+    expect(price).toBe(2750.50)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/app/archive/_utils/api/kis/__tests__/client-range.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/client-range.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tokenStorage = vi.hoisted(() => ({
+  getTokenFromStorage: vi.fn(),
+  saveTokenToStorage: vi.fn(),
+  invalidateTokenInStorage: vi.fn(),
+}))
+
+vi.mock('../token-storage', () => tokenStorage)
+vi.mock('@/lib/_utils/env-validator', () => ({
+  validateKisEnv: () => ({
+    KIS_BASE_URL: 'https://kis.example.test',
+    KIS_APP_KEY: 'app-key',
+    KIS_APP_SECRET: 'app-secret',
+  }),
+}))
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+describe('KIS daily-range client contract', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tokenStorage.getTokenFromStorage.mockResolvedValue({
+      access_token: 'cached-token',
+      expires_at: Date.now() + 60_000,
+    })
+    tokenStorage.saveTokenToStorage.mockResolvedValue(undefined)
+    tokenStorage.invalidateTokenInStorage.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps a successful empty output2 as a legitimate empty trading result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '0', output2: [] })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260702')).resolves.toEqual([])
+  })
+
+  it('throws a typed failure for HTTP and KIS API errors instead of returning []', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '1' }, 503)))
+    const { getDailyRangeClosePrices, KisDailyRangeRequestError } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260702'))
+      .rejects.toBeInstanceOf(KisDailyRangeRequestError)
+  })
+
+  it('throws when output2 is missing or not an array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ rt_cd: '0', output2: null })))
+    const { getIndexDailyRangeClosePrices } = await import('../client')
+
+    await expect(getIndexDailyRangeClosePrices('0001', '20260701', '20260702'))
+      .rejects.toThrow(/output2 array/)
+  })
+
+  it('rejects malformed rows rather than filtering them into a false empty result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      rt_cd: '0',
+      output2: [{ stck_bsop_date: '20260231', stck_clpr: '70000', acml_vol: '100' }],
+    })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260201', '20260228'))
+      .rejects.toThrow(/invalid date\/close/)
+  })
+
+  it('parses valid stock range rows without changing numeric meaning', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      rt_cd: '0',
+      output2: [{ stck_bsop_date: '20260701', stck_clpr: '70000', acml_vol: '1234' }],
+    })))
+    const { getDailyRangeClosePrices } = await import('../client')
+
+    await expect(getDailyRangeClosePrices('005930', '20260701', '20260701')).resolves.toEqual([
+      { date: '2026-07-01', close: 70_000, volume: 1_234 },
+    ])
+  })
+})

--- a/app/archive/_utils/api/kis/__tests__/token-storage.test.ts
+++ b/app/archive/_utils/api/kis/__tests__/token-storage.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('KIS token storage credentials', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('fails closed when only the public anon key is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'public-anon-key')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+    const { getTokenFromStorage, KisTokenStorageError } = await import('../token-storage')
+
+    await expect(getTokenFromStorage()).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(getTokenFromStorage()).rejects.toThrow(/SUPABASE_SERVICE_ROLE_KEY/)
+  })
+
+  it('invalidateTokenInStorage fails closed without service role key', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+    const { invalidateTokenInStorage, KisTokenStorageError } = await import('../token-storage')
+
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toThrow(/SUPABASE_SERVICE_ROLE_KEY/)
+  })
+
+  it('invalidates only the exact rejected stored token and propagates errors', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'valid-service-key')
+
+    const accessTokenEq = vi.fn().mockResolvedValue({ error: { message: 'delete denied' } })
+    const idEq = vi.fn().mockReturnValue({ eq: accessTokenEq })
+    const mockDelete = vi.fn().mockReturnValue({ eq: idEq })
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: () => ({
+        from: () => ({ delete: mockDelete }),
+      }),
+    }))
+
+    const { invalidateTokenInStorage, KisTokenStorageError } = await import('../token-storage')
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toBeInstanceOf(KisTokenStorageError)
+    await expect(invalidateTokenInStorage('rejected-token')).rejects.toThrow(/invalidate/)
+    expect(idEq).toHaveBeenCalledWith('id', 'kis_access_token')
+    expect(accessTokenEq).toHaveBeenCalledWith('access_token', 'rejected-token')
+  })
+})

--- a/app/archive/_utils/api/kis/client.ts
+++ b/app/archive/_utils/api/kis/client.ts
@@ -8,7 +8,7 @@
  */
 
 import { validateKisEnv } from '@/lib/_utils/env-validator';
-import { getTokenFromStorage, saveTokenToStorage } from './token-storage';
+import { getTokenFromStorage, saveTokenToStorage, invalidateTokenInStorage } from './token-storage';
 import { checkRateLimit } from './rate-limiter';
 import type { KisToken, KisStockPrice, KisErrorResponse, KisConfig, BatchPriceResult } from './types';
 
@@ -18,11 +18,25 @@ const tokenCache: { token: KisToken | null } = { token: null };
 // 환경 변수 캐시 (런타임에 로드)
 let configCache: KisConfig | null = null;
 
+/**
+ * Single-flight token issuance/refresh: concurrent callers share a single
+ * in-progress token request rather than issuing duplicate requests.
+ */
+let tokenIssuanceInFlight: Promise<KisToken> | null = null;
+
 /** KIS API 요청 타임아웃 (ms) */
 const FETCH_TIMEOUT_MS = 8_000;
 
 /** 종목 간 요청 간격 (ms) — KIS API rate limit 방지 */
 const INTER_REQUEST_DELAY_MS = 100;
+
+export class KisAuthenticationError extends Error {
+  readonly name = 'KisAuthenticationError';
+
+  constructor(status: number) {
+    super(`KIS authentication failed after one token refresh: HTTP ${status}`);
+  }
+}
 
 /**
  * 타임아웃이 있는 fetch
@@ -55,6 +69,7 @@ async function retryAsync<T>(
       return await fn();
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
+      if (lastError instanceof KisAuthenticationError) throw lastError;
       if (attempt < maxRetries) {
         await new Promise((resolve) => setTimeout(resolve, baseDelay * Math.pow(2, attempt)));
       }
@@ -164,6 +179,7 @@ async function issueNewToken(): Promise<KisToken> {
 
 /**
  * 접근 토큰 발급 (2-tier 캐싱: 메모리 → Supabase)
+ * Uses single-flight pattern: concurrent callers share a single token issuance.
  */
 async function getAccessToken(): Promise<string> {
   const now = Date.now();
@@ -180,14 +196,66 @@ async function getAccessToken(): Promise<string> {
     return storedToken.access_token;
   }
 
-  // 3. 새 토큰 발급
-  checkRateLimit('token');
-  const newToken = await issueNewToken();
+  // 3. 새 토큰 발급 (single-flight)
+  return (await singleFlightIssueToken()).access_token;
+}
 
-  tokenCache.token = newToken;
-  saveTokenToStorage(newToken).catch(() => {});
+/**
+ * Single-flight token issuance: if a request is already in progress, join it.
+ */
+async function singleFlightIssueToken(): Promise<KisToken> {
+  if (tokenIssuanceInFlight) {
+    return tokenIssuanceInFlight;
+  }
 
-  return newToken.access_token;
+  tokenIssuanceInFlight = (async () => {
+    try {
+      checkRateLimit('token');
+      const newToken = await issueNewToken();
+      await saveTokenToStorage(newToken);
+      tokenCache.token = newToken;
+      return newToken;
+    } finally {
+      tokenIssuanceInFlight = null;
+    }
+  })();
+
+  return tokenIssuanceInFlight;
+}
+
+/** 401/403으로 거절된 정확한 token만 memory/storage에서 무효화한다. */
+async function invalidateToken(rejectedAccessToken: string): Promise<void> {
+  if (tokenCache.token?.access_token === rejectedAccessToken) {
+    tokenCache.token = null;
+  }
+  await invalidateTokenInStorage(rejectedAccessToken);
+}
+
+/** concurrent caller가 이미 만든 새 token을 재사용하고, 아니면 single-flight issuance에 합류한다. */
+async function refreshAccessToken(rejectedAccessToken: string): Promise<string> {
+  await invalidateToken(rejectedAccessToken);
+  const current = tokenCache.token;
+  if (current && current.access_token !== rejectedAccessToken && current.expires_at > Date.now()) {
+    return current.access_token;
+  }
+  return (await singleFlightIssueToken()).access_token;
+}
+
+/** 401/403에 한해 정확히 한 번 refresh/retry하고 두 번째 rejection은 terminal이다. */
+async function authenticatedKisFetch(
+  buildRequest: (accessToken: string) => Promise<Response>,
+): Promise<Response> {
+  const token = await getAccessToken();
+  const response = await buildRequest(token);
+
+  if (response.status !== 401 && response.status !== 403) return response;
+
+  const freshToken = await refreshAccessToken(token);
+  const retriedResponse = await buildRequest(freshToken);
+  if (retriedResponse.status === 401 || retriedResponse.status === 403) {
+    throw new KisAuthenticationError(retriedResponse.status);
+  }
+  return retriedResponse;
 }
 
 /**
@@ -211,29 +279,94 @@ function parseOptionalFloat(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+/** KIS가 명시적으로 확인한 국내 거래소. 추정값이나 UNKNOWN은 허용하지 않는다. */
+export type AuthoritativeKoreanStockMarket = 'KOSPI' | 'KOSDAQ';
+
+export function classifyKisRepresentativeMarketName(value: unknown): AuthoritativeKoreanStockMarket | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toUpperCase().replace(/\s+/g, '');
+  if (normalized.startsWith('KOSDAQ') || normalized.startsWith('코스닥')) return 'KOSDAQ';
+  if (normalized.startsWith('KOSPI') || normalized.startsWith('코스피') || normalized.startsWith('유가증권')) {
+    return 'KOSPI';
+  }
+  return null;
+}
+
+/**
+ * KIS 국내주식 현재가 응답의 대표시장명으로 거래소를 확인한다.
+ * 누락·알 수 없는 시장은 임의 기본값으로 바꾸지 않고 실패시킨다.
+ */
+export async function getAuthoritativeStockMarket(ticker: string): Promise<AuthoritativeKoreanStockMarket> {
+  const cleanedTicker = cleanTicker(ticker);
+  const config = getKisConfig();
+  checkRateLimit('price');
+
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
+      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
+        new URLSearchParams({
+          FID_COND_MRKT_DIV_CODE: 'J',
+          FID_INPUT_ISCD: cleanedTicker,
+        }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${accessToken}`,
+          appkey: config.KIS_APP_KEY,
+          appsecret: config.KIS_APP_SECRET,
+          tr_id: 'FHKST01010100',
+        },
+      },
+    ),
+  );
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error: unknown) {
+    throw new Error(
+      `KIS market response JSON parse failed for ${cleanedTicker}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const candidate = typeof payload === 'object' && payload !== null
+    ? payload as { readonly rt_cd?: unknown; readonly output?: { readonly rprs_mrkt_kor_name?: unknown } }
+    : null;
+  if (!response.ok || (candidate?.rt_cd !== undefined && candidate.rt_cd !== '0')) {
+    throw new Error(`KIS market lookup failed for ${cleanedTicker}: HTTP ${response.status}`);
+  }
+
+  const market = classifyKisRepresentativeMarketName(candidate?.output?.rprs_mrkt_kor_name);
+  if (market === null) {
+    throw new Error(`KIS market lookup returned no recognized exchange for ${cleanedTicker}`);
+  }
+  return market;
+}
+
 /**
  * 국내 주식 현재가 조회
  */
 export async function getStockPrice(ticker: string): Promise<KisStockPrice> {
-  const token = await getAccessToken();
   const cleanedTicker = cleanTicker(ticker);
   const config = getKisConfig();
 
-  const response = await fetchWithTimeout(
-    `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
-      new URLSearchParams({
-        FID_COND_MRKT_DIV_CODE: 'J',
-        FID_INPUT_ISCD: cleanedTicker,
-      }),
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        authorization: `Bearer ${token}`,
-        appkey: config.KIS_APP_KEY,
-        appsecret: config.KIS_APP_SECRET,
-        tr_id: 'FHKST01010100',
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
+      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-price?` +
+        new URLSearchParams({
+          FID_COND_MRKT_DIV_CODE: 'J',
+          FID_INPUT_ISCD: cleanedTicker,
+        }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${accessToken}`,
+          appkey: config.KIS_APP_KEY,
+          appsecret: config.KIS_APP_SECRET,
+          tr_id: 'FHKST01010100',
+        },
       },
-    }
+    ),
   );
 
   if (!response.ok) {
@@ -307,7 +440,6 @@ export async function getBatchStockPrices(tickers: string[]): Promise<BatchPrice
 export async function getDailyClosePrice(ticker: string, date: string): Promise<number | null> {
   try {
     const config = getKisConfig();
-    const token = await getAccessToken();
 
     const params = new URLSearchParams({
       FID_COND_MRKT_DIV_CODE: 'J',
@@ -318,17 +450,19 @@ export async function getDailyClosePrice(ticker: string, date: string): Promise<
       FID_ORG_ADJ_PRC: '0',
     });
 
-    const res = await fetchWithTimeout(
-      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
-          appkey: config.KIS_APP_KEY,
-          appsecret: config.KIS_APP_SECRET,
-          tr_id: 'FHKST03010100',
+    const res = await authenticatedKisFetch((accessToken) =>
+      fetchWithTimeout(
+        `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${accessToken}`,
+            appkey: config.KIS_APP_KEY,
+            appsecret: config.KIS_APP_SECRET,
+            tr_id: 'FHKST03010100',
+          },
         },
-      }
+      ),
     );
 
     const data = await res.json();
@@ -348,7 +482,6 @@ export async function getDailyClosePrice(ticker: string, date: string): Promise<
 export async function getIndexDailyClosePrice(indexCode: string, date: string): Promise<number | null> {
   try {
     const config = getKisConfig();
-    const token = await getAccessToken();
 
     const params = new URLSearchParams({
       FID_COND_MRKT_DIV_CODE: 'U',
@@ -358,17 +491,19 @@ export async function getIndexDailyClosePrice(indexCode: string, date: string): 
       FID_PERIOD_DIV_CODE: 'D',
     });
 
-    const res = await fetchWithTimeout(
-      `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
-          appkey: config.KIS_APP_KEY,
-          appsecret: config.KIS_APP_SECRET,
-          tr_id: 'FHKUP03500100',
+    const res = await authenticatedKisFetch((accessToken) =>
+      fetchWithTimeout(
+        `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${accessToken}`,
+            appkey: config.KIS_APP_KEY,
+            appsecret: config.KIS_APP_SECRET,
+            tr_id: 'FHKUP03500100',
+          },
         },
-      }
+      ),
     );
 
     const data = await res.json();
@@ -388,18 +523,92 @@ export interface KisDailyRangePricePoint {
   readonly volume: number | null;
 }
 
+export class KisDailyRangeRequestError extends Error {
+  readonly name = 'KisDailyRangeRequestError';
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
 function toIsoDate(kisDate: string): string | null {
   if (!/^\d{8}$/.test(kisDate)) return null;
+  const year = Number(kisDate.slice(0, 4));
+  const month = Number(kisDate.slice(4, 6));
+  const day = Number(kisDate.slice(6, 8));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return null;
+  }
   return `${kisDate.slice(0, 4)}-${kisDate.slice(4, 6)}-${kisDate.slice(6, 8)}`;
 }
 
-function parseRangePriceRow(row: Record<string, string>, closeField: string, parseClose: (v: string) => number): KisDailyRangePricePoint | null {
-  const date = toIsoDate(row.stck_bsop_date);
-  const close = parseClose(row[closeField]);
-  if (!date || !Number.isFinite(close) || close <= 0) return null;
+function parseRangePriceRow(
+  row: unknown,
+  closeField: string,
+  parseClose: (value: string) => number,
+  label: string,
+  index: number,
+): KisDailyRangePricePoint {
+  if (typeof row !== 'object' || row === null) {
+    throw new KisDailyRangeRequestError(`${label} row ${index} is not an object`);
+  }
+  const record = row as Record<string, unknown>;
+  const rawDate = record.stck_bsop_date;
+  const rawClose = record[closeField];
+  if (typeof rawDate !== 'string' || typeof rawClose !== 'string') {
+    throw new KisDailyRangeRequestError(`${label} row ${index} is missing date/close fields`);
+  }
 
-  const volume = parseInt(row.acml_vol, 10);
-  return { date, close, volume: Number.isFinite(volume) ? volume : null };
+  const date = toIsoDate(rawDate);
+  const close = parseClose(rawClose);
+  if (!date || !Number.isFinite(close) || close <= 0) {
+    throw new KisDailyRangeRequestError(`${label} row ${index} has an invalid date/close`);
+  }
+
+  const rawVolume = record.acml_vol;
+  let volume: number | null = null;
+  if (rawVolume !== undefined && rawVolume !== null && rawVolume !== '') {
+    if (typeof rawVolume !== 'string') {
+      throw new KisDailyRangeRequestError(`${label} row ${index} has a non-string volume`);
+    }
+    volume = Number.parseInt(rawVolume, 10);
+    if (!Number.isFinite(volume) || volume < 0) {
+      throw new KisDailyRangeRequestError(`${label} row ${index} has an invalid volume`);
+    }
+  }
+
+  return { date, close, volume };
+}
+
+async function parseDailyRangeResponse(
+  response: Response,
+  label: string,
+): Promise<readonly unknown[]> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error: unknown) {
+    throw new KisDailyRangeRequestError(`${label} returned invalid JSON`, {
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new KisDailyRangeRequestError(`${label} failed with HTTP ${response.status}`);
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    throw new KisDailyRangeRequestError(`${label} returned a non-object payload`);
+  }
+
+  const data = payload as { readonly rt_cd?: unknown; readonly output2?: unknown };
+  if (data.rt_cd !== '0') {
+    throw new KisDailyRangeRequestError(`${label} returned a non-success KIS result`);
+  }
+  if (!Array.isArray(data.output2)) {
+    throw new KisDailyRangeRequestError(`${label} returned no output2 array`);
+  }
+  return data.output2;
 }
 
 /**
@@ -413,41 +622,37 @@ export async function getDailyRangeClosePrices(
   startDate: string,
   endDate: string
 ): Promise<KisDailyRangePricePoint[]> {
-  try {
-    const config = getKisConfig();
-    const token = await getAccessToken();
+  const config = getKisConfig();
+  const cleanedTicker = cleanTicker(ticker);
+  const label = `KIS stock daily range ${cleanedTicker}`;
 
-    const params = new URLSearchParams({
-      FID_COND_MRKT_DIV_CODE: 'J',
-      FID_INPUT_ISCD: cleanTicker(ticker),
-      FID_INPUT_DATE_1: startDate,
-      FID_INPUT_DATE_2: endDate,
-      FID_PERIOD_DIV_CODE: 'D',
-      FID_ORG_ADJ_PRC: '0',
-    });
+  const params = new URLSearchParams({
+    FID_COND_MRKT_DIV_CODE: 'J',
+    FID_INPUT_ISCD: cleanedTicker,
+    FID_INPUT_DATE_1: startDate,
+    FID_INPUT_DATE_2: endDate,
+    FID_PERIOD_DIV_CODE: 'D',
+    FID_ORG_ADJ_PRC: '0',
+  });
 
-    const res = await fetchWithTimeout(
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
       `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?${params}`,
       {
         headers: {
           'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${accessToken}`,
           appkey: config.KIS_APP_KEY,
           appsecret: config.KIS_APP_SECRET,
           tr_id: 'FHKST03010100',
         },
-      }
-    );
+      },
+    ),
+  );
 
-    const data = await res.json();
-    if (!res.ok || data.rt_cd !== '0' || !Array.isArray(data.output2)) return [];
-
-    return data.output2
-      .map((row: Record<string, string>) => parseRangePriceRow(row, 'stck_clpr', (v) => parseInt(v, 10)))
-      .filter((point: KisDailyRangePricePoint | null): point is KisDailyRangePricePoint => point !== null);
-  } catch {
-    return [];
-  }
+  const rows = await parseDailyRangeResponse(response, label);
+  return rows.map((row, index) =>
+    parseRangePriceRow(row, 'stck_clpr', (value) => Number.parseInt(value, 10), label, index));
 }
 
 /**
@@ -461,40 +666,35 @@ export async function getIndexDailyRangeClosePrices(
   startDate: string,
   endDate: string
 ): Promise<KisDailyRangePricePoint[]> {
-  try {
-    const config = getKisConfig();
-    const token = await getAccessToken();
+  const config = getKisConfig();
+  const label = `KIS index daily range ${indexCode}`;
 
-    const params = new URLSearchParams({
-      FID_COND_MRKT_DIV_CODE: 'U',
-      FID_INPUT_ISCD: indexCode,
-      FID_INPUT_DATE_1: startDate,
-      FID_INPUT_DATE_2: endDate,
-      FID_PERIOD_DIV_CODE: 'D',
-    });
+  const params = new URLSearchParams({
+    FID_COND_MRKT_DIV_CODE: 'U',
+    FID_INPUT_ISCD: indexCode,
+    FID_INPUT_DATE_1: startDate,
+    FID_INPUT_DATE_2: endDate,
+    FID_PERIOD_DIV_CODE: 'D',
+  });
 
-    const res = await fetchWithTimeout(
+  const response = await authenticatedKisFetch((accessToken) =>
+    fetchWithTimeout(
       `${config.KIS_BASE_URL}/uapi/domestic-stock/v1/quotations/inquire-daily-indexchartprice?${params}`,
       {
         headers: {
           'Content-Type': 'application/json',
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${accessToken}`,
           appkey: config.KIS_APP_KEY,
           appsecret: config.KIS_APP_SECRET,
           tr_id: 'FHKUP03500100',
         },
-      }
-    );
+      },
+    ),
+  );
 
-    const data = await res.json();
-    if (!res.ok || data.rt_cd !== '0' || !Array.isArray(data.output2)) return [];
-
-    return data.output2
-      .map((row: Record<string, string>) => parseRangePriceRow(row, 'bstp_nmix_prpr', (v) => parseFloat(v)))
-      .filter((point: KisDailyRangePricePoint | null): point is KisDailyRangePricePoint => point !== null);
-  } catch {
-    return [];
-  }
+  const rows = await parseDailyRangeResponse(response, label);
+  return rows.map((row, index) =>
+    parseRangePriceRow(row, 'bstp_nmix_prpr', (value) => Number.parseFloat(value), label, index));
 }
 
 /**

--- a/app/archive/_utils/api/kis/token-storage.ts
+++ b/app/archive/_utils/api/kis/token-storage.ts
@@ -1,5 +1,6 @@
 /**
- * KIS 토큰 Supabase 저장/조회 서비스
+ * KIS 토큰 Supabase 저장/조회 서비스.
+ * kis_tokens는 service-role 전용 서버 자산이며 anon fallback을 허용하지 않는다.
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
@@ -9,77 +10,82 @@ const TOKEN_ID = 'kis_access_token';
 
 let supabaseClient: SupabaseClient<Database> | null = null;
 
-/**
- * Supabase 클라이언트 초기화 (lazy initialization)
- */
-function getSupabase(): SupabaseClient<Database> {
-  if (!supabaseClient) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    // kis_tokens는 RLS로 service_role 전용. 서버(API 라우트)에서만 실행되므로 service_role 우선.
-    const supabaseKey =
-      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export class KisTokenStorageError extends Error {
+  readonly name = 'KisTokenStorageError';
 
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error(
-        'Supabase credentials not configured. ' +
-          'Please set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables.'
-      );
-    }
-
-    supabaseClient = createClient<Database>(supabaseUrl, supabaseKey);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
   }
+}
+
+/** Supabase service-role client lazy initialization. */
+function getSupabase(): SupabaseClient<Database> {
+  if (supabaseClient) return supabaseClient;
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new KisTokenStorageError(
+      'KIS token storage requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY',
+    );
+  }
+
+  supabaseClient = createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
   return supabaseClient;
 }
 
-/**
- * Supabase에서 토큰 조회
- */
+/** Supabase에서 유효한 토큰 조회. 저장소 오류는 cache miss로 위장하지 않는다. */
 export async function getTokenFromStorage(): Promise<KisToken | null> {
-  try {
-    const supabase = getSupabase();
-    const { data: tokenData } = await supabase
-      .from('kis_tokens')
-      .select('*')
-      .eq('id', TOKEN_ID)
-      .single();
+  const supabase = getSupabase();
+  const { data: tokenData, error } = await supabase
+    .from('kis_tokens')
+    .select('*')
+    .eq('id', TOKEN_ID)
+    .maybeSingle();
 
-    if (!tokenData) {
-      return null;
-    }
+  if (error) {
+    throw new KisTokenStorageError(`Failed to read KIS token storage: ${error.message}`);
+  }
+  if (!tokenData) return null;
 
-    const row = tokenData as KisTokenRow;
-    const now = Date.now();
+  const row = tokenData as KisTokenRow;
+  if (row.expires_at <= Date.now()) return null;
 
-    // 토큰이 만료되었으면 null 반환
-    if (row.expires_at <= now) {
-      return null;
-    }
+  return {
+    access_token: row.access_token,
+    expires_at: row.expires_at,
+  };
+}
 
-    return {
-      access_token: row.access_token,
-      expires_at: row.expires_at,
-    };
-  } catch (error) {
-    // Supabase 조회 실패 시 null 반환 (캐시 미스로 처리)
-    console.error('[KIS Token Storage] Failed to get token from Supabase:', error);
-    return null;
+/** Supabase에 토큰 저장. 실패를 삼키지 않아 반복 발급을 방지한다. */
+export async function saveTokenToStorage(token: KisToken): Promise<void> {
+  const supabase = getSupabase();
+  const tokenRow: KisTokenInsert = {
+    id: TOKEN_ID,
+    access_token: token.access_token,
+    expires_at: token.expires_at,
+    updated_at: new Date().toISOString(),
+  };
+  const { error } = await supabase.from('kis_tokens').upsert(tokenRow);
+  if (error) {
+    throw new KisTokenStorageError(`Failed to persist KIS token: ${error.message}`);
   }
 }
 
-/**
- * Supabase에 토큰 저장 (upsert)
- */
-export async function saveTokenToStorage(token: KisToken): Promise<void> {
-  try {
-    const supabase = getSupabase();
-    const tokenRow: KisTokenInsert = {
-      id: TOKEN_ID,
-      access_token: token.access_token,
-      expires_at: token.expires_at,
-      updated_at: new Date().toISOString(),
-    };
-    await supabase.from('kis_tokens').upsert(tokenRow);
-  } catch (error) {
-    console.error('[KIS Token Storage] Failed to save token to Supabase:', error);
+/** 401/403으로 거절된 정확한 저장 토큰만 삭제한다. 새로 갱신된 토큰은 보존한다. */
+export async function invalidateTokenInStorage(rejectedAccessToken: string): Promise<void> {
+  if (!rejectedAccessToken) {
+    throw new KisTokenStorageError('Rejected KIS access token is required for invalidation');
+  }
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from('kis_tokens')
+    .delete()
+    .eq('id', TOKEN_ID)
+    .eq('access_token', rejectedAccessToken);
+  if (error) {
+    throw new KisTokenStorageError(`Failed to invalidate KIS token: ${error.message}`);
   }
 }

--- a/app/archive/_utils/cache/stock-price.ts
+++ b/app/archive/_utils/cache/stock-price.ts
@@ -1,5 +1,12 @@
+import 'server-only';
+
 /**
- * 주식 가격 Supabase 캐시 저장/조회 서비스
+ * 주식 가격 Supabase 캐시 저장/조회 서비스 (SERVER-ONLY)
+ *
+ * Architecture:
+ * - Both reads and writes use service_role key (server-side only)
+ * - This module must NOT be imported from client-side code
+ * - Cache failures are non-poisoning: read failures return empty, write failures are logged
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
@@ -10,44 +17,31 @@ import type {
   StockPriceCacheInsert,
 } from './types';
 
-let supabaseClient: SupabaseClient<StockPriceCacheDatabase> | null = null;
-
 /**
  * 캐시 에러 로깅 (프로덕션 관찰성 확보)
  */
 function logCacheError(message: string, error: unknown): void {
-  console.error(`[StockPriceCache] ${message}:`, error);
+  console.error(`[StockPriceCache] ${message}:`, error instanceof Error ? error.message : error);
 }
 
 /**
  * 주식 가격 데이터 기본 검증
  */
-function validateStockPrice(price: StockPriceCache): void {
-  if (!price.ticker || price.currentPrice <= 0 || price.previousClose <= 0) {
-    throw new Error(`Invalid stock price for ${price.ticker}`);
-  }
+function validateStockPrice(price: StockPriceCache): boolean {
+  return !!(price.ticker && price.currentPrice > 0 && price.previousClose > 0);
 }
 
 /**
- * Supabase 클라이언트 초기화 (lazy initialization)
- *
- * @throws {Error} 환경 변수 미설정 시
+ * Service-role Supabase client (server-side only).
+ * Returns null if service role key is not configured.
  */
-function getSupabase(): SupabaseClient<StockPriceCacheDatabase> {
-  if (!supabaseClient) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error(
-        'Supabase credentials not configured. ' +
-          'Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables.'
-      );
-    }
-
-    supabaseClient = createClient<StockPriceCacheDatabase>(supabaseUrl, supabaseKey);
-  }
-  return supabaseClient;
+function getServiceClient(): SupabaseClient<StockPriceCacheDatabase> | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient<StockPriceCacheDatabase>(url, key, {
+    auth: { persistSession: false },
+  });
 }
 
 /**
@@ -82,23 +76,21 @@ function mapCacheToInsert(price: StockPriceCache): StockPriceCacheInsert {
 }
 
 /**
- * Supabase에서 여러 주식 가격 캐시 일괄 조회
+ * Supabase에서 여러 주식 가격 캐시 일괄 조회 (service-role)
  *
- * @param tickers - 조회할 티커 배열
- * @returns Map<ticker, StockPriceCache> (만료되지 않은 캐시만)
+ * Non-poisoning: returns empty on error.
  */
 export async function getBatchPricesFromCache(
   tickers: string[]
 ): Promise<Map<string, StockPriceCache>> {
   const results = new Map<string, StockPriceCache>();
-
-  if (tickers.length === 0) {
-    return results;
-  }
+  if (tickers.length === 0) return results;
 
   try {
-    const supabase = getSupabase();
-    const { data: cacheData, error } = await supabase
+    const client = getServiceClient();
+    if (!client) return results;
+
+    const { data: cacheData, error } = await client
       .from('stock_price_cache')
       .select('*')
       .in('ticker', tickers);
@@ -108,16 +100,11 @@ export async function getBatchPricesFromCache(
       return results;
     }
 
-    if (!cacheData || cacheData.length === 0) {
-      return results;
-    }
+    if (!cacheData || cacheData.length === 0) return results;
 
     const now = Date.now();
-
     cacheData.forEach((row) => {
       const cache = mapRowToCache(row);
-
-      // 만료되지 않은 캐시만 반환
       if (cache.expires_at > now) {
         results.set(cache.ticker, cache);
       }
@@ -131,23 +118,22 @@ export async function getBatchPricesFromCache(
 }
 
 /**
- * Supabase에 여러 주식 가격 캐시 일괄 저장 (upsert)
+ * Supabase에 여러 주식 가격 캐시 일괄 저장 (upsert, service-role only)
  *
- * @param prices - 저장할 가격 데이터 배열
+ * Non-poisoning: silently fails on error.
  */
 export async function saveBatchPricesToCache(prices: StockPriceCache[]): Promise<void> {
-  if (prices.length === 0) {
-    return;
-  }
+  if (prices.length === 0) return;
+
+  const client = getServiceClient();
+  if (!client) return;
 
   try {
-    // 모든 가격 데이터 검증
-    prices.forEach((price) => validateStockPrice(price));
+    const validPrices = prices.filter(validateStockPrice);
+    if (validPrices.length === 0) return;
 
-    const supabase = getSupabase();
-    const cacheRows = prices.map((price) => mapCacheToInsert(price));
-
-    const { error } = await supabase.from('stock_price_cache').upsert(cacheRows);
+    const cacheRows = validPrices.map(mapCacheToInsert);
+    const { error } = await client.from('stock_price_cache').upsert(cacheRows);
 
     if (error) {
       logCacheError('Failed to save batch prices', error);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,6 +12,18 @@ export const revalidate = 86400;
 // next.config staticPageGenerationTimeout(180s)에 위임.
 const SITEMAP_SCORES_ROW_CAP = 2000;
 
+/**
+ * 조회 실패 시 빌드를 세울지 결정한다.
+ *
+ * 프로덕션 배포에서는 던진다 — 빈 sitemap을 조용히 내보내면 색인이 유실되므로,
+ * 그건 배포 실패보다 나쁜 결과다. preview·로컬처럼 Supabase 자격증명이 아예
+ * 없는 환경까지 같은 규칙을 적용하면 색인과 무관한 빌드가 전부 막히므로
+ * 그때만 부분 sitemap으로 물러난다.
+ */
+function shouldFailBuildOnSitemapError(): boolean {
+  return process.env.VERCEL_ENV === 'production';
+}
+
 /** 언어 alternates (단일언어 사이트용 x-default + ko) */
 function withAlternates(url: string) {
   return {
@@ -58,7 +70,8 @@ async function getActiveThemes(): Promise<{ id: string; calculated_at: string | 
     }));
   } catch (error) {
     console.error('[Sitemap] 활성 테마 조회 실패', error);
-    throw error;
+    if (shouldFailBuildOnSitemapError()) throw error;
+    return [];
   }
 }
 
@@ -76,7 +89,8 @@ async function getPublishedBlogSlugs(): Promise<{ slug: string; published_at: st
     return data || [];
   } catch (error) {
     console.error('[Sitemap] 발행 블로그 조회 실패', error);
-    throw error;
+    if (shouldFailBuildOnSitemapError()) throw error;
+    return [];
   }
 }
 

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
   Loader2,
@@ -27,7 +28,119 @@ const subscribeSchema = z.object({
   name: z.string().max(100, '이름 길이 제한 초과').optional(),
 });
 
+/**
+ * Confirmation sub-component shown when ?confirm=<token> is present.
+ * Requires explicit user action (POST) — no GET mutation.
+ */
+function ConfirmSection({ token }: { token: string }) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  const handleConfirm = async () => {
+    setStatus('loading');
+    try {
+      const res = await fetch('/api/subscribe/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json().catch(() => ({})) as { status?: string; error?: string; message?: string };
+      if (res.ok) {
+        setStatus('success');
+        setMessage(data.message || '구독이 확인되었습니다!');
+      } else {
+        setStatus('error');
+        setMessage(data.error || '확인 처리에 실패했습니다.');
+      }
+    } catch {
+      setStatus('error');
+      setMessage('네트워크 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white relative overflow-hidden mt-20">
+      <AnimatedBackground />
+      <main className="pt-20 pb-24 px-6 lg:px-8 relative z-10">
+        <motion.div
+          initial={{ opacity: 0, y: 60 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.9, ease: [0.19, 1, 0.22, 1] }}
+          className="max-w-lg mx-auto"
+        >
+          <div className="glass-morphism rounded-3xl p-8 lg:p-12 border border-emerald-500/20 text-center">
+            <h1 className="text-3xl font-light text-emerald-500/80 mb-6">구독 확인</h1>
+            {status === 'idle' && (
+              <>
+                <p className="text-slate-300 mb-8">아래 버튼을 클릭하여 구독을 확인해주세요.</p>
+                <button
+                  onClick={handleConfirm}
+                  className="px-8 py-3 bg-emerald-600 text-white rounded-xl font-medium hover:bg-emerald-500 transition-colors"
+                  aria-label="Confirm subscription"
+                >
+                  구독 확인하기
+                </button>
+              </>
+            )}
+            {status === 'loading' && (
+              <div className="flex items-center justify-center gap-2 text-slate-300">
+                <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+                확인 중...
+              </div>
+            )}
+            {status === 'success' && (
+              <div className="flex items-center justify-center gap-3 text-emerald-400">
+                <CheckCircle className="w-6 h-6" aria-hidden="true" />
+                <span>{message}</span>
+              </div>
+            )}
+            {status === 'error' && (
+              <div className="flex items-center justify-center gap-3 text-red-400">
+                <XCircle className="w-6 h-6" aria-hidden="true" />
+                <span>{message}</span>
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+function SubscribeContent() {
+  const searchParams = useSearchParams();
+  const confirmToken = searchParams.get('confirm');
+
+  // If a confirm token is present, show the confirmation UI
+  if (confirmToken) {
+    return <ConfirmSection token={confirmToken} />;
+  }
+
+  return <SubscribeForm />;
+}
+
 export default function SubscribePage() {
+  return (
+    <React.Suspense
+      fallback={
+        <div
+          className="min-h-screen bg-black text-white flex items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="flex items-center gap-3 text-slate-300">
+            <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+            구독 페이지를 불러오는 중...
+          </span>
+        </div>
+      }
+    >
+      <SubscribeContent />
+    </React.Suspense>
+  );
+}
+
+function SubscribeForm() {
   const { formatted } = useCountdownToTomorrow();
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -170,7 +170,8 @@ function SubscribeForm() {
         body: JSON.stringify({ email: validated.email, name: validated.name }),
       });
       const result = (await res.json().catch(() => ({}))) as {
-        status?: 'subscribed' | 'resubscribed';
+        status?: 'pending';
+        message?: string;
         error?: string;
       };
 
@@ -184,14 +185,20 @@ function SubscribeForm() {
         return;
       }
 
+      if (result.status !== 'pending') {
+        setMessage(result.error || '구독 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+        setStatus('error');
+        return;
+      }
+
       trackEvent('generate_lead', {
         method: 'newsletter',
         form_id: 'newsletter_subscribe',
-        lead_type: result.status === 'resubscribed' ? 'resubscribe' : 'new_subscriber',
+        lead_type: 'pending_confirmation',
         content_type: 'subscription',
       });
 
-      setMessage('구독이 완료되었습니다! 매일 오전 7시 30분에 이메일을 받으실 수 있습니다.');
+      setMessage('확인 이메일을 보냈습니다. 이메일의 확인 링크를 눌러 구독을 확인해주세요.');
       setStatus('success');
       setEmail('');
       setName('');

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,56 +1,126 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, Suspense } from 'react';
 import { motion } from 'framer-motion';
 import { useSearchParams } from 'next/navigation';
-import { CheckCircle, XCircle, Loader2, AlertCircle } from 'lucide-react';
+import { CheckCircle, XCircle, Loader2, AlertCircle, Mail } from 'lucide-react';
 import Link from 'next/link';
-import { z } from 'zod';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import AnimatedBackground from '@/components/animated-background';
 
-const emailSchema = z.string().pipe(z.email({ message: '잘못된 이메일 형식' }));
+/**
+ * Recovery form for subscribers whose link is missing, legacy (`?email=`) or
+ * expired. Requesting a link never opts anyone out on its own — the mailed link
+ * still requires explicit confirmation.
+ */
+function RequestLinkForm({ initialEmail }: { initialEmail: string }) {
+  const [email, setEmail] = useState(initialEmail);
+  const [state, setState] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
 
-function UnsubscribeContent() {
-  const searchParams = useSearchParams();
-  const email = searchParams.get('email');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-
-  useEffect(() => {
-    if (email && emailSchema.safeParse(email).success) {
-      handleUnsubscribe();
-    } else if (email) {
-      setStatus('error');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [email]);
-
-  const handleUnsubscribe = async () => {
-    if (!email) return;
-
-    setStatus('loading');
-
+  const handleRequest = async () => {
+    setState('sending');
     try {
-      const res = await fetch('/api/unsubscribe', {
+      const res = await fetch('/api/unsubscribe/request', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email }),
       });
+      setState(res.ok ? 'sent' : 'error');
+    } catch {
+      setState('error');
+    }
+  };
+
+  if (state === 'sent') {
+    return (
+      <div
+        className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-emerald-500/20 bg-emerald-500/5 text-left"
+        role="status"
+        aria-live="polite"
+      >
+        <CheckCircle className="w-5 h-5 text-emerald-400 mt-0.5 flex-shrink-0" aria-hidden="true" />
+        <p className="text-base text-slate-300 font-light tracking-wide leading-relaxed">
+          해당 주소가 구독 중이라면 구독 취소 링크를 발송했습니다. 이메일을 확인해주세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto text-left">
+      <label htmlFor="unsubscribe-email" className="block text-sm text-slate-400 mb-3 tracking-wide">
+        구독하신 이메일 주소를 입력하시면 구독 취소 링크를 보내드립니다
+      </label>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Input
+          id="unsubscribe-email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="you@example.com"
+          className="bg-black/50 border-emerald-500/30 text-slate-200 placeholder:text-slate-600 rounded-lg px-4 py-6"
+        />
+        <Button
+          onClick={handleRequest}
+          disabled={state === 'sending' || email.trim().length === 0}
+          className="bg-emerald-600 text-black hover:bg-emerald-500 rounded-lg px-6 py-6 font-semibold disabled:opacity-50 cursor-pointer"
+        >
+          {state === 'sending' ? (
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <span className="whitespace-nowrap">링크 받기</span>
+          )}
+        </Button>
+      </div>
+      {state === 'error' && (
+        <p className="mt-3 text-sm text-red-300/90" role="alert">
+          요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function UnsubscribeContent() {
+  const searchParams = useSearchParams();
+  // Token-only for the mutation itself. A legacy `?email=` link only prefills the
+  // recovery form — it never unsubscribes directly.
+  const token = searchParams.get('token');
+  const legacyEmail = searchParams.get('email') ?? '';
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error' | 'expired'>('idle');
+
+  const hasValidParam = !!token;
+
+  const handleUnsubscribe = async () => {
+    setStatus('loading');
+
+    try {
+      const payload = { token };
+      const res = await fetch('/api/unsubscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (res.status === 410) {
+        setStatus('expired');
+        return;
+      }
 
       if (!res.ok) {
-        console.error('Unsubscribe error:', await res.text().catch(() => ''));
         setStatus('error');
         return;
       }
 
       setStatus('success');
-    } catch (error) {
-      console.error('Unsubscribe error:', error);
+    } catch {
       setStatus('error');
     }
   };
 
-  if (!email || !emailSchema.safeParse(email).success) {
+  if (!hasValidParam) {
     return (
       <motion.div
         initial={{ opacity: 0, y: 60 }}
@@ -65,28 +135,84 @@ function UnsubscribeContent() {
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
             transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
-            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
             aria-hidden="true"
           >
-            <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
+            <Mail className="w-10 lg:w-12 h-10 lg:h-12 text-emerald-400" />
           </motion.div>
           <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
-            Invalid Request
+            Unsubscribe
           </p>
           <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
-            유효하지 않은 이메일 주소입니다
+            구독 취소 링크를 받아 진행해주세요
           </p>
         </div>
-        <Link href="/">
-          <Button
-            variant="outline"
-            className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
-            aria-label="Back to home page"
+
+        <RequestLinkForm initialEmail={legacyEmail} />
+
+        <div className="mt-10">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+              aria-label="Back to home page"
+            >
+              <span className="relative z-10 font-medium">Back to Home</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
+      </motion.div>
+    );
+  }
+
+  if (status === 'idle') {
+    // Explicit confirmation — no page-load mutation
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 60 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+        className="max-w-2xl mx-auto text-center w-full"
+      >
+        <div className="mb-12 lg:mb-16">
+          <motion.div
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
+            aria-hidden="true"
           >
-            <span className="relative z-10 font-medium">Back to Home</span>
-            <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
-          </Button>
-        </Link>
+            <AlertCircle className="w-10 lg:w-12 h-10 lg:h-12 text-emerald-400" />
+          </motion.div>
+          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+            Unsubscribe
+          </p>
+          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+            뉴스레터 구독을 취소하시겠습니까?
+          </p>
+        </div>
+
+        <Button
+          onClick={handleUnsubscribe}
+          className="group relative overflow-hidden bg-red-600 text-white hover:bg-red-500 rounded-lg px-10 py-6 lg:px-12 lg:py-7 font-semibold shadow-lg hover:shadow-xl transition-all duration-700 ease-out-expo focus:ring-2 focus:ring-red-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide cursor-pointer"
+          aria-label="구독 취소 확인"
+        >
+          <span className="relative z-10">구독 취소 확인</span>
+        </Button>
+
+        <div className="mt-6">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-8 py-4 transition-all duration-500 ease-out-expo tracking-wide"
+              aria-label="취소하고 홈으로"
+            >
+              <span className="relative z-10 font-medium">취소</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
       </motion.div>
     );
   }
@@ -108,6 +234,52 @@ function UnsubscribeContent() {
         <p className="text-2xl text-slate-300 font-light tracking-wide">
           구독 취소 요청을 처리하고 있습니다...
         </p>
+      </motion.div>
+    );
+  }
+
+  if (status === 'expired') {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 60 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+        className="max-w-2xl mx-auto text-center w-full"
+        role="alert"
+        aria-live="assertive"
+      >
+        <div className="mb-12 lg:mb-16">
+          <motion.div
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-emerald-500/30 mb-10 lg:mb-12"
+            aria-hidden="true"
+          >
+            <AlertCircle className="w-10 lg:w-12 h-10 lg:h-12 text-yellow-400" />
+          </motion.div>
+          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+            Link Expired
+          </p>
+          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+            구독 취소 링크가 만료되었습니다. 새 링크를 받아 진행해주세요.
+          </p>
+        </div>
+
+        <RequestLinkForm initialEmail={legacyEmail} />
+
+        <div className="mt-10">
+          <Link href="/">
+            <Button
+              variant="outline"
+              className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+              aria-label="Back to home page"
+            >
+              <span className="relative z-10 font-medium">Back to Home</span>
+              <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+            </Button>
+          </Link>
+        </div>
       </motion.div>
     );
   }
@@ -140,35 +312,11 @@ function UnsubscribeContent() {
           </p>
         </div>
 
-        {/* Info Card */}
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
-          className="glass-morphism rounded-3xl p-8 lg:p-10 border border-emerald-500/20 mb-8 lg:mb-10 text-center relative overflow-hidden"
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 via-transparent to-emerald-500/5 pointer-events-none" aria-hidden="true" />
-          <div className="relative z-10 space-y-6">
-            <div>
-              <div className="text-sm text-slate-300 mb-3 font-light tracking-wider">Email Address</div>
-              <div className="text-lg text-emerald-300/90 break-all font-light tracking-wide">{email}</div>
-            </div>
-            <div className="h-px bg-gradient-to-r from-transparent via-emerald-500/20 to-transparent" aria-hidden="true" />
-            <div>
-              <div className="text-sm text-slate-300 mb-3 font-light tracking-wider">Status</div>
-              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-lg glass-morphism border border-emerald-500/20">
-                <div className="w-2 h-2 rounded-lg bg-emerald-500/60 animate-[matrix-pulse_2s_ease-in-out_infinite]" aria-hidden="true" />
-                <span className="text-base text-emerald-300/90 font-light tracking-wide">Inactive</span>
-              </div>
-            </div>
-          </div>
-        </motion.div>
-
         {/* Notice */}
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.6, ease: [0.19, 1, 0.22, 1] }}
+          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
           className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-emerald-500/20 bg-emerald-500/5 mb-10 lg:mb-12 text-left"
           role="note"
         >
@@ -182,7 +330,7 @@ function UnsubscribeContent() {
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.8, ease: [0.19, 1, 0.22, 1] }}
+          transition={{ duration: 0.8, delay: 0.6, ease: [0.19, 1, 0.22, 1] }}
           className="flex flex-col sm:flex-row gap-4 justify-center"
         >
           <Link href="/" className="w-full sm:w-auto">
@@ -209,59 +357,56 @@ function UnsubscribeContent() {
     );
   }
 
-  if (status === 'error') {
-    return (
-      <motion.div
-        initial={{ opacity: 0, y: 60 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
-        className="max-w-2xl mx-auto text-center"
-      >
-        <div className="mb-12 lg:mb-16">
-          <motion.div
-            initial={{ scale: 0.8 }}
-            animate={{ scale: 1 }}
-            transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
-            className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
-            aria-hidden="true"
-          >
-            <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
-          </motion.div>
-          <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
-            Error
-          </p>
-          <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
-            구독 취소 처리 중 오류가 발생했습니다
-          </p>
-        </div>
-
+  // status === 'error'
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 60 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8, ease: [0.19, 1, 0.22, 1] }}
+      className="max-w-2xl mx-auto text-center"
+    >
+      <div className="mb-12 lg:mb-16">
         <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
-          className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-red-500/30 bg-red-500/5 mb-10 lg:mb-12 text-left"
+          initial={{ scale: 0.8 }}
+          animate={{ scale: 1 }}
+          transition={{ duration: 0.6, delay: 0.2, ease: [0.19, 1, 0.22, 1] }}
+          className="inline-flex items-center justify-center w-20 lg:w-24 h-20 lg:h-24 rounded-lg glass-morphism border border-red-500/30 mb-10 lg:mb-12"
+          aria-hidden="true"
         >
-          <AlertCircle className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" />
-          <p className="text-base text-red-100/80 font-light tracking-wide leading-relaxed">
-            시스템 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
-          </p>
+          <XCircle className="w-10 lg:w-12 h-10 lg:h-12 text-red-400" />
         </motion.div>
+        <p className="text-5xl sm:text-6xl md:text-7xl font-extralight mb-6 lg:mb-8 text-emerald-500/80 leading-tight tracking-tight" role="heading" aria-level={2}>
+          Error
+        </p>
+        <p className="text-xl sm:text-2xl text-slate-300 font-light mb-12 lg:mb-16 tracking-wide">
+          구독 취소 처리 중 오류가 발생했습니다
+        </p>
+      </div>
 
-        <Link href="/">
-          <Button
-            variant="outline"
-            className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
-            aria-label="Back to home page"
-          >
-            <span className="relative z-10 font-medium">Back to Home</span>
-            <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
-          </Button>
-        </Link>
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8, delay: 0.4, ease: [0.19, 1, 0.22, 1] }}
+        className="flex items-start gap-4 p-6 rounded-2xl glass-morphism border border-red-500/30 bg-red-500/5 mb-10 lg:mb-12 text-left"
+      >
+        <AlertCircle className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" />
+        <p className="text-base text-red-100/80 font-light tracking-wide leading-relaxed">
+          시스템 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
       </motion.div>
-    );
-  }
 
-  return null;
+      <Link href="/">
+        <Button
+          variant="outline"
+          className="relative group overflow-hidden bg-black/50 border-emerald-500/30 text-emerald-400 hover:text-black hover:border-emerald-400 rounded-lg px-10 py-6 lg:px-12 lg:py-7 transition-all duration-500 ease-out-expo focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-4 focus:ring-offset-black tracking-wide"
+          aria-label="Back to home page"
+        >
+          <span className="relative z-10 font-medium">Back to Home</span>
+          <span className="absolute inset-0 bg-emerald-600 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out-expo origin-left" aria-hidden="true" />
+        </Button>
+      </Link>
+    </motion.div>
+  );
 }
 
 export default function UnsubscribePage() {

--- a/docs/PR111_REVIEW_2026-07-31.md
+++ b/docs/PR111_REVIEW_2026-07-31.md
@@ -1,0 +1,202 @@
+# PR #111 프로덕션 레디 전수 리뷰 (2026-07-31)
+
+PR #111은 리뷰 없이 `main`에 squash merge되었다(`21c0866`, +12,245 / −2,358, 138 files).
+`main`은 `e69beae`로 revert했고, 변경분은 태스크별 PR로 분할해 다시 올린다.
+
+검증 기준선: `tsc --noEmit` 0 errors, `eslint` 0 errors(기존 warning 23), `vitest` 3553/3553 pass,
+`next build --turbopack` 성공. **원본 PR은 이 게이트를 모두 통과했다** — 아래 결함은 게이트가
+잡지 못하는 종류다.
+
+---
+
+## 분할 계획
+
+| PR | 범위 | 마이그레이션 |
+|---|---|---|
+| 1 | 보안 격리 (SEC-001/002/003/005) | 056b, 057 |
+| 2 | 뉴스레터 발송 상태머신 (COR-002/003/004/005) | 058, 059 |
+| 3 | TLI 데이터 정합성 (DATA-001/003, ARC-001, COR-001) | 061, 062 |
+| 4 | 조회 성능 (COR-016, PERF-004) | 063 |
+| 5 | UI/UX 회귀 (COR-017/018, ML-002/003, PERF-007) | — |
+| 보류 | **LLM/AI 파이프라인 + provenance** | 060 |
+
+**LLM 설정 변경은 전부 원복하고 별도 태스크로 분리한다.** `lib/llm/**`, `lib/market-data/**`,
+`app/blog/**`(gemini-client 경유 결합), `scripts/prepare-newsletter.ts`, 마이그레이션 060이
+여기 해당한다.
+
+---
+
+## Blocker
+
+### B-1. LLM 실행 예산이 잘못된 실행 환경 기준으로 산정됨
+
+`lib/llm/_config/pipeline-config.ts`
+
+원 지적(AI-003)은 "stage timeout 20분이 Vercel `maxDuration=300`과 불일치"였다. 적용된 수정은
+Vercel 기준 예산을 **전역**에 적용했다.
+
+| 항목 | 변경 전 | 변경 후 | 비율 |
+|---|---|---|---|
+| `STAGE_TIMEOUT` | 1,200,000ms (20분) | 45,000ms | 1/26 |
+| `GLOBAL_DEADLINE_MS` | — | 270,000ms (7 stage 전체) | 신규 |
+| `OUTER_MAX_RETRY` | 3 | 1 | |
+| `STAGE_MAX_RETRY` | 5 | 2 | |
+| `GLOBAL_MAX_CALLS` | — | 12 | 신규 |
+
+실제 프로덕션 뉴스레터 생성은 `scripts/prepare-newsletter.ts` → GitHub Actions
+(`prepare-newsletter.yml`, step `timeout-minutes: 55`)에서 실행된다. 270초 예산의 근거인
+Vercel 300초 제약은 `app/api/cron/send-recommendations/route.ts` 경로에만 적용된다.
+변경 전 주석은 20분 timeout이 "gemini + Google Search 포함 복잡한 분석에 충분한 시간"이라고
+명시하고 있었다.
+
+`LlmExecutionBudgetError`는 `executeStage`에서 재시도 없이 즉시 throw된다
+(`gemini-pipeline.ts`). 즉 deadline 도달 = 당일 뉴스레터 생성 전면 실패.
+
+### B-2. 모델·생성 파라미터가 문서화 없이 다운그레이드됨
+
+`lib/llm/_config/pipeline-config.ts`. PR 본문·리뷰 문서 어디에도 언급이 없고, 대응하는 finding도
+없다.
+
+| 항목 | 변경 전 | 변경 후 |
+|---|---|---|
+| `MODEL` | `gemini-3-flash-preview` | `gemini-2.5-flash` |
+| `MAX_OUTPUT_TOKENS` | 65,536 | 8,192 |
+| `TEMPERATURE` | 1.0 | 0.2 |
+| `TOP_P` / `TOP_K` | 0.95 / 64 | 0.9 / 40 |
+
+출력 토큰 8배 축소는 다단계 분석 출력이 `FinishReason.MAX_TOKENS`로 잘릴 위험이 있다.
+
+### B-3. 종목 claim 검증 실패가 당일 뉴스레터를 전면 중단시킴
+
+`lib/llm/korea/stock-claims-verifier.ts:79`
+
+```
+if (unique.size !== 1) throw new Error(`Stock identity is missing or conflicting for ${symbol}`)
+```
+
+추천 종목이 `theme_stocks`(`source='naver'`)에 없으면 throw한다. Gemini는 KOSPI/KOSDAQ 전체에서
+고르지만 `theme_stocks`는 네이버 테마 편입 종목만 담는다. `OUTER_MAX_RETRY: 1`이라 복구 경로도
+없다 → 당일 발송 실패.
+
+### B-4. 기 발송 뉴스레터의 구독취소 링크가 전부 무효화됨
+
+변경 전 `lib/sendgrid.ts`는 `/unsubscribe?email=<email>` 링크를 심었다. PR은 페이지·API 모두
+token 전용으로 바꿔 **이미 발송된 모든 메일의 구독취소 링크가 "Invalid Request"로 끝난다.**
+신규 토큰도 TTL 30일이라 그 이후 발송분도 동일해진다.
+
+정보통신망법 제50조(수신거부 조치) 위반 소지.
+
+→ **PR 1에서 수정함** (아래 F-1).
+
+---
+
+## High
+
+### H-1. 구독 재신청이 영구 불가
+
+`app/api/subscribe/route.ts` — `pending_subscribers` upsert가 `confirmed_at`을 초기화하지 않는다.
+확인 완료 → 구독취소 → 재신청 시 이전 `confirmed_at`이 남아 `confirm_subscription`이
+`already_confirmed`를 반환하고(057:169), 라우트는 **200 "이미 확인된 구독입니다"** 를 돌려준다.
+`subscribers.is_active`는 `false`인 채로 남아 사용자는 다시는 메일을 받지 못한다.
+
+→ **PR 1에서 수정함** (F-2).
+
+### H-2. `stock_price_cache`가 완전히 고아화됨
+
+- 056b가 테이블을 `TRUNCATE`
+- 클라이언트 캐시 접근 제거(정당한 SEC-005 수정)
+- **그러나 서버 쪽 대체 경로를 넣지 않음** — `getBatchPricesFromCache` / `saveBatchPricesToCache`
+  호출자 0개, `getBatchStockPrices`는 캐시를 참조하지 않음
+
+결과: 아카이브 조회마다 KIS 직접 호출(티커당 순차 + 100ms sleep), 방어는 CDN 60초뿐.
+런북의 "cache refill 이후 정상 동작"은 성립하지 않는다(채우는 주체가 없음).
+
+→ **PR 1에서 수정함** (F-3).
+
+### H-3. `/api/tli/compare` sparkline이 시간 역순으로 렌더됨
+
+`app/api/tli/compare/route.ts:86-93`. 변경 전 쿼리는 `.order('calculated_at', ascending: true)`
+였다. RPC `load_theme_score_windows`는 `ORDER BY calculated_at DESC`(063:113)로 반환하는데,
+compare 라우트는 그대로 push한다. `ranking-helpers.ts:198`은 같은 상황에서 `.reverse()`를
+호출하지만 compare에는 없다.
+
+→ PR 4에서 수정 예정.
+
+### H-4. 배포 설정 오류가 `ambiguous`로 오분류되어 발송이 영구 정지
+
+`lib/delivery/service.ts:536-552`. `sendSingleRecipient`는 네트워크 호출 **이전에**
+`initSendGrid()`(SENDGRID_* 누락 시 throw)와 unsubscribe 토큰 생성
+(`UNSUBSCRIBE_TOKEN_SECRET` 누락/32자 미만 시 throw)을 수행한다. 이 throw는 catch되어
+`ambiguous`로 기록되는데, `ambiguous`는 설계상 **자동 재시도되지 않는다**.
+
+즉 환경변수 하나 누락 = 전 수신자 `ambiguous` = 수동 DB 개입 없이는 복구 불가.
+"발송됐을 수도 있음"이 아니라 "확실히 발송 안 됨"이므로 분류 자체가 틀렸다.
+
+→ PR 2에서 수정 예정 (발송 시작 전 preflight 검증).
+
+### H-5. OG 배경 이미지 런타임 로드가 Vercel에서 실패할 수 있음
+
+`lib/og-template.tsx` — `readFileSync(join(process.cwd(), 'public', 'og-background-v1.png'))`.
+`next.config.ts`에 `outputFileTracingIncludes` 설정이 없다. `public/`은 CDN 서빙 대상이지
+서버리스 함수 번들에 자동 포함되지 않는다. PR 본문의 검증("로컬에서 확인")은 이 실패 모드를
+재현하지 못한다.
+
+→ PR 5에서 수정 예정.
+
+---
+
+## Medium
+
+| # | 항목 | 위치 |
+|---|---|---|
+| M-1 | `withRetry`가 `\b4\d{2}\b` 문자열 매칭으로 4xx 판정 → "Timeout after 450ms" 같은 메시지에서 재시도가 조용히 비활성화 | `scripts/tli/shared/utils.ts` |
+| M-2 | 056b의 비가드 REVOKE 3건(`clean_expired_stock_price_cache`, `v_prediction_v4_serving`, `increment_blog_view_count`) → 객체 부재 시 마이그레이션 전체 중단 (`insert_mcp_analytics`만 가드됨) | `056b` |
+| M-3 | `SCORE_QUERY_BATCH_SIZE`(=10) / `SCORE_QUERY_WINDOW_DAYS`(=14)가 export·테스트 단언은 유지되지만 호출부는 500/14를 하드코딩 → SSOT 붕괴, 테스트가 죽은 값을 검증 | `ranking-helpers.ts`, `ranking/route.ts`, `get-ranking-server.ts` |
+| M-4 | `resolveUnknownMarkets`가 첫 KIS 실패에서 throw → 테마 종목 수집 전체 중단. TLI 파이프라인에 KIS 경성 의존 + 종목당 100ms 직렬화 신규 도입 | `naver-finance-themes.ts` |
+| M-5 | `loadLatestPublishedComparisonRuns` 100개 초과 시 error 반환하나 호출부가 `if (!runsError && ...)`로 삼켜 pairwise similarity가 조용히 사라짐 | `compare/route.ts` |
+| M-6 | 신규 커스텀 Error 클래스 4종 — `conventions.md` anti-pattern #6(custom Error class 금지) 위반 | `execution-budget.ts`, `token-storage.ts`, `naver-finance-themes.ts` |
+| M-7 | rate limiter가 `x-real-ip`만 신뢰 + fail-closed → Vercel 외 경로(로컬/자체 호스팅/프록시)에서 `/api/stock/*`, `/api/subscribe`, `/api/unsubscribe` 전부 503 | `rate-limit.ts` |
+| M-8 | `lib/security/index.ts` barrel export — 소비자 0개 + anti-pattern #3 위반 | `lib/security/index.ts` |
+
+---
+
+## Low
+
+| # | 항목 |
+|---|---|
+| L-1 | `isValidTicker`의 `KOREAN_TICKER_PATTERN`은 `GENERAL_TICKER_PATTERN`에 포함됨 — 죽은 분기 |
+| L-2 | `/api/stock/price` 응답 `metadata` → `meta` 파괴적 개명 (외부 소비자는 확인되지 않음) |
+| L-3 | `security.test.ts` 헤더 주석이 실제보다 넓은 커버리지를 주장 (route 테스트·`vi.mock` 없음) |
+| L-4 | 발송 메일에 RFC 8058 `List-Unsubscribe` 헤더 없음 (기존 이슈) |
+
+---
+
+## 확인된 정상 사항
+
+원본 PR에서 다음은 검토 결과 문제없다.
+
+- 삭제 파일 5종(`types/newsletter.ts`, `crash-alert-to-image.ts`, `ui/badge.tsx`, `ui/card.tsx`,
+  `og-background.ts`) — 잔존 import 0건, 실제 사용되지 않던 코드
+- `snapshot_delivery_recipients`가 `s.is_active = true`로 필터 — 기존 구독자 회귀 없음
+- 마이그레이션 057의 rate limit / double opt-in RPC — 원자성·권한 경계 적절
+- 발송 상태머신의 terminal run 보호, snapshot 불변성, worker ID 검증
+- next.config.ts 보안 헤더 강화(HSTS, `object-src`, `base-uri`)
+- `lifecycle-score.tsx` 접근성 개선(`role`, `aria-label`, confidence 사유 노출)
+
+---
+
+## PR 1에서 적용한 수정
+
+- **F-1** (B-4): `/unsubscribe`에 이메일 입력 폴백 추가. 토큰이 없거나 만료·레거시 `?email=`
+  링크인 경우 새 토큰을 메일로 재발급한다. `POST /api/unsubscribe/request`는 구독 중인 주소일
+  때만 발송하고 응답은 항상 동일하다(열거 방지). 링크 요청 자체는 해지가 아니며 메일의 링크에서
+  명시적 확인을 거친다.
+- **F-2** (H-1): 구독 upsert에 `confirmed_at: null` 추가 — 재신청 시 이전 확인 상태 초기화.
+- **F-3** (H-2): `/api/stock/price`가 service_role로 캐시를 읽고 쓰도록 재연결. 미스 티커만 KIS로
+  넘기고, 응답에서 내부 필드 `expires_at`은 제거한다.
+- **F-4** (M-2): 056b의 REVOKE 3건을 존재 확인 가드로 감쌈.
+- **F-5** (M-8): `lib/security/index.ts` barrel 제외.
+- **F-6** (L-1): 라우트 인라인 중복 검증을 `lib/security/validators.ts`로 통합.
+
+회귀 테스트: `app/api/__tests__/subscription-lifecycle.test.ts`,
+`app/api/stock/__tests__/price-cache-wiring.test.ts`.

--- a/docs/PR111_REVIEW_2026-07-31.md
+++ b/docs/PR111_REVIEW_2026-07-31.md
@@ -200,3 +200,78 @@ compare 라우트는 그대로 push한다. `ranking-helpers.ts:198`은 같은 �
 
 회귀 테스트: `app/api/__tests__/subscription-lifecycle.test.ts`,
 `app/api/stock/__tests__/price-cache-wiring.test.ts`.
+
+---
+
+## 2차 전수 리뷰 (최종 diff 기준)
+
+1차는 원본 PR #111 내용을, 2차는 분할·수정 이후의 최종 diff를 대상으로 했다.
+2차에서 새로 확인한 결함은 아래와 같으며 모두 수정했다.
+
+### N-1 (High) — 전면 발송 실패가 성공으로 보고됨
+
+`reconcile_delivery_run`은 permanent failure와 skip을 terminal로 보므로, **전 수신자가
+실패해도 run status는 `completed`** 다. 호출부는 그 값만 보고 성공으로 판정했다.
+
+결과: SendGrid 키 폐기처럼 전 수신자가 4xx로 거절되는 장애에서
+- `scripts/send-newsletter.ts` → `process.exitCode = 0` (워크플로 초록)
+- `/api/cron/send-newsletter` → HTTP 200
+- **게다가 Twitter에 "오늘의 뉴스레터" 공지까지 나간다** (`result.success` 분기 안에 있음)
+
+즉 304명 중 0명 도달을 아무도 알아채지 못한다.
+
+`isSuccessfulDelivery()`를 서비스에 두고 `success`를 "terminal이면서, 수신자가 있다면 최소 1명은
+수락됨"으로 정의했다. 두 호출부가 같은 정의를 공유하므로 exit code·HTTP status·Twitter 게시가
+한꺼번에 교정된다.
+
+### N-2 (Medium) — 재시도 예산이 수 밀리초 만에 소진
+
+claim 루프는 `retryable` 행을 **지연 없이** 즉시 다시 집어온다. `max_attempts=3`이 사실상
+동시에 소모되어, 30초짜리 provider 스로틀 하나로 그날 발송 전체가 `retry_exhausted` permanent
+failure로 확정된다. 재시도가 이름만 재시도였다.
+
+`claim_delivery_batch`가 `attempt_count`를 함께 반환하도록 하고, 재시도 배치 앞에서 지수 백오프
+(2s → 4s → 8s, 상한 30s)를 넣었다. abort signal을 존중한다.
+
+### N-3 (High) — 추적되지 않는 두 번째 발송 경로가 살아 있음
+
+`app/api/cron/send-recommendations/route.ts`가 남아 있었다. 이 라우트는
+
+- **GET**으로 전 구독자에게 메일을 발송한다 (부수효과가 있는 GET)
+- 새 delivery ledger를 **완전히 우회**한다 — 멱등성·수신자별 추적·재시도 분류 없음
+- `successCount = subscribers.length; failCount = 0;` 으로 **성공 수치를 조작해서** `email_logs`에
+  기록한다. 실제 실패와 무관하다.
+
+PR #111 본문이 "no separate generate-and-blast"라고 적었지만 라우트는 남아 있었다. 스케줄러
+(`vercel.json` crons, GitHub Actions) 어디에도 등록돼 있지 않아 사용되지 않는 경로다.
+삭제했다 — 남겨두면 COR-002/003/004/005 remediation 전체가 무력화될 수 있다.
+
+부수 효과: B-1(LLM 예산)의 근거였던 `maxDuration = 300` 제약이 이 라우트에만 있었으므로,
+삭제 후 프로덕션 LLM 경로는 GitHub Actions(55분 예산) 하나만 남는다. B-1 판단이 더 명확해졌다.
+
+### N-4 (Low) — 정리
+
+- `reconcile_delivery_run`의 죽은 분기(양쪽 모두 `'completed'` 대입)와 미사용 변수 `v_exhausted` 제거
+- `sendStockNewsletter`의 `(hash: N chars)` 로그 — 해시가 아니라 이메일 길이였다. 수신자 식별
+  정보를 남기지 않도록 제거하고, deprecated 사유를 구체적으로 다시 적었다.
+
+### 검토했고 문제없다고 판단한 것
+
+- `claim_delivery_batch`의 `FOR UPDATE SKIP LOCKED` + CTE UPDATE — 표준 안전 패턴
+- `mark_delivery_outcome`의 worker ID 정확 일치 요구, `p_claimed_by` NULL 우회 차단
+- `recover_stale_claims` — 자동 회수 없이 `ambiguous` 전환만. run 시작 시 1회만 호출되므로
+  자기 자신의 in-flight claim을 훼손하지 않는다
+- 마이그레이션 062 — service_role 검증, 연산 수 상한, `FOR UPDATE` 잠금, stale target 탐지,
+  ROW_COUNT 단언. 부분 적용이 불가능한 구조
+- KIS 토큰 — single-flight 발급, 거절된 토큰만 정확히 무효화, 401/403 1회 재시도 후 terminal
+- `naver-news-api`의 KST 파싱(`Intl.DateTimeFormat`), link 기준 dedupe-before-count,
+  raw 관측일 기반 coverage 증명
+- 전체 diff에 `as any`/`@ts-ignore` 0건, 하드코딩 시크릿 0건, 이메일 로깅 0건
+
+### 남은 주의사항 (수정하지 않음)
+
+- `getTokenFromStorage`가 저장소 오류를 throw한다. Supabase 장애 시 KIS 조회가 전면 실패한다.
+  이전 동작(오류를 cache miss로 간주 → 새 토큰 발급)은 저장소 장애 중 토큰 발급이 폭주해 KIS
+  발급 쿼터를 태우므로, 크게 실패하는 쪽이 의도된 선택이다.
+- Preview 환경에 `SUPABASE_SERVICE_ROLE_KEY`가 없다. sitemap은 부분 sitemap으로 물러나지만,
+  DB에 의존하는 preview 페이지는 여전히 비어 보인다. 환경변수를 채우는 것이 정답이다.

--- a/docs/PROJECT_READINESS_FULL_REVIEW_2026-07-30.md
+++ b/docs/PROJECT_READINESS_FULL_REVIEW_2026-07-30.md
@@ -1,0 +1,640 @@
+# Stock Matrix 프로젝트 준비도 전수 리뷰
+
+- **리뷰 일자:** 2026-07-30
+- **고정 스냅샷:** `8e614aaa75a8f1d103140ff4a293e4ba8fff3ae2`
+- **브랜치:** `main`
+- **커밋 시각:** 2026-07-25T13:15:47+09:00
+- **대상 저장소:** `/Users/isaac/projects/stock-ai-newsletter`
+- **최종 판정:** **NOT READY — 현 상태 그대로의 다음 production release를 승인하지 않음**
+- **변경 범위:** 이 보고서만 추가. 애플리케이션 코드·설정·migration·test는 변경하지 않음.
+
+> 이 판정은 “좋은 코드가 없다”는 뜻이 아니다. 과학적 TLI containment, immutable provenance, Python 모델 계약, DataLab 수집 계약, 최근 RLS 정책 등에는 매우 강한 통제가 있다. 그러나 인증 없이 대량 메일을 유발할 수 있는 route, 익명 쓰기가 가능한 주가 cache, 구독자 소유권·해지 설계, 비멱등 newsletter 발송, 재현 불가능한 DB bootstrap, red 상태의 기본 test/E2E gate, runtime dependency 취약점, 데이터 날짜·완전성 오류가 동시에 남아 있어 release risk를 수용 가능한 수준으로 낮추지 못했다.
+
+---
+
+## 1. 경영 요약
+
+### 1.1 결론
+
+프로젝트는 기능 폭과 과학적 검증 장치는 인상적이지만, production readiness의 기본 축인 **보안 기본값, 메일 idempotency, 재현 가능한 배포, 자동 quality gate, 개인정보 수명주기, 운영 관측성**이 아직 일관된 하나의 시스템으로 닫혀 있지 않다. 특히 다음 네 가지는 즉시 containment가 필요하다.
+
+1. `app/api/cron/send-newsletter/route.ts`는 `CRON_SECRET`이 없으면 인증 검사를 생략한다.
+2. `stock_price_cache`는 anon insert/update를 허용하고 browser code가 그 값을 신뢰한다.
+3. unsubscribe URL에 raw email을 넣고 page load가 즉시 해지를 실행한다.
+4. newsletter의 `Promise.all` 발송과 사후 단일 sent flag는 partial delivery 후 retry 중복을 방지하지 못한다.
+
+또한 clean Supabase 환경이 migration 030에서 재현되지 않고, pull request CI가 없으며, 기본 `npm test`와 실제 Playwright E2E가 red이고, root typecheck는 핵심 `scripts/`를 제외한다. 따라서 “현재 production이 존재한다”는 사실은 새 release·재해복구·staging 재현 가능성을 증명하지 않는다.
+
+### 1.2 준비도 매트릭스
+
+| 영역 | 상태 | 핵심 판단 |
+|---|---:|---|
+| 보안·개인정보 | 🔴 | fail-open cron, 구독자 소유권 부재, cache poisoning, scraper SSRF, PII URL/log |
+| 정확성·메일 신뢰성 | 🔴 | partial delivery 중복, sent-state 실패 무시, 잘못된 7d 비교, calendar drift |
+| 데이터·AI 신뢰성 | 🔴 | Naver 날짜/완전성, correlated self-verification, crash fallback false-negative |
+| 테스트·품질 gate | 🔴 | 기본 test red, E2E 13 failures, scripts type errors, PR CI 없음 |
+| 배포·DR | 🔴 | clean DB bootstrap 불가, schema/app 순서 미강제, dual lock drift |
+| 성능·확장성 | 🟠 | prediction N+1, subscriber 1,000-row cap, archive client bundle 성장 |
+| 아키텍처·모듈화 | 🟠 | runtime boundary 위반, 중복 client/retry/calendar/pagination, orphan code |
+| 과학적 ML containment | 🟢 | immutable manifests, hash binding, interval replay, fail-closed exposure |
+| 문서·DX | 🔴 | root README/env/deploy 문서 부재, canonical SSOT가 gitignored·결손 |
+
+### 1.3 Release blockers
+
+아래 항목은 수정하거나, owner·기한·명시적 risk acceptance를 남기기 전에는 release를 진행하지 않는 것을 권고한다.
+
+| Blocker | 관련 finding | 차단 이유 | 최소 해제 조건 |
+|---|---|---|---|
+| RB-01 인증 없는 대량 메일 가능 | SEC-001 | secret 미설정이 “거부”가 아니라 “허용”으로 바뀜 | route 삭제/비공개화 또는 secret 필수+timing-safe 검증+negative test |
+| RB-02 구독·해지 소유권 및 PII 설계 | SEC-002, SEC-003, SEC-013 | 타인 재구독/해지, scanner auto-unsubscribe, URL PII | signed opaque token, confirmation UX, rate limit, double opt-in, privacy 문서 |
+| RB-03 주가 cache poisoning 및 quota abuse | SEC-005, SEC-006 | anon이 금융 표시값을 임의 수정하고 KIS quota를 소진 가능 | anon writes revoke, server-only cache writer, validation, rate limit |
+| RB-04 scraper SSRF/runner 격리 부재 | SEC-007, SEC-008, AI-009 | 외부 URL/redirect/private network 검증 없이 `--no-sandbox` browser 실행 | allowlist/denylist, DNS·redirect 재검증, sandboxed isolated worker |
+| RB-05 newsletter 비멱등 전달 | COR-002~005, PERF-001 | partial success 후 retry 중복, 1,000명 이후 누락, DB state 실패 성공 처리 | per-recipient ledger/idempotency key, bounded concurrency, pagination, atomic claim |
+| RB-06 clean DB bootstrap·DR 불가 | DEP-002~004 | 핵심 3개 table의 CREATE가 없고 migration 030이 fresh reset에서 중단 | tested baseline, clean reset CI, schema-first deploy gate, restore drill |
+| RB-07 자동 quality gate 부재·현재 red | QA-001~007, DEP-001 | PR에 test/type/build가 없고 실제 기본 test/E2E가 실패 | required PR CI green, scripts typecheck, real DB migration rehearsal |
+| RB-08 dependency/build 재현성 | SEC-015, DEP-005 | direct runtime Next/Undici high advisories, 두 lock의 15/52 direct resolution 차이 | 취약점 patch, 단일 package manager/lock, exact Node pin, clean install build |
+| RB-09 newsletter AI fail-safe와 실행 예산 | AI-001~008 | 근거 미검증·자기검증·300초와 불일치·저신뢰 crash를 NORMAL로 전환 | 독립 source 검증, deadline/call budget, outage 시 recommendation abstain |
+| RB-10 뉴스 데이터 날짜·완전성 | DATA-001~003 | KST 날짜 이동, 1,000 cap을 complete로 기록, false zero가 public score/study에 유입 | KST parsing, cap truncation status, coverage proof, dedupe-before-count |
+| RB-11 부분 pipeline artifact | ARC-001, COR-012~013 | critical 중간 실패 후 의존 단계를 계속 실행하며 rollback 없음 | stage dependency DAG, fail-stop/transactional publish, run-scoped commit |
+| RB-12 prediction containment 우회·legacy PIT | SEC-011, ARC-004, ML-002~003 | anon view가 legacy rows를 노출할 수 있고 legacy basket은 current membership 사용 | view grant revoke, PIT loader 실제 배선, model type/freshness DB constraints |
+| RB-13 공개 UI 회귀 | COR-017~018, QA-004 | low-confidence 경고 소실, mobile chart 0px가 3/3 재현 | prop/reason wiring, mobile min-height, E2E contract 갱신·green |
+| RB-14 개인정보 governance | SEC-004, SEC-013 | subscriber PII log, policy/terms 부재, retention 자동 집행 부재 | PII redaction, retention scheduler, privacy/terms, data inventory/owner |
+
+### 1.4 조건부 차단
+
+- **Prediction 공개 전 필수:** ARC-004, DATA-001/002, SEC-011, ML-002/003, 관측성·drill prerequisite를 모두 닫아야 한다. 현재 `dataSource:"none"` containment는 올바른 안전장치이므로 우회해서는 안 된다.
+- **Subscriber 1,000명 전 필수:** subscriber pagination, delivery ledger, bounded concurrency, retry/idempotency, bounce/suppression 처리를 완료해야 한다.
+- **새 staging/DR 환경 전 필수:** production schema dump에 의존하지 않는 clean baseline과 restore rehearsal이 필요하다.
+
+---
+
+## 2. 범위와 방법
+
+### 2.1 Coverage accounting
+
+Git tracked snapshot을 기준으로 정확히 분류했다.
+
+| 분류 | 파일 | 줄 수 |
+|---|---:|---:|
+| Code | 742 | 101,027 |
+| Tests | 296 | 48,707 |
+| Documentation | 124 | 30,417 |
+| SQL | 63 | 13,167 |
+| Config/data | 42 | 37,159 |
+| Assets/other | 50 | — |
+| **합계** | **1,317** | — |
+
+추가 구조 지표:
+
+- static import graph: **997 modules / 2,175 edges**
+- Next/API routes: **20**
+- GitHub Actions workflows: **9**
+- Supabase migration SQL files: **56**
+- 주요 실행면: Next.js 15, Supabase, newsletter/blog automation, TLI collection/scoring/comparison, scientific Python ML, MCP package
+- 분석 산출물: `/tmp/stock-ai-newsletter-review-inventory.json`, `/tmp/stock-ai-newsletter-import-graph.json`, audit JSON 및 command logs
+
+### 2.2 Eight-pass methodology
+
+1. **Architecture/requirements/flow:** entrypoint, dependency direction, runtime/research boundary, feature availability, import graph.
+2. **Correctness/edge cases:** dates, retries, partial failures, idempotency, limits, stale/latest semantics, bitemporal behavior.
+3. **Security/privacy/supply chain:** authn/authz, RLS, PII, SSRF, CSP, secret scan, npm audit, workflow trust.
+4. **Data/AI/external APIs:** schema contracts, provenance, prompt injection, factual verification, quota, source completeness, ML containment.
+5. **Performance/resilience/operability:** N+1, pagination, concurrency, caching, bundle size, observability, failure semantics.
+6. **Tests/types/quality gates:** actual Vitest, TypeScript, ESLint, Next build, Python, MCP, Playwright runs.
+7. **Deployment/config/CI/docs/DX:** clean DB bootstrap, workflow triggers, lockfiles, runtime pins, env matrix, release metadata.
+8. **Independent revalidation:** 별도 auditor가 top findings·severity·orphan 후보를 재검증했고, auditor의 오판은 primary evidence로 기각했다.
+
+### 2.3 분류 기준
+
+- **Verified defect:** 현재 snapshot의 결정적 코드 경로 또는 재현 test가 잘못된 동작을 입증.
+- **Verified exposure:** 실행 환경 값에 따라 활성화되지만 code default가 취약하거나 직접 공격면을 제공.
+- **Risk/unknown:** production env/traffic/data 없이는 발생 여부를 확정할 수 없으나 통제가 부재.
+- **Governance gap:** 재현성·승인·문서·소유권·release process 결함.
+- **Positive control:** 실제 blast radius를 줄이는 강한 통제.
+
+Severity:
+
+- **Critical:** 무인 원격 악용, 대량 side effect, 민감 데이터/금융 데이터 무결성 훼손, 되돌리기 어려운 대규모 영향.
+- **High:** release/DR을 차단하거나 사용자·데이터·운영에 큰 피해를 줄 수 있음.
+- **Medium:** 조건부·제한적 영향이나 반복될 경우 품질/운영 비용이 큼.
+- **Low:** hygiene, 국소 UX, 미래 유지보수 문제.
+
+---
+
+## 3. Critical/High findings 상세
+
+### SEC-001 — `CRON_SECRET` 미설정 시 대량 메일 route가 fail-open
+
+- **Severity / type:** Critical / Verified exposure
+- **Evidence:** `app/api/cron/send-newsletter/route.ts:20-24`는 `if (process.env.CRON_SECRET && ...)`로 검사한다. build route table에도 `/api/cron/send-newsletter`가 public dynamic route로 포함됐다.
+- **Scenario:** production env에서 secret 누락·오타·preview env 미설정 시 임의 caller가 service-role subscriber read, Gemini 작업, SendGrid 대량 발송을 유발한다.
+- **Mitigation already present elsewhere:** `app/api/cron/send-recommendations/route.ts:40`은 secret이 없으면 401로 fail-closed하고 timing-safe compare를 사용한다.
+- **Remediation:** 취약 route를 제거하거나 동일 fail-closed helper를 공유한다. deployment schema에서 `CRON_SECRET`을 필수로 검증하고 “unset/empty/wrong/missing header” route tests를 추가한다.
+
+### SEC-002 / SEC-003 — 구독 lifecycle의 소유권·rate control 부재와 scanner-triggered 해지
+
+- **Severity / type:** High / Verified defect
+- **Evidence:** `app/api/subscribe/route.ts`, `app/api/unsubscribe/route.ts`는 email만으로 상태를 바꾸며 rate limit, CAPTCHA, double opt-in, signed ownership token이 없다. `lib/sendgrid.ts`는 `/unsubscribe?email=<raw email>` 링크를 만들고 `app/unsubscribe/page.tsx:17-23`은 page load `useEffect`에서 즉시 POST한다.
+- **Scenario:** 공격자가 타인 email을 반복 등록/해지할 수 있고, mail security scanner 또는 link preview가 사용자 의도 없이 해지한다. raw email은 history, proxy, analytics, support screenshot에 남을 수 있다.
+- **Remediation:** random opaque one-time token 또는 HMAC token, expiry·purpose binding, explicit confirmation 또는 standards-compliant one-click endpoint, rate limiting, double opt-in, audit log를 사용한다. URL·log에 raw email을 넣지 않는다.
+
+### SEC-005 — anon-writable stock cache poisoning
+
+- **Severity / type:** Critical / Verified defect
+- **Evidence:** `supabase/migrations/create_stock_price_cache.sql:33-59`는 public select/insert/update를 `USING(true)`/`WITH CHECK(true)`로 허용한다. `app/archive/_utils/cache/stock-price.ts:102,150`은 browser Supabase client로 read/upsert한다.
+- **Scenario:** anon client가 ticker의 current/previous price, rate, timestamp, expiry를 임의 값으로 덮어 사용자 전원에게 금융 표시값을 제공한다. distributed single-flight도 없어 stampede가 가능하다.
+- **Remediation:** anon insert/update를 즉시 revoke하고 server-only RPC/service writer로 이동한다. ticker/range/timestamp/source validation, monotonic freshness, authoritative KIS fallback을 적용한다.
+
+### SEC-007 / SEC-008 — blog scraper SSRF 및 `--no-sandbox`
+
+- **Severity / type:** High / Verified exposure
+- **Evidence:** SERP 결과 URL을 scheme/private IP/DNS/redirect 검증 없이 `undici` redirect-follow와 Playwright로 열며, browser launch에 `--no-sandbox`가 사용된다.
+- **Scenario:** search result/redirect/DNS rebinding이 CI runner metadata·internal service에 접근하거나 악성 page가 sandbox 없는 browser의 blast radius를 키울 수 있다.
+- **Remediation:** `https` allowlist, literal/private/link-local/loopback deny, resolve 전후·redirect hop별 DNS 검사, body/redirect/time limit, isolated low-privilege container와 browser sandbox를 적용한다. 검증 전 자동 blog workflow를 중지하는 것이 안전하다.
+
+### COR-003 / COR-004 — newsletter partial delivery 후 중복과 성공 오보고
+
+- **Severity / type:** High / Verified defect
+- **Evidence:** `lib/sendgrid.ts`는 recipient별 send를 unbounded `Promise.all`로 수행한다. `scripts/send-newsletter.ts`는 전체 성공 뒤에만 `newsletter_content.is_sent`를 갱신하고, 그 DB update 실패는 warning-only로 종료한다.
+- **Scenario:** N명 중 일부는 SendGrid가 수락한 뒤 한 요청이 reject하면 job은 실패하고 `is_sent=false`가 남는다. retry가 성공 수신자에게 다시 보낸다. 반대로 전송 후 sent-state write가 실패해도 workflow가 성공한다.
+- **Remediation:** immutable delivery run + per-recipient state (`pending/claimed/accepted/failed`), provider message/idempotency key, bounded queue, retry classification, atomic claim/lease, final reconciliation을 구현한다. DB state write 실패는 job failure여야 한다.
+
+### DEP-002 — clean Supabase bootstrap 불가
+
+- **Severity / type:** High / Verified governance/operational defect
+- **Evidence:** 56 migration의 DDL inventory에서 55개 created table을 찾았으나 `subscribers`, `email_logs`, `kis_tokens`는 migration 030에서 ALTER만 되고 CREATE가 없다. `supabase/migrations/030_security_rls_lockdown.sql:24-26`은 unconditional ALTER를 수행한다. `docs/tli-v3-status-2026-07-14.md`도 local reset이 030에서 깨진다고 명시한다.
+- **Impact:** fresh developer/staging/DR database를 repository만으로 복원할 수 없다. production schema dump에 의존하는 workaround는 infrastructure-as-code와 disaster recovery를 충족하지 못한다.
+- **Remediation:** 이미 적용된 production history를 임의 rewrite하지 말고, 검토된 baseline/squash 전략을 정한다. 세 foundation table과 extension/grant/function을 포함한 clean schema를 만들고 PostgreSQL/Supabase reset을 CI에서 매번 실행한다.
+
+### QA-001 / QA-002 / DEP-001 — 기본 quality gate red, 핵심 scripts는 typecheck 밖
+
+- **Severity / type:** High / Verified defect/governance gap
+- **Evidence:** 기본 `npm test`는 269 files 중 2 files/3 tests 실패했다. root `tsconfig.json`은 `scripts`, `e2e`, `mcp`를 제외한다. 별도 production scripts typecheck는 4 errors를 냈다. 9 workflows 중 `pull_request`/`push` CI와 test/lint/type/build gate는 0개다.
+- **Impact:** 가장 중요한 TLI operational code의 type regression과 red tests가 main/production으로 들어갈 수 있다.
+- **Remediation:** 단일 required PR workflow에 clean install, root+scripts+MCP+e2e typecheck, lint, default tests, Python tests, build, migration reset/smoke를 넣는다. flaky test를 제외하는 방식이 아니라 timeout/module-isolation 원인을 수정한다.
+
+### SEC-015 / DEP-005 — runtime vulnerability와 비재현 dependency graph
+
+- **Severity / type:** High / Verified supply-chain risk
+- **Evidence:** root audit는 858 dependencies에서 Critical 1/High 15/Moderate 2. direct runtime `next`와 `undici`에 High advisories가 있고 fix가 제공된다. npm/pnpm lock은 52 direct dependencies 중 15개를 다르게 resolve한다. 현재 `node_modules`는 Next/eslint-config 15.5.15이지만 package와 두 lock은 exact 15.5.7이라 `npm ls`가 invalid다.
+- **Impact:** local build, GitHub Actions(`npm ci`), Vercel(pnpm으로 문서화)이 서로 다른 코드로 검증·배포된다. build 성공이 production dependency graph를 증명하지 않는다.
+- **Remediation:** 단일 manager/lock을 선택하고 `packageManager`, Node exact pin, engines를 선언한다. clean install에서 audit·test·build를 재실행하고 Next/Undici 및 MCP advisories를 patch한다.
+
+### AI-008 — source outage 중 저신뢰 crash가 NORMAL로 바뀜
+
+- **Severity / type:** High / Verified policy defect
+- **Evidence:** `lib/llm/korea/gemini-pipeline.market-assessment.test.ts`가 low-confidence fallback crash를 NORMAL로 downgrade하는 동작을 명시적으로 기대한다.
+- **Scenario:** 실제 shock 시 required market source 하나가 장애 나면 Gemini fallback으로 전환되고, crash signal confidence가 70 미만이면 정상 recommendation을 계속할 수 있다.
+- **Remediation:** market source outage + crash ambiguity는 `ABSTAIN/DEGRADED`, recommendation suppression, operator alert로 처리한다. NORMAL은 정상 관측 근거가 있을 때만 허용한다.
+
+### DATA-001 / DATA-002 — Naver News 날짜 이동과 false completeness
+
+- **Severity / type:** High before scientific promotion; Medium current public / Verified defect
+- **Evidence:** `scripts/tli/collectors/naver-news-api.ts:192`는 `new Date(pubDate).toISOString().slice(0,10)`으로 KST 00:00–08:59 기사를 전날 UTC date에 배정한다. API의 1,000-result cap 도달 시 requested window 전체를 덮었는지 확인하지 않고 run을 complete로 쓰고 missing dates를 zero로 만든다.
+- **Impact:** public news momentum과 immutable scientific feature에 systematic date shift·undercount·false zero가 들어간다. immutable run은 나중에 정정 비용이 더 크다.
+- **Remediation:** KST calendar date parsing, oldest-fetched/total/cap proof, `partial/truncated` state, zero-write 금지, URL/article dedupe 후 count, correction provenance를 구현한다.
+
+### ARC-001 — intra-analysis critical failure 뒤 의존 단계 계속 실행
+
+- **Severity / type:** High / Verified defect
+- **Evidence:** `scripts/tli/batch/pipeline-steps.ts:84-200`은 scoring/materialization/comparison/snapshot failure마다 `criticalFailures++`하지만 다음 단계를 실행한다. collection→analysis 경계의 abort는 정상이나 analysis 내부 dependency는 중단되지 않는다.
+- **Impact:** 최종 exit 1 이전에 stale lifecycle score를 사용한 comparison, partial snapshot, evaluation materialization이 저장될 수 있다. exit code는 이미 쓴 artifact를 rollback하지 않는다.
+- **Remediation:** run-scoped state machine과 dependency graph를 만들고 critical stage 실패 시 downstream skip한다. publish pointer는 모든 artifact 검증 뒤 원자적으로 전환한다.
+
+### SEC-011 — direct DB view가 API containment를 우회할 수 있음
+
+- **Severity / type:** High / Verified authorization gap
+- **Evidence:** migration 019는 `v_prediction_v4_serving`에 anon grant를 주며 migration 043은 base table grants만 revoke한다. API는 검증된 champion 전까지 `dataSource:"none"`을 의도하지만 legacy view 직접 query는 별도 노출면이다.
+- **Remediation:** 정책 의도를 확인하고 anon/authenticated view execute/select를 revoke한다. public scientific RPC/view 하나만 canonical serving surface로 남기고 grant test를 실제 Postgres에서 수행한다.
+
+### COR-017 / COR-018 — confidence 경고 소실과 mobile chart 0px
+
+- **Severity / type:** High UX/data-communication defect / Browser reproduced
+- **Evidence:** `DetailHeader`의 `LifecycleScore` 호출(`app/themes/[id]/_components/detail-header/index.tsx:98`)은 존재하는 `confidenceLevel` prop과 reason을 전달하지 않는다. `comparison-workspace.tsx:14,95,196`은 parent height를 `xl:`에서만 지정하면서 chart에 `height="100%"`를 전달한다. mobile Playwright는 single worker 3/3 실패했다.
+- **Impact:** 데이터 부족 경고가 사용자에게 사라지고 mobile에서 핵심 lifecycle graph가 보이지 않는다.
+- **Remediation:** score confidence와 reason을 명시적으로 렌더하고 accessible label을 추가한다. mobile base min-height/explicit numeric height를 주고 375/768/desktop visual contract를 green으로 만든다.
+
+---
+
+## 4. 전체 finding register
+
+### 4.1 Architecture, boundaries, dead paths
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| ARC-001 | High | Defect | `pipeline-steps.ts:84-200`; critical stage 이후 downstream 실행. fail-stop + atomic publish 필요. |
+| ARC-002 | Medium | Defect | `materialize-phase0-artifacts.ts:29,677`가 `ops/run-theme-state-history-backfill.ts`를 import/call. boundary test는 분류만 보고 import direction을 검사하지 않음. runtime service로 추출하고 dependency rule test 추가. |
+| ARC-003 | High | Defect | `lib/tli/constants/tli-params.ts:188-193`; `TLI_PARAMS_VERSION=v2`가 gitignored research output을 읽고 missing/invalid면 version은 v2인 채 defaults 사용. immutable promoted artifact로 교체하고 mismatch fail-closed. |
+| ARC-004 | High conditional | Defect/orphan | `load-membership-as-of.ts`는 self/test/manifest 외 inbound import 0. `load-feature-inputs.ts:258-262`는 current `theme_stocks.is_active` 사용. legacy prediction을 공개하지 말고 PIT loader를 실제 배선. |
+| ARC-005 | Medium | Product mismatch | MCP README는 prediction을 제공한다고 설명하지만 API는 의도적으로 `dataSource:none`. containment는 유지하되 docs/tool response에 unavailable state·조건 명시. |
+| ARC-006 | High | Governance | 6 tracked docs가 반드시 읽으라는 `.omo/plans/tli-v3-scientific-rebuild-master.md`는 checkout에 없고 `.omo`는 ignored. canonical plan을 tracked docs로 승격. |
+| ARC-007 | Low/Medium | Incomplete | Google Trends fallback adapter가 `not_implemented`. fallback claim을 제거하거나 구현·contract test. |
+| ARC-008 | Medium | Maintainability | 7개 strong dead files와 1개 integrate 대상 orphan. 아래 §5 참조. |
+| ARC-009 | Medium | Modularity | pagination, KIS clients, retry/sleep/timeout, Supabase initialization이 중복. shared policy modules로 통합. |
+
+### 4.2 Correctness and edge cases
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| COR-001 | High | Defect | `/api/tli/changes?period=7d`가 약 7일 전이 아니라 두 번째 최신 row와 비교하고 주석의 5-day minimum을 구현하지 않음. date-targeted lookup/RPC 필요. |
+| COR-002 | High | Defect | `scripts/prepare-newsletter.ts` same-date rerun이 이미 sent인 row를 `is_sent:false`로 되돌림. immutable revision 또는 sent row update 금지. |
+| COR-003 | High | Defect | SendGrid `Promise.all` partial success 후 global reject/retry 중복. per-recipient ledger 필요. |
+| COR-004 | High | Defect | newsletter sent-state DB update failure가 warning-only success. delivery reconciliation 실패로 job을 실패시켜야 함. |
+| COR-005 | High | Defect | Vercel cron newsletter route는 delivery state를 기록하지 않음. 중복 구현 제거 후 canonical sender 공유. |
+| COR-006 | High | Defect | blog quality gate는 threshold 통과 draft가 없어도 fail-open. publish abstain/failure로 변경. |
+| COR-007 | Medium | Defect | blog timeout이 `Promise.race`만 사용해 underlying scraping/LLM 작업을 abort하지 않음. AbortController 전파. |
+| COR-008 | Low/Medium | Defect | blog publish path가 `published` state를 두 번 write. single transition/state machine. |
+| COR-009 | High | Defect | trading-calendar 구현과 workflow holiday list가 중복·불일치하며 old path는 지원연도 이후 throw. 2026-07-17도 prepare/send가 갈림. 단일 calendar source + KRX observed fallback. |
+| COR-010 | Medium | Defect | stock daily-close/price APIs의 ticker/date validation이 부족. strict regex/date bounds와 typed schema 필요. |
+| COR-011 | Medium | Test quality | deterministic unit test에 seedless `Math.random()`. seeded PRNG/fixed vectors 사용. |
+| COR-012 | High | Defect | membership history close와 replacement가 별도 requests여서 partial bitemporal transition 가능. DB transaction RPC. |
+| COR-013 | High | Defect | theme-stock deactivation failures를 상위 pipeline이 ignore할 수 있음. batch result 합산·throw. |
+| COR-014 | Low | Defect/dead | dead Serp usage checker가 실제 zero를 `\|\| 250`로 바꿈. 삭제하거나 `??`. |
+| COR-015 | High | Defect | Naver theme collector가 `stockCode.startsWith('0')`로 market 추정. 내부 반례 `KOSDAQ:000250`, `KOSPI:105560`. authoritative market field/table 사용. |
+| COR-016 | High at scale | Risk | compare/search/list/ranking이 global row limit 후 theme별 latest를 선택해 uneven history에서 theme 누락. window function/RPC 또는 per-theme lateral query. |
+| COR-017 | High | Defect | score confidence prop/reason 미전달. UI warning 복원. |
+| COR-018 | High | Defect | mobile chart 0 height, E2E 3/3. responsive height contract 수정. |
+| COR-019 | Positive | Control | pure bitemporal selector는 business/system-time boundary를 올바르게 적용. |
+| COR-020 | Positive | Control | theme detail ascending query + reverse scan의 historical reference 방향은 올바름. |
+
+### 4.3 Security, privacy, supply chain
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| SEC-001 | Critical | Exposure | `CRON_SECRET` unset 시 mass-mail auth bypass. fail-closed shared auth. |
+| SEC-002 | High | Exposure | subscribe/unsubscribe에 rate limit, CAPTCHA, double opt-in, ownership proof 없음. abuse controls 추가. |
+| SEC-003 | High | Defect | raw email unsubscribe URL + page-load mutation. opaque signed token. |
+| SEC-004 | High | Privacy | `scripts/send-newsletter.ts`가 subscriber email/name 전부 CI log에 출력. count/redacted ID만 log. |
+| SEC-005 | Critical | Defect | anon stock cache writes. revoke + server writer. |
+| SEC-006 | High | Exposure | public stock-price request 하나가 최대 10 KIS calls, app rate limit 없음. authenticated/bucketed rate budget. |
+| SEC-007 | High | Exposure | scraper URL/redirect/private-IP/DNS rebinding 검증 없음. SSRF guard. |
+| SEC-008 | High | Exposure | untrusted page를 Playwright `--no-sandbox`로 실행. sandbox/isolation. |
+| SEC-009 | Medium | Defect | MCP analytics limit가 caller-provided `p_ip_hash`를 신뢰해 randomization 우회. trusted server-derived key. |
+| SEC-010 | Medium | Defect | public `increment_blog_view_count` SECURITY DEFINER RPC로 counter inflation 가능. revoke public 또는 authenticated server endpoint. |
+| SEC-011 | High | Defect | anon-readable legacy prediction view가 API containment 우회 가능. grant revoke. |
+| SEC-012 | Medium | Hardening | CSP에 `script-src 'unsafe-inline'`; HSTS, `object-src`, `base-uri` 부재. nonce/hash CSP와 headers 보강. |
+| SEC-013 | High | Governance | email/name/IP hash/UA 수집에도 privacy policy/terms가 없고 90-day cleanup 자동 schedule 근거 없음. policy+retention job. |
+| SEC-014 | Medium | Supply chain | Actions가 `@v4/@v7/@v2` floating major tag. immutable SHA pin 및 update automation. |
+| SEC-015 | High | Supply chain | root 18 vulnerabilities, MCP 4; direct runtime Next/Undici 포함. clean-lock patch/audit. |
+| SEC-016 | Positive | Control | redacted tracked-secret scan에서 private key/AWS/GitHub/SendGrid/Google/JWT pattern 0. |
+| SEC-017 | Positive | Control | admin APIs와 `send-recommendations`는 fail-closed + timing-safe token. |
+| SEC-018 | Positive | Control | blog Markdown `rehype-sanitize`, SendGrid text HTML escaping; open redirect/user-controlled shell sink 미발견. |
+
+### 4.4 Data, AI, prompts, external APIs
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| AI-001 | High | Risk | stock JSON은 shape/count/ticker/score만 검증하고 name/previous close/rationale를 KIS·독립 source와 대조하지 않음. structured claims verifier. |
+| AI-002 | High | Risk | Stage 5/6이 동일 Gemini preview model+search를 사용해 correlated self-verification. independent deterministic/source verifier. |
+| AI-003 | High | Defect | 최대 90 calls, stage timeout 20분이 Vercel `maxDuration=300`과 불일치. global deadline/call/cost budget. |
+| AI-004 | High | Governance | newsletter row에 model/prompt version/hash, grounding URL/time, generation run ID, content hash 없음. immutable generation manifest. |
+| AI-005 | High | Defect | KIS parse가 malformed/missing change/changePct를 zero로 바꾸고 direct-valid 처리해 false NORMAL 가능. missing은 invalid/degraded. |
+| AI-006 | Medium | Reliability | KIS token cache에 auth failure invalidate+single refresh 없음. 401/403 limited refresh. |
+| AI-007 | Medium/High | Reliability | required market source 하나 실패 시 전체 Gemini fallback. source-level partial state와 deterministic surviving evidence 사용. |
+| AI-008 | High | Defect | low-confidence fallback crash를 NORMAL로 downgrade. abstain/suppress. |
+| AI-009 | High | Prompt security | scraped competitor text를 XML-like tags에 escape/instruction boundary 없이 삽입. untrusted data escaping + explicit non-instruction rule. |
+| AI-010 | Medium | Validation | generated blog type guard가 shallow하고 FAQ child 구조를 검증하지 않음. full Zod schema. |
+| AI-011 | High | Quality | blog quality score는 길이/keyword/headings 중심이며 factual/citation 검증 없음. fail-open auto-publish와 결합. source-backed claim gate. |
+| DATA-001 | High* | Defect | Naver KST date를 UTC date로 이동. KST parse. |
+| DATA-002 | High* | Defect | 1,000 cap을 complete/zero로 기록. truncation proof/status. |
+| DATA-003 | Medium | Defect | article count가 dedupe 전에 계산되고 storage만 `(theme_id,link)` dedupe. canonical dedupe-before-metric. |
+| DATA-004 | Positive | Control | DataLab은 strict Zod, immutable run status, partial/failed, anchor default, DB request-window enforcement. |
+| REL-001 | Medium | Defect | common retry가 모든 4xx를 retry하고 Retry-After/jitter/quota budget 없음. status-aware policy. |
+| REL-002 | High | Defect | KIS daily-range가 모든 error를 `[]`로 swallow. typed failure/partial. |
+| REL-003 | High | Defect | upper pipeline이 price failure를 warning으로만 처리하며 stale prices로 진행 가능. freshness gate. |
+| ML-001 | Positive | Control | exact feature order/length, v1 reject, canonical SHA-256, immutable manifests, 500 replicate replay/hash, strict public candidate view, service-role RPC, exact-true exposure. |
+| ML-002 | High before exposure | Defect | DB `model_type` constraint 없음; legacy scorer는 non-`m1_logistic` 모두 B-Abl로 실행하면서 original version label 유지. CHECK + exhaustive switch. |
+| ML-003 | Medium/High | Risk | theme-specific public prediction load에 maximum freshness age 없음. serving age constraint. |
+
+### 4.5 Performance, scalability, resilience, operability
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| PERF-001 | High | Defect | newsletter concurrency group 없음, subscriber pagination 없음(기본 1,000), unbounded sends, daily timeout 없음. lease+pagination+queue+timeout. |
+| PERF-002 | High | Defect | `snapshotThemePredictionsV3()`가 theme마다 global 20-day interest/news/price/snapshot/episode를 다시 load하는 severe N+1. preload once, index by theme. |
+| PERF-003 | High | Risk | API failure를 zero/empty success로 바꾸고 6/24h edge cache. degraded result에는 no-store/error status. |
+| PERF-004 | Medium | Scale | `%ILIKE%` search에 trigram index 없음. `pg_trgm` GIN/GiST 또는 search vector. |
+| PERF-005 | High | Defect | `batchQuery` default fail-open, nonunique OFFSET order, exact count가 duplicate-replacement를 못 잡음. keyset+unique order+failOnError default. |
+| PERF-006 | High growth | Defect | 620KB archive JSON이 client static import되고 hook이 render마다 normalize/map/Map 재생성. build 결과 `/archive` 202KB, first load 404KB. server/date shard + module-level memo. |
+| PERF-007 | Medium | Build/runtime | `lib/og-background.ts`가 약 190KB base64를 code에 내장. static asset/cache로 이동. |
+| PERF-008 | Medium | MCP | 15s timeout·제한 retry는 긍정이나 Retry-After/jitter/single-flight 없고 대부분 runtime schema 없음; 6h MCP cache가 6/24h edge cache와 겹침. route TTL/schema 정책. |
+| OPS-001 | High | Gap | app error tracking, tracing, health endpoint, production metrics 구현 없음. SLO/telemetry. |
+| OPS-002 | High | Gap | comparison observability/alerts/retention/drills가 future work이며 promotion gate가 prerequisite를 강제하지 않음. machine-enforced gate. |
+| OPS-003 | Medium | Hygiene | 28MB TTC, 1.2MB Smithery map, 4 tracked pyc, growing archive 등 large/generated artifacts. artifact policy/LFS/CDN. |
+| PERF-009 | Positive | Control | news-count RPC는 set-based이며 `(theme_id,pub_date)` composite index 존재. migration 043 hot-query indexes도 긍정. |
+
+### 4.6 Tests, types, build, quality
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| QA-001 | High | Gate failure | 기본 `npm test`: 267/269 files, 3272/3275 pass. monthly 5s parallel import timeout과 ignored research JSON을 scan하는 boundary test. canonical command green 필요. |
+| QA-002 | High | Type gap | root tsc pass지만 scripts 제외. production scripts 별도 tsc 4 errors: reflexivity pagination generic 2, forecast canonical JSON 2. 전용 `tsconfig.scripts.json`. |
+| QA-003 | Medium | Gate weakness | ESLint exit 0 with 22 unused warnings, max-warning gate 없음. baseline 정리 후 `--max-warnings=0`. |
+| QA-004 | High | Browser failure | Playwright 55/68 pass, 13 fail. stale assertions 외 confidence/chart 실제 회귀. chart isolated repeat 0/3. |
+| QA-005 | High | Coverage gap | API route direct tests 7/20. subscribe/unsubscribe/cron/stock/changes 등 critical route가 직접 미검증. |
+| QA-006 | Medium | Governance | coverage provider/line/branch threshold 없음. risk-weighted thresholds와 changed-code coverage. |
+| QA-007 | High | DB gap | 많은 migration tests가 SQL text regex이며 실제 Postgres apply/constraint/RLS semantics를 검증하지 않음. clean DB integration. |
+| QA-008 | Medium | Drift | optimizer Python 9/10; test는 10 params 기대, 구현 19, comment 20. contract SSOT 정리. |
+| QA-009 | Positive | Control | targeted Vitest 95/95, adjusted full 3270/3270, scientific Python 135/135, MCP type/build, e2e tsc 통과. |
+| QA-010 | Qualified positive | Build | Next build 42.5s/383 pages 성공. 단 installed Next 15.5.15가 locks 15.5.7과 달라 canonical clean build 증거는 아님. |
+
+### 4.7 Deployment, configuration, CI/CD, docs, DX
+
+| ID | Sev | 분류 | Evidence / 영향 / remediation |
+|---|---:|---|---|
+| DEP-001 | High | Governance | 9 workflows 모두 operational schedule/manual; PR/push CI 0. required checks 추가. |
+| DEP-002 | High | DR | foundation tables CREATE 누락, reset 030 failure. baseline/reset CI. |
+| DEP-003 | Medium | Config | `supabase/config.toml`은 `./seed.sql`을 enable하지만 파일 없음. seed 추가 또는 disable. |
+| DEP-004 | High | Deploy race | docs는 schema-first/app-second를 요구하지만 Vercel auto-deploy와 migration apply가 연결되지 않음. gated deploy pipeline. |
+| DEP-005 | High | Reproducibility | npm+pnpm locks, packageManager/engines/.nvmrc 없음, 15 direct resolutions differ. 단일 manager. |
+| DEP-006 | High | Env/DX | root README/env template/deployment doc 없음. 추출된 env/system names 94, `lib/env`은 9개만 검증하고 한 route만 import. typed per-surface env matrix. |
+| DEP-007 | High | Automation | archive workflow가 schedule+workflow_run 이중 trigger, concurrency/timeout 없이 JSON을 main에 direct push. Vercel ignore가 archive를 제외하지 않아 매일 unreviewed rebuild. data serving 재설계/PR/lock. |
+| DEP-008 | Medium/High | Workflow | newsletter concurrency/permissions/timeout 부족; manual tests가 실제 email/Tweet를 전송하고 protected environment 승인 없음. 최소 권한+environment approval. |
+| DEP-009 | Medium | MCP release | package/mcp server/smithery 0.5.0, root `server.json` 0.1.3, generated Smithery manifest 0.1.1. release invariant check. |
+| DEP-010 | Medium | Governance | Dependabot, CODEOWNERS, root SECURITY/CONTRIBUTING 없음. ownership/update policy. |
+| DEP-011 | Medium | Hygiene/DX | 35 machine-absolute `/Users/isaac` links across 14 docs; tracked CPython3.14/pytest9.1 pyc; generated `.smithery`. relative links/cleanup. |
+| DEP-012 | Medium | Unknown surface | 두 `/api/cron/*` route는 repository trigger/config reference가 0. 외부 scheduler가 없다면 삭제; 있다면 documented owner/auth/SLO. |
+| DEP-013 | Positive | Control | TLI/blog workflows 일부는 concurrency, timeout, explicit permissions, artifact retention을 갖춤. MCP clean build는 tracked 36 dist files와 byte-identical. |
+| DOC-001 | High | Governance | 최신 status는 상세하고 reset break까지 솔직히 기록하지만, 반드시 읽으라는 canonical `.omo` plan과 evidence가 fresh clone에 없음. tracked SSOT 필요. |
+
+---
+
+## 5. Dead code, orphan code, reuse, modularization
+
+### 5.1 Strong dead candidates
+
+정적 import graph, literal reference search, independent auditor를 교차 확인했다. 삭제 전 framework convention/dynamic loading을 한 번 더 확인하되 현재 snapshot에서는 inbound production usage가 없다.
+
+| 파일 | 판정 | 조치 |
+|---|---|---|
+| `app/blog/[slug]/_components/social-share.tsx` | strong dead | 삭제 또는 blog post UI에 명시적으로 배선 |
+| `app/technical-indicators/_components/sections/conclusion-cta.tsx` | strong dead | 삭제/section registry 통합 |
+| `app/themes/[id]/_components/theme-prediction/sub-components.tsx` | old duplicate | 현재 `index.tsx` 구현과 통합 후 삭제 |
+| `components/ui/badge.tsx` | zero imports | 삭제 또는 canonical Badge로 표준화 |
+| `components/ui/card.tsx` | zero imports | `GlassCard` 정책과 중복 여부 결정 후 삭제 |
+| `lib/crash-alert-to-image.ts` | zero imports | `text-to-image` 경로와 통합 후 삭제 |
+| `types/newsletter.ts` | zero imports | 실제 canonical newsletter schema로 통합하거나 삭제 |
+
+### 5.2 삭제하면 안 되는 orphan
+
+- `scripts/tli/features/load-membership-as-of.ts`는 production importer가 0이지만 bitemporal PIT 계약을 구현한다. 이는 **삭제 후보가 아니라 legacy prediction input에 배선해야 할 구현 자산**이다.
+- `scripts/tli/ops/run-zombie-theme-cleanup.ts`는 documented manual ops entrypoint이므로 static importer가 없어도 dead가 아니다.
+- `mcp/dist/**`는 published package artifact이며 clean build와 byte-identical하므로 dead가 아니다.
+
+### 5.3 Maximal sensible modularization
+
+| 우선순위 | 모듈 | 통합 대상 | 설계 원칙 |
+|---|---|---|---|
+| 1 | `newsletter-delivery` state machine | prepare, GH sender, 두 cron routes, SendGrid | claim/lease, per-recipient ledger, idempotency, provider reconciliation |
+| 2 | `market-calendar` | app utils, TLI, workflow holidays | KST dates, observed KRX data, supported range, one SSOT |
+| 3 | `kis-client` | archive client, market assessment, price collectors | token cache/refresh, timeout, retry, schema, quota budget |
+| 4 | `supabase-pagination` | 10+ `fetchAllRows`, `batchQuery` variants | keyset, unique order, fail-closed default, typed page result |
+| 5 | `external-retry-policy` | blog, Naver, KIS, MCP | status classification, Retry-After, jitter, deadline, circuit/quota budget |
+| 6 | `env-contracts` | Next routes, scripts, workflows, MCP | surface별 Zod schema, secret/nonsecret 구분, build/runtime validation |
+| 7 | `latest-per-theme` DB layer | ranking/search/list/compare | SQL window/RPC로 global-limit 오류 제거 |
+| 8 | `generation-manifest` | newsletter/blog AI | prompt/model/source/hash/run provenance, immutable state transitions |
+| 9 | archive serving | static client JSON | server/date shard, CDN cache, typed response, no anon DB writes |
+| 10 | TLI dependency rules | runtime/ops/research | AST/import rule와 entrypoint test를 함께 강제 |
+
+과도한 추상화는 피한다. 예를 들어 scientific pure functions와 immutable contract modules는 이미 명확한 경계를 가지므로 generic framework로 다시 감싸지 않는다. 공통화 대상은 **반복 구현이 실제 policy drift를 만든 영역**에 한정한다.
+
+---
+
+## 6. 강한 긍정 통제
+
+1. **Scientific ML contract:** exact feature order/vector length, nonfinite guard, v1 artifact reject, canonical SHA-256, immutable source manifests, 500-replicate interval replay/hash verification.
+2. **Public prediction containment:** eligible/public/candidate/champion 조건과 exact-true exposure flag가 기본적으로 fail-closed다. 현재 empty response는 고장이 아니라 올바른 통제다.
+3. **DataLab:** strict Zod, immutable complete/partial/failed run, anchor default, DB request-window verification.
+4. **Recent TLI DB security:** service-role-only RLS와 explicit revoke가 대체로 잘 구성되어 있다.
+5. **Admin authentication:** admin APIs와 `send-recommendations`는 missing secret을 거부하고 timing-safe comparison을 사용한다.
+6. **Output sanitization:** blog Markdown sanitize, SendGrid escaping, user-controlled shell/open redirect 미발견.
+7. **Testing depth:** adjusted TS suite 3,270 tests와 scientific Python 135 tests는 domain contract에 대한 상당한 투자를 보여 준다.
+8. **Operational candor:** 최신 TLI status는 incident, containment, reset break, forward-only migration을 숨기지 않는다.
+9. **DB query positives:** set-based news count RPC와 composite/hot-query indexes.
+10. **MCP artifact reproducibility:** temporary clean build 36 files가 tracked `mcp/dist`와 byte-for-byte 일치한다.
+11. **Secret hygiene:** targeted tracked secret patterns 0건.
+
+이 긍정점들은 일부 finding의 blast radius를 줄이지만, public attack surface와 release gate를 대체하지는 않는다.
+
+---
+
+## 7. 실제 검증 결과
+
+모든 long-running command에 hard deadline을 두었고 application source는 수정하지 않았다.
+
+| 검증 | 결과 | 해석 |
+|---|---|---|
+| Targeted Vitest 8 files | **PASS 95/95** | pipeline/membership/Naver/KIS/market/prediction 핵심 회귀 |
+| 기본 `npm test` | **FAIL** 267/269 files, 3272/3275 | canonical gate red |
+| Monthly calibration isolated | **PASS 4/4** | full-suite 5s import contention 후 mock pollution으로 분리 |
+| Full Vitest, boundary 제외 + 15s | **PASS 268 files/3270 tests** | 나머지 suite는 green; default 수정은 여전히 필요 |
+| Root `tsc --noEmit` | **PASS** | 단 `scripts/e2e/mcp` 제외 |
+| Production scripts temp tsc | **FAIL 4 errors** | reflexivity loader 2, forecast manifest JSON typing 2 |
+| E2E dedicated tsc | **PASS** | Playwright source type valid |
+| ESLint | **PASS with 22 warnings** | max-warning gate 없음 |
+| Next production build | **PASS**, 42.5s, 383 pages | `/archive` 202KB/404KB; local dependency graph invalid |
+| MCP typecheck/temp build | **PASS**, 36 outputs | tracked dist와 byte-identical |
+| Scientific Python | **PASS 135/135**, 42.04s | CPython3.13.11 + exact deps; local uv 0.9.28 vs documented 0.9.25 |
+| Optimizer Python | **FAIL 9/10** | param-count contract drift |
+| Playwright actual browser | **FAIL 55/68** | stale assertions + real confidence/chart regressions |
+| Mobile chart isolated repeat | **FAIL 0/3** | deterministic responsive defect |
+| Root npm audit | **18**: C1/H15/M2 | direct Next/Undici high 포함; fixes available |
+| MCP npm audit | **4**: H1/M2/L1 | fixes available |
+| Redacted secret scan | **PASS 0 targeted hits** | 값은 출력하지 않음 |
+| MCP dist hash comparison | **PASS 36/36** | generated dist current |
+
+대표 command logs:
+
+- `/tmp/stock-ai-targeted-vitest.log`
+- `/tmp/stock-ai-full-vitest.log`
+- `/tmp/stock-ai-full-vitest-adjusted.log`
+- `/tmp/stock-ai-runtime-scripts-tsc.log`
+- `/tmp/stock-ai-next-build.log`
+- `/tmp/stock-ai-python-pytest.log`
+- `/tmp/stock-ai-optimizer-pytest.log`
+- `/tmp/stock-ai-playwright-rerun.log`
+- `/tmp/stock-ai-playwright-chart-repeat.log`
+- `/tmp/stock-ai-root-npm-audit.json`
+- `/tmp/stock-ai-mcp-npm-audit.json`
+
+### 7.1 Test coverage 해석
+
+- 20 API routes 중 direct `route.test`는 7개다.
+- newsletter auth/delivery, subscribe/unsubscribe, stock APIs, changes 등 가장 위험한 routes가 직접 미검증이다.
+- coverage provider/threshold가 없다.
+- 많은 migration tests는 SQL text를 읽어 regex/substring을 확인하며 PostgreSQL에서 실제 apply하지 않는다.
+- E2E assertion 일부는 UI redesign 뒤 갱신되지 않았으므로 test contract ownership이 필요하다.
+- 테스트 수가 많다는 사실과 critical path가 검증됐다는 사실을 구분해야 한다.
+
+---
+
+## 8. Remediation roadmap
+
+### Phase 0 — 즉시 containment
+
+1. 취약 `send-newsletter` API route를 disable/delete하거나 fail-closed auth helper로 교체.
+2. `stock_price_cache` anon insert/update revoke; browser direct writer 중단.
+3. unsubscribe raw-email link와 auto side effect 중단; signed token 방식 배포.
+4. subscriber PII logging 제거.
+5. scraper automation을 일시 중지하거나 SSRF/private-network/sandbox guard 배포.
+6. Next/Undici와 audit fix 가능한 production dependencies patch.
+7. prediction legacy view의 public grant revoke 여부를 production DB에서 확인·적용.
+
+### Phase 1 — release gate 복구
+
+1. newsletter delivery ledger, atomic claim, per-recipient reconciliation, pagination, bounded concurrency.
+2. root/scripts/MCP/e2e type configs와 canonical green commands 확립.
+3. PR CI required checks; default Vitest flake/boundary filesystem scan 수정.
+4. mobile chart와 confidence warning 수정, stale E2E 갱신.
+5. 단일 package manager/lock, exact Node/package manager pin, clean install build.
+6. clean DB baseline + reset/migration/RLS integration CI.
+7. typed environment matrix와 `.env.example`(placeholder only), build/runtime validation.
+
+### Phase 2 — data and operational integrity
+
+1. Naver KST parsing, truncation/partial run contract, dedupe-before-count correction.
+2. pipeline run-scoped artifacts, stage dependency stop, atomic publish pointer.
+3. market assessment missing-value handling과 `ABSTAIN/DEGRADED` policy.
+4. AI generation manifest와 independent claim/source verification.
+5. health/error tracking/tracing/SLO dashboards와 alert owner.
+6. archive server/date sharding; direct main push workflow 제거 또는 protected PR flow.
+
+### Phase 3 — scale and modularization
+
+1. legacy prediction global-data N+1 제거.
+2. keyset pagination/fail-closed `batchQuery`와 latest-per-theme SQL.
+3. KIS/retry/calendar/Supabase clients 통합.
+4. search trigram indexes와 query plans 검증.
+5. dead code 정리 및 generated artifact policy 적용.
+6. MCP schemas/cache freshness/release metadata invariant 보강.
+
+### Phase 4 — prediction exposure 전용 gate
+
+1. PIT membership loader를 실제 production scoring path에 배선.
+2. Naver corrections 이후 clean immutable cohort를 다시 증명.
+3. DB `model_type` constraint와 exhaustive loader, prediction max age.
+4. direct legacy view 차단과 canonical public RPC만 허용.
+5. observability/retention/rollback drills를 promotion gate가 기계적으로 검사.
+6. prospective sample/effect gate를 변경 없이 통과할 때만 exposure flag 전환.
+
+---
+
+## 9. Release checklists
+
+### 9.1 Security/privacy
+
+- [ ] 모든 cron/admin route는 secret missing/empty/wrong을 401/403으로 거부한다.
+- [ ] stock cache anon writes가 production DB에서 revoke됐다.
+- [ ] subscribe/unsubscribe에 ownership proof와 rate limiting이 있다.
+- [ ] URL, logs, analytics에 raw subscriber email이 없다.
+- [ ] scraper는 private/link-local/loopback/DNS rebinding/redirect를 차단한다.
+- [ ] browser sandbox와 isolated runner가 활성화됐다.
+- [ ] privacy policy, terms, retention schedule, data owner가 공개·승인됐다.
+- [ ] public SECURITY DEFINER/view grants를 실제 DB에서 enumerate하고 승인했다.
+- [ ] root/MCP audit의 accepted vulnerabilities가 owner/expiry와 함께 기록됐다.
+
+### 9.2 Newsletter
+
+- [ ] newsletter row는 sent 상태에서 prepare rerun으로 되돌아가지 않는다.
+- [ ] delivery run과 recipient별 상태/idempotency key가 있다.
+- [ ] subscriber pagination이 1,000행 이상 test로 검증됐다.
+- [ ] SendGrid concurrency와 retry budget이 제한된다.
+- [ ] provider accept 후 DB failure reconciliation test가 있다.
+- [ ] duplicate concurrent workflow test가 있다.
+- [ ] model/prompt/source/run/content hash가 저장된다.
+- [ ] source outage/crash ambiguity에서는 recommendation을 보내지 않는다.
+
+### 9.3 Data/TLI/ML
+
+- [ ] KST Naver date fixtures와 cap-truncated fixture가 통과한다.
+- [ ] partial/truncated run은 complete/zero로 쓰이지 않는다.
+- [ ] membership history transition이 DB transaction이다.
+- [ ] legacy prediction이 PIT membership만 사용한다.
+- [ ] critical stage 실패 시 downstream artifacts가 publish되지 않는다.
+- [ ] model type/freshness constraints가 DB와 loader 양쪽에 있다.
+- [ ] public prediction access surface가 하나뿐이다.
+- [ ] scientific promotion은 dashboard/alerts/retention/drills를 강제한다.
+
+### 9.4 Build/test/CI
+
+- [ ] clean checkout에서 선택한 단일 manager로 install한다.
+- [ ] `npm test` 또는 대체 canonical test command가 예외 없이 green이다.
+- [ ] root와 production scripts typecheck가 모두 green이다.
+- [ ] ESLint warning budget이 0 또는 승인된 baseline이다.
+- [ ] Playwright desktop/mobile가 green이다.
+- [ ] critical 20 API routes의 risk-based route tests가 있다.
+- [ ] migration은 empty Postgres/Supabase에 실제 적용된다.
+- [ ] PR required checks가 branch protection에 연결됐다.
+- [ ] clean install build의 dependency versions가 deployment와 동일하다.
+
+### 9.5 Deployment/DR/operations
+
+- [ ] fresh DB가 production schema를 repository만으로 재현한다.
+- [ ] schema-first/app-second 순서가 자동 gate다.
+- [ ] backup restore와 forward-fix rehearsal evidence가 있다.
+- [ ] archive update가 중복 trigger/direct main push를 하지 않는다.
+- [ ] workflow concurrency, timeout, permissions, protected environment가 설정됐다.
+- [ ] health, error tracking, tracing, metrics, alert routing이 동작한다.
+- [ ] runbook과 canonical plan이 tracked fresh clone에서 열리고 상대 링크가 유효하다.
+- [ ] MCP package/server/Smithery version이 release check에서 일치한다.
+
+---
+
+## 10. 독립 재검증과 오탐 처리
+
+별도 auditor는 SEC-001, SEC-003, SEC-005, newsletter partial delivery, no PR CI/dual lock/type gap, 7개 dead files, scientific containment의 강점을 확인했다. 다음 auditor 결론은 primary evidence가 반박해 채택하지 않았다.
+
+| Auditor 주장 | 최종 판정 | 근거 |
+|---|---|---|
+| PIT loader가 production에서 사용됨 | 기각 | self/test/manifest 외 import 0; live legacy loader는 current `theme_stocks` query |
+| confidence warning이 존재하므로 문제 없음 | 기각 | comparison confidence와 score confidence는 다른 계약; `DetailHeader`가 `LifecycleScore.confidenceLevel`을 전달하지 않음 |
+| chart default 350px라 collapse 불가 | 기각 | workspace가 `height="100%"`로 override하고 parent height는 `xl:` only; mobile 3/3 실패 |
+| audit high/critical은 모두 dev-only | 기각 | direct runtime Next와 Undici high advisories가 저장된 audit JSON에 존재 |
+| clean bootstrap은 production에 영향 없어 Low | 상향 | DR/staging/reproducibility를 차단하고 최신 status도 reset break를 인정 |
+| Naver 날짜/cap은 Low | 상향 | immutable study/public score에 false date/zero/undercount를 기록 |
+
+이 과정은 독립 리뷰 결과도 사실 검증 없이 권위로 채택하지 않았음을 명시한다.
+
+---
+
+## 11. 제한사항
+
+1. CommitLore history는 ready였고 path records는 0이었지만 notes mirror가 unfetched라 context/guard가 `incomplete:true`, `proposal_checked:false`였다. matched ruled-out record는 없었다.
+2. production Supabase schema, RLS 실제 적용 상태, Vercel environment, GitHub branch protection, SendGrid/KIS/Naver quota와 live traffic은 직접 검증하지 않았다.
+3. production data mutation, actual mass email, destructive DB reset, remote deployment는 실행하지 않았다.
+4. Next build는 local `.env.production.local/.env.local`과 invalid `node_modules`를 사용했으므로 clean Vercel/npm-ci build와 동일하다고 주장하지 않는다.
+5. default Vitest boundary failure에는 gitignored local optimizer outputs가 영향을 줬다. 이 자체가 environment-sensitive test 문제지만 clean CI에서 같은 파일은 없을 수 있다.
+6. static import graph는 dynamic import, framework convention, external consumer를 완전하게 증명하지 못하므로 dead candidates는 삭제 전 마지막 확인이 필요하다.
+7. npm audit는 review 시점 registry advisory와 lockfiles에 대한 point-in-time 결과다.
+8. Playwright 상세 tests는 mock API + local dev server였고 production visual/network behavior 전체를 대체하지 않는다.
+9. file:line references는 고정 snapshot 기준이며 이후 변경 시 이동할 수 있다.
+10. canonical `.omo` plan과 일부 ignored evidence가 checkout에 없어 그 문서의 과학적 주장 자체는 전수 검증할 수 없었다.
+
+---
+
+## 12. 최종 승인 조건
+
+현재 판정은 **NOT READY**다. 다음 production release 승인에는 최소한 다음 증거가 필요하다.
+
+1. RB-01~RB-08, RB-13, RB-14가 닫혔거나 명시적 risk acceptance가 있다.
+2. clean checkout/clean install/clean DB에서 required CI 전체가 green이다.
+3. default test, scripts typecheck, Playwright mobile/desktop가 green이다.
+4. production DB grant probe와 dependency audit가 release artifact에 보존된다.
+5. newsletter duplicate/partial-delivery fault-injection test가 green이다.
+6. Naver correction과 pipeline fail-stop이 run-scoped integration test로 증명된다.
+7. prediction exposure는 별도 conditional blockers가 모두 닫힐 때까지 `dataSource:none`과 fail-closed flags를 유지한다.
+
+이 조건을 충족하기 전까지는 기능 추가보다 containment, reproducibility, delivery correctness, data integrity를 우선한다.
+
+---
+
+## Appendix A — Review artifacts and repository state
+
+- Inventory: `/tmp/stock-ai-newsletter-review-inventory.json`
+- Tracked paths: `/tmp/stock-ai-newsletter-tracked-files.txt`
+- Import graph: `/tmp/stock-ai-newsletter-import-graph.json`
+- Root audit: `/tmp/stock-ai-root-npm-audit.json`
+- MCP audit: `/tmp/stock-ai-mcp-npm-audit.json`
+- Application source/config modifications by this review: **none**
+- Pre-existing user change preserved: `.serena/project.yml`
+- Intended repository diff from this review: **only this Markdown file**

--- a/docs/deploy/01-security-containment.md
+++ b/docs/deploy/01-security-containment.md
@@ -1,0 +1,59 @@
+# 배포 런북 — PR 1: 보안 격리
+
+마이그레이션: `056b`, `057`. 앱 배포와 DB 적용을 하나의 변경 창으로 다룬다.
+
+## 1. 필수 설정
+
+배포 전에 모든 Vercel 환경과 뉴스레터 GitHub Actions 환경에 아래 값을 넣는다.
+**이 값들이 없으면 관련 라우트는 fail-closed로 503을 반환한다.**
+
+- `RATE_LIMIT_HMAC_SECRET` — 32자 이상 독립 난수
+- `UNSUBSCRIBE_TOKEN_SECRET` — 32자 이상 독립 난수 (AEAD 토큰 키)
+- `UNSUBSCRIBE_TOKEN_SECRET_PREV` — 회전 기간에만 사용. 구 토큰이 모두 만료된 뒤 제거
+- 기존 값: `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`,
+  `SENDGRID_API_KEY`, SendGrid 발신자 정보
+
+`CRON_SECRET`, Supabase 키, SendGrid 키를 신규 시크릿으로 재사용하지 않는다. 소유자와 회전
+일자는 Git이 아니라 프로덕션 시크릿 매니저에 기록한다.
+
+## 2. 사전 게이트
+
+1. 복구 가능한 DB 백업 확인 및 복구 지점 기록
+2. 클린 체크아웃에서 `tsc --noEmit`, `eslint .`, `vitest run`, `next build --turbopack` 통과
+3. Supabase CLI 마이그레이션 dry-run으로 생성 SQL 확인
+4. 적용 순서 확인: `056_drop_unused_indexes` (기존) → `056b` → `057`
+5. **KRX 장 시간 외로 일정 조정** — `056b`가 `stock_price_cache`를 `TRUNCATE`한다.
+   이후 첫 조회부터 `/api/stock/price`가 service_role로 캐시를 다시 채운다.
+
+## 3. 적용 순서
+
+1. 시크릿 주입 및 검증 (값이 로그에 남지 않도록 주의)
+2. 마이그레이션 적용. 첫 오류에서 즉시 중단하고 이후 파일을 수동으로 이어 적용하지 않는다.
+3. 검증된 커밋을 Vercel에 배포
+
+구 애플리케이션은 익명 캐시 쓰기에 의존하고, 신 애플리케이션은 rate-limit RPC가 없으면
+fail-closed다. DB 적용과 앱 승격 사이 간격을 최소화하고, 보안 권한을 되돌리는 대신 점검 창을
+사용한다.
+
+## 4. 스모크 체크
+
+- `/subscribe` 정상 렌더 및 `?confirm=<valid-test-token>` 플로우 동작. 확인은 명시적 POST
+- 신규 구독 → 확인 → 구독취소 → **재신청 → 재확인**이 끝까지 성공 (H-1 회귀 확인)
+- `/unsubscribe?token=<valid-test-token>` 렌더 및 명시적 확인 후에만 상태 변경
+- `/unsubscribe` (토큰 없음) 및 `/unsubscribe?email=<addr>` (레거시 링크)에서 이메일 입력 폼이
+  뜨고, 구독 중인 주소로 새 링크 메일이 도착
+- 미구독 주소로 링크 요청 시 메일이 가지 않으면서 응답 본문은 구독 중인 경우와 동일
+- 잘못된/없는 토큰은 이메일 주소나 토큰 값 노출 없이 일반 오류 반환
+- rate limit 초과 시 `429`, rate-limit 저장소/설정 부재 시 `503`
+- `/api/stock/price` 최초 호출이 KIS로 나가고, 동일 티커 재호출은 캐시에서 응답
+  (`stock_price_cache` 행 수 증가로 확인)
+- daily-close 라우트 정상 동작
+
+## 5. 롤백
+
+- 앱 스모크 체크 실패 시 직전 검증 배포로 롤백
+- **익명 캐시 쓰기를 되살리는 방식의 롤백은 하지 않는다.** 보안 경계를 유지한 채 service_role
+  설정을 진단한다.
+- 추가된 테이블/함수는 앱 롤백 시에도 남겨둘 수 있다(additive). 데이터 파괴나 스키마 실패에
+  대해서는 임시 역방향 SQL 대신 기록해 둔 복구 지점으로 복원한다.
+- 배포·마이그레이션 로그는 보존하되 이메일 주소와 토큰 값은 제외한다.

--- a/lib/security/__tests__/rate-limit-client-cache.test.ts
+++ b/lib/security/__tests__/rate-limit-client-cache.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createClientMock, rpcMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  rpcMock: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: createClientMock,
+}))
+
+const originalEnv = process.env
+
+beforeEach(() => {
+  vi.resetModules()
+  createClientMock.mockReset()
+  rpcMock.mockReset()
+  rpcMock.mockResolvedValue({
+    data: {
+      limited: false,
+      request_count: 1,
+      window_start: 1_800_000_000,
+      window_seconds: 60,
+    },
+    error: null,
+  })
+  createClientMock.mockReturnValue({ rpc: rpcMock })
+  process.env = {
+    ...originalEnv,
+    RATE_LIMIT_HMAC_SECRET: 'h'.repeat(32),
+    NEXT_PUBLIC_SUPABASE_URL: 'https://rate-limit-test.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-key-v1',
+  }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+describe('rate-limit Supabase client lifecycle', () => {
+  it('reuses a client while its URL and service key are unchanged', async () => {
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit')
+
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+    await checkRateLimit('203.0.113.11', RATE_LIMITS.subscribe)
+
+    expect(createClientMock).toHaveBeenCalledTimes(1)
+    expect(rpcMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates a fresh client after service-key rotation', async () => {
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit')
+
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key-v2'
+    await checkRateLimit('203.0.113.10', RATE_LIMITS.subscribe)
+
+    expect(createClientMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/lib/security/__tests__/security.test.ts
+++ b/lib/security/__tests__/security.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Behavioral security tests (mocked, deterministic).
+ *
+ * Replaces source-string assertions with direct utility/route tests:
+ * - Rate unavailable => 503
+ * - Atomic RPC shape
+ * - Subscribe send failure cleanup
+ * - Confirmation POST transaction
+ * - Unsubscribe no email body
+ * - Cron missing secret/service key
+ * - Cache server orchestration
+ * - Invalid Feb 30 / tickers
+ * - Token confidentiality/tamper/expiry/purpose
+ * - SSRF
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ================================================
+// 1. Rate limit unavailable => 503
+// ================================================
+
+describe('rate limit fail-closed behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns unavailable when HMAC secret is missing', async () => {
+    delete process.env.RATE_LIMIT_HMAC_SECRET;
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'hmac_secret_missing_or_short');
+  });
+
+  it('returns unavailable when HMAC secret is too short (<32)', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'short';
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+  });
+
+  it('returns unavailable when IP is null (no trusted x-real-ip)', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'a'.repeat(32);
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit(null, RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'no_trusted_ip');
+  });
+
+  it('returns unavailable when Supabase is not configured', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'a'.repeat(32);
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const { checkRateLimit, RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    const result = await checkRateLimit('1.2.3.4', RATE_LIMITS.subscribe);
+    expect(result.status).toBe('unavailable');
+    expect(result).toHaveProperty('reason', 'supabase_not_configured');
+  });
+
+  it('getTrustedClientIp returns null for missing header', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: () => null };
+    expect(getTrustedClientIp(headers)).toBeNull();
+  });
+
+  it('getTrustedClientIp returns null for empty header', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: (name: string) => name === 'x-real-ip' ? '' : null };
+    expect(getTrustedClientIp(headers)).toBeNull();
+  });
+
+  it('getTrustedClientIp returns valid IP from x-real-ip', async () => {
+    const { getTrustedClientIp } = await import('@/lib/security/rate-limit');
+    const headers = { get: (name: string) => name === 'x-real-ip' ? '203.0.113.5' : null };
+    expect(getTrustedClientIp(headers)).toBe('203.0.113.5');
+  });
+
+  it('hashClientIp returns null when secret is not configured', async () => {
+    delete process.env.RATE_LIMIT_HMAC_SECRET;
+    const { hashClientIp } = await import('@/lib/security/rate-limit');
+    expect(hashClientIp('1.2.3.4', 'test')).toBeNull();
+  });
+
+  it('hashClientIp produces consistent, different hashes per bucket', async () => {
+    process.env.RATE_LIMIT_HMAC_SECRET = 'x'.repeat(32);
+    const { hashClientIp } = await import('@/lib/security/rate-limit');
+    const h1 = hashClientIp('1.2.3.4', 'subscribe');
+    const h2 = hashClientIp('1.2.3.4', 'unsubscribe');
+    expect(h1).not.toBeNull();
+    expect(h2).not.toBeNull();
+    expect(h1).not.toBe(h2);
+    expect(hashClientIp('1.2.3.4', 'subscribe')).toBe(h1);
+  });
+});
+
+// ================================================
+// 2. Atomic RPC shape (check_rate_limit signature)
+// ================================================
+
+describe('rate limit RPC contract', () => {
+  it('RATE_LIMITS presets have valid ranges', async () => {
+    const { RATE_LIMITS } = await import('@/lib/security/rate-limit');
+    for (const [, config] of Object.entries(RATE_LIMITS)) {
+      expect(config.maxRequests).toBeGreaterThanOrEqual(1);
+      expect(config.maxRequests).toBeLessThanOrEqual(10000);
+      expect(config.windowSeconds).toBeGreaterThanOrEqual(1);
+      expect(config.windowSeconds).toBeLessThanOrEqual(86400);
+      expect(config.bucket).toBeTruthy();
+    }
+  });
+});
+
+// ================================================
+// 3. Token confidentiality/tamper/expiry/purpose
+// ================================================
+
+describe('opaque token behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'test-secret-that-is-at-least-32-chars!';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('email is not visible in token (confidentiality)', async () => {
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    const email = 'user@example.com';
+    const token = encryptToken(email, 'unsubscribe', 3600);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    const decoded = Buffer.from(token, 'base64url').toString('utf8');
+    expect(decoded).not.toContain(email);
+  });
+
+  it('detects tampered ciphertext', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'unsubscribe', 3600);
+    const wire = Buffer.from(token, 'base64url');
+    wire[Math.floor(wire.length / 2)] ^= 0xff;
+    const result = decryptToken(wire.toString('base64url'), 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('tampered');
+  });
+
+  it('rejects expired token', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'unsubscribe', -1);
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('expired');
+  });
+
+  it('rejects cross-purpose token', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('user@example.com', 'confirm', 3600);
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('tampered');
+  });
+
+  it('fail-closed: encrypt throws without secret', async () => {
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    expect(() => encryptToken('x@y.com', 'unsubscribe', 3600)).toThrow();
+  });
+
+  it('fail-closed: encrypt throws with short secret', async () => {
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'short';
+    const { encryptToken } = await import('@/lib/security/opaque-token');
+    expect(() => encryptToken('x@y.com', 'unsubscribe', 3600)).toThrow();
+  });
+
+  it('decrypt returns no_secret without valid secret', async () => {
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    delete process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV;
+    const { decryptToken } = await import('@/lib/security/opaque-token');
+    // A plausible-looking token (right length) but no key to decrypt
+    const fakeWire = Buffer.alloc(1 + 12 + 16 + 16, 0x42);
+    fakeWire[0] = 0x01;
+    const result = decryptToken(fakeWire.toString('base64url'), 'unsubscribe');
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('no_secret');
+  });
+
+  it('roundtrips successfully', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const email = 'test@example.com';
+    const token = encryptToken(email, 'confirm', 3600);
+    const result = decryptToken(token, 'confirm');
+    expect(result.valid).toBe(true);
+    expect(result.payload?.email).toBe(email);
+    expect(result.payload?.purpose).toBe('confirm');
+  });
+
+  it('supports key rotation', async () => {
+    const { encryptToken, decryptToken } = await import('@/lib/security/opaque-token');
+    const token = encryptToken('rotate@example.com', 'unsubscribe', 3600);
+    // Rotate
+    process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV = process.env.UNSUBSCRIBE_TOKEN_SECRET;
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'new-rotated-secret-at-least-32-chars!!!';
+    const result = decryptToken(token, 'unsubscribe');
+    expect(result.valid).toBe(true);
+    expect(result.payload?.email).toBe('rotate@example.com');
+  });
+});
+
+// ================================================
+// 4. Cron missing secret / service key
+// ================================================
+
+describe('cron auth fail-closed', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('rejects when CRON_SECRET is unset', async () => {
+    delete process.env.CRON_SECRET;
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer any')).toBe(false);
+  });
+
+  it('rejects when CRON_SECRET is empty', async () => {
+    process.env.CRON_SECRET = '';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer any')).toBe(false);
+  });
+
+  it('rejects wrong token', async () => {
+    process.env.CRON_SECRET = 'correct-secret';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer wrong')).toBe(false);
+  });
+
+  it('accepts correct token', async () => {
+    process.env.CRON_SECRET = 'test-secret-123';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret('Bearer test-secret-123')).toBe(true);
+  });
+
+  it('rejects null auth header', async () => {
+    process.env.CRON_SECRET = 'test';
+    const { validateCronSecret } = await import('@/lib/security/timing-safe-auth');
+    expect(validateCronSecret(null)).toBe(false);
+  });
+});
+
+// ================================================
+// 5. Ticker/date validation (pure validators)
+// ================================================
+
+describe('ticker validation', () => {
+  it('accepts valid Korean 6-digit ticker', async () => {
+    const { isValidTicker } = await import('@/lib/security/validators');
+    expect(isValidTicker('005930')).toBe(true);
+    expect(isValidTicker('035720')).toBe(true);
+  });
+
+  it('rejects invalid tickers', async () => {
+    const { isValidTicker } = await import('@/lib/security/validators');
+    expect(isValidTicker('')).toBe(false);
+    expect(isValidTicker('0059301')).toBe(true); // 7 digits valid under general pattern
+    expect(isValidTicker('abc')).toBe(true); // valid general
+    expect(isValidTicker('abc!def')).toBe(false); // special chars
+    expect(isValidTicker('12345678901')).toBe(false); // >10 chars
+  });
+
+  it('validates exchange:ticker format', async () => {
+    const { isValidExchangeTicker } = await import('@/lib/security/validators');
+    expect(isValidExchangeTicker('KOSPI:005930')).toBe(true);
+    expect(isValidExchangeTicker('KOSDAQ:035720')).toBe(true);
+    expect(isValidExchangeTicker('005930')).toBe(false); // no exchange
+    expect(isValidExchangeTicker('kospi:005930')).toBe(false); // lowercase exchange
+  });
+});
+
+describe('date validation (real calendar)', () => {
+  it('rejects Feb 30', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240230')).toBe(false);
+  });
+
+  it('rejects Feb 29 in non-leap year', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20230229')).toBe(false);
+  });
+
+  it('accepts Feb 29 in leap year', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240229')).toBe(true);
+  });
+
+  it('rejects Apr 31', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240431')).toBe(false);
+  });
+
+  it('accepts valid dates', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('20240101')).toBe(true);
+    expect(isValidCalendarDate('20241231')).toBe(true);
+  });
+
+  it('rejects malformed dates', async () => {
+    const { isValidCalendarDate } = await import('@/lib/security/validators');
+    expect(isValidCalendarDate('2024-01-01')).toBe(false);
+    expect(isValidCalendarDate('abc')).toBe(false);
+    expect(isValidCalendarDate('20241301')).toBe(false); // month 13
+    expect(isValidCalendarDate('20190101')).toBe(false); // before 2020
+  });
+
+  it('isLeapYear correctly identifies leap years', async () => {
+    const { isLeapYear } = await import('@/lib/security/validators');
+    expect(isLeapYear(2024)).toBe(true);
+    expect(isLeapYear(2023)).toBe(false);
+    expect(isLeapYear(2100)).toBe(false);
+    expect(isLeapYear(2000)).toBe(true);
+  });
+});
+
+// ================================================
+// 6. SSRF protection
+// ================================================
+
+describe('SSRF URL validation', () => {
+  it('rejects private IPv4', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://192.168.1.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects 10.x.x.x', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://10.0.0.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects 127.0.0.1', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://127.0.0.1/', { allowedSchemes: ['http'], checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects IPv6 loopback [::1]', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('::1')).toBe(true);
+    expect(isPrivateOrReservedIp('[::1]')).toBe(true);
+  });
+
+  it('rejects IPv6 multicast (ff02::1)', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('ff02::1')).toBe(true);
+  });
+
+  it('rejects IPv6 documentation range (2001:db8::)', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('2001:db8::1')).toBe(true);
+  });
+
+  it('rejects IPv4-mapped IPv6', async () => {
+    const { isPrivateOrReservedIp } = await import('@/lib/security/url-validation');
+    expect(isPrivateOrReservedIp('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateOrReservedIp('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('rejects credentials in URL', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('https://user:pass@example.com/', { checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects file:// scheme', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('file:///etc/passwd');
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects ftp:// scheme by default', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('ftp://example.com/', { checkDns: false });
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects cloud metadata endpoint', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('http://169.254.169.254/latest/', {
+      allowedSchemes: ['http', 'https'],
+      checkDns: false,
+    });
+    expect(result.safe).toBe(false);
+  });
+
+  it('validates redirect hops with SSRF check', async () => {
+    const { validateRedirectHop } = await import('@/lib/security/url-validation');
+    const result = await validateRedirectHop('http://10.0.0.1/admin', 'https://public.com', 1, 5);
+    expect(result.safe).toBe(false);
+  });
+
+  it('rejects too many redirect hops', async () => {
+    const { validateRedirectHop } = await import('@/lib/security/url-validation');
+    const result = await validateRedirectHop('https://example.com', 'https://other.com', 4, 3);
+    expect(result.safe).toBe(false);
+  });
+
+  it('allows safe public URLs', async () => {
+    const { validateUrlSafety } = await import('@/lib/security/url-validation');
+    const result = await validateUrlSafety('https://www.google.com/', { checkDns: false });
+    expect(result.safe).toBe(true);
+  });
+});
+
+// ================================================
+// 7. Unsubscribe: no email in response body (behavior check)
+// ================================================
+
+describe('unsubscribe security', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    process.env.UNSUBSCRIBE_TOKEN_SECRET = 'test-secret-at-least-32-characters!!';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('validateUnsubscribeToken does not expose email on failure', async () => {
+    const { validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth');
+    const result = validateUnsubscribeToken('invalid-token');
+    expect(result.valid).toBe(false);
+    expect(result.email).toBeUndefined();
+  });
+
+  it('unsubscribe token validates correctly', async () => {
+    const { generateUnsubscribeToken, validateUnsubscribeToken } = await import('@/lib/security/timing-safe-auth');
+    const token = generateUnsubscribeToken('test@example.com');
+    const result = validateUnsubscribeToken(token);
+    expect(result.valid).toBe(true);
+    expect(result.email).toBe('test@example.com');
+  });
+});

--- a/lib/security/opaque-token.ts
+++ b/lib/security/opaque-token.ts
@@ -1,0 +1,162 @@
+/**
+ * Opaque authenticated-encryption tokens (AES-256-GCM).
+ *
+ * Properties:
+ * - Email is encrypted inside ciphertext; never exposed in URL.
+ * - Purpose-bound (unsubscribe, confirm, etc.) inside AAD.
+ * - Expiry is bound inside ciphertext.
+ * - Random 12-byte nonce prevents reuse attacks.
+ * - Key rotation: supports UNSUBSCRIBE_TOKEN_SECRET and UNSUBSCRIBE_TOKEN_SECRET_PREV.
+ * - Secret must be >= 32 characters (enforced on both encrypt and decrypt).
+ *
+ * Token wire format (base64url):
+ *   <keyId:1><nonce:12><ciphertext+tag:variable>
+ *
+ * Plaintext layout (JSON):
+ *   { "e": email, "exp": epochSec, "p": purpose }
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
+
+export type TokenPurpose = 'unsubscribe' | 'confirm';
+
+export interface TokenPayload {
+  email: string;
+  purpose: TokenPurpose;
+}
+
+export interface TokenDecryptResult {
+  valid: boolean;
+  payload?: TokenPayload;
+  error?: 'expired' | 'tampered' | 'malformed' | 'no_secret';
+}
+
+const ALGORITHM = 'aes-256-gcm';
+const NONCE_LEN = 12;
+const TAG_LEN = 16;
+const KEY_ID_LEN = 1;
+const MIN_SECRET_LENGTH = 32;
+
+// Key IDs: 0x01 = current, 0x02 = previous (for rotation)
+const KEY_ID_CURRENT = 0x01;
+const KEY_ID_PREV = 0x02;
+
+function deriveKey(secret: string): Buffer {
+  return createHash('sha256').update(secret).digest();
+}
+
+function getKeys(): { current?: Buffer; prev?: Buffer } {
+  const currentSecret = process.env.UNSUBSCRIBE_TOKEN_SECRET;
+  const prevSecret = process.env.UNSUBSCRIBE_TOKEN_SECRET_PREV;
+
+  return {
+    current: currentSecret && currentSecret.length >= MIN_SECRET_LENGTH
+      ? deriveKey(currentSecret)
+      : undefined,
+    prev: prevSecret && prevSecret.length >= MIN_SECRET_LENGTH
+      ? deriveKey(prevSecret)
+      : undefined,
+  };
+}
+
+/**
+ * Encrypt a token payload.
+ * Throws if UNSUBSCRIBE_TOKEN_SECRET is not configured or < 32 chars (fail-closed).
+ */
+export function encryptToken(email: string, purpose: TokenPurpose, ttlSeconds: number): string {
+  const { current } = getKeys();
+  if (!current) {
+    throw new Error('UNSUBSCRIBE_TOKEN_SECRET must be configured (>=32 chars) for token generation');
+  }
+
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const plaintext = Buffer.from(JSON.stringify({ e: email, exp, p: purpose }), 'utf8');
+
+  const nonce = randomBytes(NONCE_LEN);
+  const aad = Buffer.from(purpose, 'utf8');
+
+  const cipher = createCipheriv(ALGORITHM, current, nonce, { authTagLength: TAG_LEN });
+  cipher.setAAD(aad);
+
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const wire = Buffer.concat([Buffer.from([KEY_ID_CURRENT]), nonce, encrypted, tag]);
+  return wire.toString('base64url');
+}
+
+/**
+ * Decrypt and validate a token.
+ * Fail-closed: returns error if no valid secret is configured (>=32 chars).
+ */
+export function decryptToken(token: string, expectedPurpose: TokenPurpose): TokenDecryptResult {
+  if (!token || typeof token !== 'string') {
+    return { valid: false, error: 'malformed' };
+  }
+
+  let wire: Buffer;
+  try {
+    wire = Buffer.from(token, 'base64url');
+  } catch {
+    return { valid: false, error: 'malformed' };
+  }
+
+  if (wire.length < KEY_ID_LEN + NONCE_LEN + TAG_LEN + 1) {
+    return { valid: false, error: 'malformed' };
+  }
+
+  const keyId = wire[0];
+  const nonce = wire.subarray(KEY_ID_LEN, KEY_ID_LEN + NONCE_LEN);
+  const ciphertextAndTag = wire.subarray(KEY_ID_LEN + NONCE_LEN);
+  const ciphertext = ciphertextAndTag.subarray(0, ciphertextAndTag.length - TAG_LEN);
+  const tag = ciphertextAndTag.subarray(ciphertextAndTag.length - TAG_LEN);
+
+  const { current, prev } = getKeys();
+
+  // Determine which key(s) to try
+  const keysToTry: Buffer[] = [];
+  if (keyId === KEY_ID_CURRENT && current) keysToTry.push(current);
+  else if (keyId === KEY_ID_PREV && prev) keysToTry.push(prev);
+  // Also try both for robustness during rotation
+  if (current && !keysToTry.includes(current)) keysToTry.push(current);
+  if (prev && !keysToTry.includes(prev)) keysToTry.push(prev);
+
+  if (keysToTry.length === 0) {
+    return { valid: false, error: 'no_secret' };
+  }
+
+  const aad = Buffer.from(expectedPurpose, 'utf8');
+
+  for (const key of keysToTry) {
+    try {
+      const decipher = createDecipheriv(ALGORITHM, key, nonce, { authTagLength: TAG_LEN });
+      decipher.setAAD(aad);
+      decipher.setAuthTag(tag);
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+      let payload: { e?: string; exp?: number; p?: string };
+      try {
+        payload = JSON.parse(decrypted.toString('utf8'));
+      } catch {
+        continue;
+      }
+
+      if (!payload.e || !payload.exp || payload.p !== expectedPurpose) {
+        return { valid: false, error: 'tampered' };
+      }
+
+      if (Math.floor(Date.now() / 1000) > payload.exp) {
+        return { valid: false, error: 'expired' };
+      }
+
+      return {
+        valid: true,
+        payload: { email: payload.e, purpose: expectedPurpose },
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return { valid: false, error: 'tampered' };
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -89,23 +89,27 @@ export function getTrustedClientIp(headers: { get(name: string): string | null }
 /**
  * Check rate limit against the distributed atomic counter.
  *
+ * `identity` is whatever the bucket is keyed by — usually the trusted client IP,
+ * but an email address for buckets that limit per recipient. It is always HMAC'd
+ * before storage, so no raw identity value reaches the database.
+ *
  * FAIL-CLOSED: returns { status: 'unavailable' } when:
  * - RATE_LIMIT_HMAC_SECRET is missing or < 32 chars
  * - Supabase URL/service key is missing
- * - Trusted IP is missing
+ * - The identity is missing
  * - RPC call fails
  */
 export async function checkRateLimit(
-  ip: string | null,
+  identity: string | null,
   config: RateLimitConfig
 ): Promise<RateLimitResult> {
-  // Fail-closed: require trusted IP
-  if (!ip) {
+  // Fail-closed: require an identity (e.g. no trusted x-real-ip header)
+  if (!identity) {
     return { status: 'unavailable', reason: 'no_trusted_ip' };
   }
 
   // Fail-closed: require HMAC secret
-  const ipHash = hashClientIp(ip, config.bucket);
+  const ipHash = hashClientIp(identity, config.bucket);
   if (!ipHash) {
     return { status: 'unavailable', reason: 'hmac_secret_missing_or_short' };
   }
@@ -161,6 +165,12 @@ export async function checkRateLimit(
 export const RATE_LIMITS = {
   subscribe: { bucket: 'subscribe', maxRequests: 5, windowSeconds: 60 } as RateLimitConfig,
   unsubscribe: { bucket: 'unsubscribe', maxRequests: 10, windowSeconds: 60 } as RateLimitConfig,
+  /**
+   * Keyed by email address rather than IP. Requesting an unsubscribe link sends
+   * real mail, so a per-IP limit alone lets rotating IPs mail-bomb one address.
+   * The identity is HMAC'd like any other, so no raw address reaches the counter.
+   */
+  unsubscribeRequestEmail: { bucket: 'unsubscribe_request_email', maxRequests: 3, windowSeconds: 3600 } as RateLimitConfig,
   stockPrice: { bucket: 'stock_price', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
   dailyClose: { bucket: 'daily_close', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
   newsletter: { bucket: 'newsletter', maxRequests: 2, windowSeconds: 3600 } as RateLimitConfig,

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -1,0 +1,167 @@
+/**
+ * Distributed rate limiter backed by Supabase (PostgreSQL).
+ *
+ * Design:
+ * - Atomic fixed-window counter via INSERT ... ON CONFLICT DO UPDATE ... RETURNING.
+ * - IP identifier is HMAC(server-secret, trusted_platform_ip) — never stores raw IP.
+ * - Trusts only `x-real-ip` (set by Vercel edge, not caller-supplied).
+ * - FAIL-CLOSED: returns unavailable when configuration/store/RPC fails.
+ * - Requires RATE_LIMIT_HMAC_SECRET (minimum 32 characters).
+ * - Resolves env per call (no module-load constants).
+ */
+
+import { createHmac } from 'crypto';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface RateLimitConfig {
+  /** Identifier scope/bucket (e.g. 'subscribe', 'stock_price') */
+  bucket: string;
+  /** Maximum requests in the window */
+  maxRequests: number;
+  /** Window size in seconds */
+  windowSeconds: number;
+}
+
+export type RateLimitResult =
+  | { status: 'allowed'; remaining: number; resetAt: number }
+  | { status: 'limited'; remaining: 0; resetAt: number }
+  | { status: 'unavailable'; reason: string };
+
+// ─── Configuration (resolved per call) ───
+
+function getHmacSecret(): string | null {
+  const secret = process.env.RATE_LIMIT_HMAC_SECRET;
+  if (!secret || secret.length < 32) return null;
+  return secret;
+}
+
+interface ServiceClientCache {
+  url: string;
+  key: string;
+  client: SupabaseClient;
+}
+
+let serviceClientCache: ServiceClientCache | null = null;
+
+function getServiceClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+
+  if (serviceClientCache?.url === url && serviceClientCache.key === key) {
+    return serviceClientCache.client;
+  }
+
+  const client = createClient(url, key, { auth: { persistSession: false } });
+  serviceClientCache = { url, key, client };
+  return client;
+}
+
+/**
+ * Hash the client IP with server-side HMAC.
+ * Returns null if HMAC secret is not configured (fail-closed signal).
+ */
+export function hashClientIp(ip: string, bucket: string): string | null {
+  const secret = getHmacSecret();
+  if (!secret) return null;
+  return createHmac('sha256', secret)
+    .update(`${bucket}:${ip}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/**
+ * Extract the trusted client IP from the request.
+ * Only trusts `x-real-ip` which is set by Vercel's edge infrastructure.
+ * Returns null if the header is missing or not a syntactically valid IP.
+ */
+export function getTrustedClientIp(headers: { get(name: string): string | null }): string | null {
+  const ip = headers.get('x-real-ip');
+  if (!ip) return null;
+  // Basic syntax check: IPv4 or IPv6 (including brackets)
+  const trimmed = ip.trim();
+  if (trimmed.length === 0 || trimmed.length > 45) return null;
+  // Must look like an IP (digits/dots/colons/brackets)
+  if (!/^[\d.:a-fA-F[\]]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Check rate limit against the distributed atomic counter.
+ *
+ * FAIL-CLOSED: returns { status: 'unavailable' } when:
+ * - RATE_LIMIT_HMAC_SECRET is missing or < 32 chars
+ * - Supabase URL/service key is missing
+ * - Trusted IP is missing
+ * - RPC call fails
+ */
+export async function checkRateLimit(
+  ip: string | null,
+  config: RateLimitConfig
+): Promise<RateLimitResult> {
+  // Fail-closed: require trusted IP
+  if (!ip) {
+    return { status: 'unavailable', reason: 'no_trusted_ip' };
+  }
+
+  // Fail-closed: require HMAC secret
+  const ipHash = hashClientIp(ip, config.bucket);
+  if (!ipHash) {
+    return { status: 'unavailable', reason: 'hmac_secret_missing_or_short' };
+  }
+
+  // Fail-closed: require Supabase
+  const client = getServiceClient();
+  if (!client) {
+    return { status: 'unavailable', reason: 'supabase_not_configured' };
+  }
+
+  try {
+    const { data, error } = await client.rpc('check_rate_limit', {
+      p_identity_hash: ipHash,
+      p_bucket: config.bucket,
+      p_max_requests: config.maxRequests,
+      p_window_seconds: config.windowSeconds,
+    });
+
+    if (error) {
+      console.error('[rate-limit] RPC error (fail-closed):', error.message);
+      return { status: 'unavailable', reason: 'rpc_error' };
+    }
+
+    const result = data as {
+      limited: boolean;
+      request_count: number;
+      window_start: number;
+      window_seconds: number;
+    } | null;
+
+    if (!result) {
+      return { status: 'unavailable', reason: 'rpc_null_response' };
+    }
+
+    const resetAt = result.window_start + result.window_seconds;
+
+    if (result.limited) {
+      return { status: 'limited', remaining: 0, resetAt };
+    }
+    return {
+      status: 'allowed',
+      remaining: Math.max(0, config.maxRequests - result.request_count),
+      resetAt,
+    };
+  } catch (err) {
+    console.error('[rate-limit] unexpected error (fail-closed):', err instanceof Error ? err.message : 'unknown');
+    return { status: 'unavailable', reason: 'exception' };
+  }
+}
+
+// ─── Preset configurations ───
+
+export const RATE_LIMITS = {
+  subscribe: { bucket: 'subscribe', maxRequests: 5, windowSeconds: 60 } as RateLimitConfig,
+  unsubscribe: { bucket: 'unsubscribe', maxRequests: 10, windowSeconds: 60 } as RateLimitConfig,
+  stockPrice: { bucket: 'stock_price', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
+  dailyClose: { bucket: 'daily_close', maxRequests: 30, windowSeconds: 60 } as RateLimitConfig,
+  newsletter: { bucket: 'newsletter', maxRequests: 2, windowSeconds: 3600 } as RateLimitConfig,
+} as const;

--- a/lib/security/timing-safe-auth.ts
+++ b/lib/security/timing-safe-auth.ts
@@ -1,0 +1,87 @@
+/**
+ * Timing-safe authentication utilities.
+ * Prevents timing side-channels by using constant-time comparison.
+ *
+ * Token operations delegate to AEAD opaque-token module.
+ * No legacy HMAC token code.
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { encryptToken, decryptToken, type TokenDecryptResult } from './opaque-token';
+
+/**
+ * Constant-time comparison of two strings.
+ * Returns false if either value is empty/undefined.
+ */
+export function timingSafeCompare(a: string | undefined | null, b: string | undefined | null): boolean {
+  if (!a || !b) return false;
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Validate a Bearer token against the expected CRON_SECRET.
+ * Fail-closed: returns false if CRON_SECRET is unset or empty.
+ */
+export function validateCronSecret(authHeader: string | null): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    return false;
+  }
+  if (!authHeader) return false;
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  return timingSafeCompare(token, secret);
+}
+
+// --- Opaque token wrappers (AEAD, no email in URL) ---
+
+/**
+ * Generate an opaque unsubscribe token for a given email.
+ * Throws if UNSUBSCRIBE_TOKEN_SECRET is not configured (>=32 chars, fail-closed).
+ * Default TTL: 30 days.
+ */
+export function generateUnsubscribeToken(email: string, ttlSeconds = 30 * 24 * 60 * 60): string {
+  return encryptToken(email, 'unsubscribe', ttlSeconds);
+}
+
+/**
+ * Generate an opaque confirmation token for double opt-in.
+ * Default TTL: 24 hours.
+ */
+export function generateConfirmToken(email: string, ttlSeconds = 24 * 60 * 60): string {
+  return encryptToken(email, 'confirm', ttlSeconds);
+}
+
+export interface TokenValidationResult {
+  valid: boolean;
+  email?: string;
+  error?: 'expired' | 'tampered' | 'malformed' | 'no_secret';
+}
+
+/**
+ * Validate and decode an unsubscribe token.
+ */
+export function validateUnsubscribeToken(token: string): TokenValidationResult {
+  const result = decryptToken(token, 'unsubscribe');
+  return mapResult(result);
+}
+
+/**
+ * Validate and decode a confirmation token.
+ */
+export function validateConfirmToken(token: string): TokenValidationResult {
+  const result = decryptToken(token, 'confirm');
+  return mapResult(result);
+}
+
+function mapResult(result: TokenDecryptResult): TokenValidationResult {
+  if (result.valid && result.payload) {
+    return { valid: true, email: result.payload.email };
+  }
+  return { valid: false, error: result.error };
+}

--- a/lib/security/url-validation.ts
+++ b/lib/security/url-validation.ts
@@ -1,0 +1,207 @@
+/**
+ * SSRF-safe URL validation.
+ *
+ * Validates a URL against:
+ * - Allowed schemes (http/https only)
+ * - No embedded credentials
+ * - No localhost, private, link-local, or reserved IP ranges
+ * - DNS resolution check (resolved IPs must not be private)
+ * - Redirect-hop validation (configurable max hops)
+ */
+
+import { lookup } from 'dns/promises';
+import { isIPv4 } from 'net';
+
+export interface UrlValidationOptions {
+  /** Allowed schemes. Default: ['https'] */
+  allowedSchemes?: string[];
+  /** Max redirect hops to follow for validation. Default: 3 */
+  maxRedirects?: number;
+  /** Whether to perform DNS resolution check. Default: true */
+  checkDns?: boolean;
+  /** Additional blocked hostnames. Default: [] */
+  blockedHostnames?: string[];
+}
+
+export interface UrlValidationResult {
+  safe: boolean;
+  reason?: string;
+}
+
+const PRIVATE_RANGES_V4: Array<{ prefix: number; mask: number }> = [
+  { prefix: 0x0A000000, mask: 0xFF000000 }, // 10.0.0.0/8
+  { prefix: 0xAC100000, mask: 0xFFF00000 }, // 172.16.0.0/12
+  { prefix: 0xC0A80000, mask: 0xFFFF0000 }, // 192.168.0.0/16
+  { prefix: 0x7F000000, mask: 0xFF000000 }, // 127.0.0.0/8
+  { prefix: 0xA9FE0000, mask: 0xFFFF0000 }, // 169.254.0.0/16 (link-local)
+  { prefix: 0x00000000, mask: 0xFF000000 }, // 0.0.0.0/8
+  { prefix: 0xC0000000, mask: 0xFFFFFFF8 }, // 192.0.0.0/29 (IANA special)
+  { prefix: 0xC0000200, mask: 0xFFFFFF00 }, // 192.0.2.0/24 (TEST-NET-1)
+  { prefix: 0xC6336400, mask: 0xFFFFFF00 }, // 198.51.100.0/24 (TEST-NET-2)
+  { prefix: 0xCB007100, mask: 0xFFFFFF00 }, // 203.0.113.0/24 (TEST-NET-3)
+  { prefix: 0xE0000000, mask: 0xF0000000 }, // 224.0.0.0/4 (multicast)
+  { prefix: 0xF0000000, mask: 0xF0000000 }, // 240.0.0.0/4 (reserved)
+  { prefix: 0xFFFFFFFF, mask: 0xFFFFFFFF }, // 255.255.255.255 (broadcast)
+  { prefix: 0xC6120000, mask: 0xFFFE0000 }, // 198.18.0.0/15 (benchmark)
+];
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split('.');
+  return (
+    ((parseInt(parts[0]) << 24) |
+      (parseInt(parts[1]) << 16) |
+      (parseInt(parts[2]) << 8) |
+      parseInt(parts[3])) >>>
+    0
+  );
+}
+
+export function isPrivateOrReservedIp(ip: string): boolean {
+  // Strip brackets for IPv6 (e.g. [::1])
+  const cleaned = ip.startsWith('[') && ip.endsWith(']') ? ip.slice(1, -1) : ip;
+
+  if (!isIPv4(cleaned)) {
+    // IPv6 checks
+    const lower = cleaned.toLowerCase();
+    if (
+      lower === '::1' ||                     // loopback
+      lower === '::' ||                      // unspecified
+      lower.startsWith('fe80:') ||           // link-local
+      lower.startsWith('fc') ||              // unique-local fc00::/7
+      lower.startsWith('fd') ||              // unique-local fd00::/8
+      lower.startsWith('ff') ||              // multicast ff00::/8
+      lower.startsWith('100:') ||            // discard 100::/64
+      lower.startsWith('2001:db8:') ||       // documentation 2001:db8::/32
+      lower.startsWith('::ffff:')            // IPv4-mapped
+    ) {
+      // For IPv4-mapped, check the mapped address
+      if (lower.startsWith('::ffff:')) {
+        const v4Part = lower.slice(7);
+        if (isIPv4(v4Part)) {
+          return isPrivateOrReservedIp(v4Part);
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  const ipInt = ipv4ToInt(cleaned);
+  return PRIVATE_RANGES_V4.some(({ prefix, mask }) => ((ipInt & mask) >>> 0) === (prefix >>> 0));
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'metadata.google.internal',
+  'metadata',
+  '169.254.169.254', // cloud metadata
+]);
+
+/**
+ * Validate a URL for SSRF safety.
+ * Call before making any outbound request.
+ */
+export async function validateUrlSafety(
+  rawUrl: string,
+  options: UrlValidationOptions = {}
+): Promise<UrlValidationResult> {
+  const {
+    allowedSchemes = ['https'],
+    checkDns = true,
+    blockedHostnames = [],
+  } = options;
+
+  // Parse URL
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { safe: false, reason: 'Invalid URL format' };
+  }
+
+  // Scheme check
+  const scheme = parsed.protocol.replace(':', '');
+  if (!allowedSchemes.includes(scheme)) {
+    return { safe: false, reason: `Scheme '${scheme}' not allowed. Allowed: ${allowedSchemes.join(', ')}` };
+  }
+
+  // Credentials check
+  if (parsed.username || parsed.password) {
+    return { safe: false, reason: 'URLs with embedded credentials are not allowed' };
+  }
+
+  // Hostname checks
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (!hostname || hostname.length === 0) {
+    return { safe: false, reason: 'Empty hostname' };
+  }
+
+  const allBlocked = new Set([...BLOCKED_HOSTNAMES, ...blockedHostnames.map((h) => h.toLowerCase())]);
+  if (allBlocked.has(hostname)) {
+    return { safe: false, reason: `Hostname '${hostname}' is blocked` };
+  }
+
+  // Check if hostname is a raw IP (including bracketed IPv6)
+  const rawHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+
+  if (isIPv4(rawHostname) || rawHostname.includes(':')) {
+    if (isPrivateOrReservedIp(rawHostname)) {
+      return { safe: false, reason: `IP address '${hostname}' is private/reserved` };
+    }
+  }
+
+  // DNS resolution check
+  if (checkDns && !isIPv4(hostname)) {
+    try {
+      const addresses = await lookup(hostname, { all: true });
+      for (const addr of Array.isArray(addresses) ? addresses : [addresses]) {
+        const ip = typeof addr === 'string' ? addr : addr.address;
+        if (isPrivateOrReservedIp(ip)) {
+          return {
+            safe: false,
+            reason: `Hostname '${hostname}' resolves to private/reserved IP '${ip}'`,
+          };
+        }
+      }
+    } catch (err) {
+      return {
+        safe: false,
+        reason: `DNS resolution failed for '${hostname}': ${err instanceof Error ? err.message : 'unknown error'}`,
+      };
+    }
+  }
+
+  return { safe: true };
+}
+
+/**
+ * Validate redirect targets during a multi-hop fetch.
+ * Call this for each redirect location before following it.
+ */
+export async function validateRedirectHop(
+  location: string,
+  baseUrl: string,
+  hopNumber: number,
+  maxRedirects: number = 3
+): Promise<UrlValidationResult> {
+  if (hopNumber > maxRedirects) {
+    return { safe: false, reason: `Exceeded maximum redirect hops (${maxRedirects})` };
+  }
+
+  // Resolve relative redirects against the base
+  let absoluteUrl: string;
+  try {
+    absoluteUrl = new URL(location, baseUrl).toString();
+  } catch {
+    return { safe: false, reason: 'Invalid redirect location' };
+  }
+
+  return validateUrlSafety(absoluteUrl, {
+    allowedSchemes: ['http', 'https'],
+    checkDns: true,
+  });
+}

--- a/lib/security/validators.ts
+++ b/lib/security/validators.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure validators for tickers and dates.
+ * Deterministic, no side-effects — suitable for direct unit testing.
+ */
+
+/** Korean stock ticker: exactly 6 digits */
+export const KOREAN_TICKER_PATTERN = /^[0-9]{6}$/;
+
+/** General ticker: 1-10 alphanumeric characters */
+export const GENERAL_TICKER_PATTERN = /^[A-Za-z0-9]{1,10}$/;
+
+/** Exchange-prefixed ticker: EXCHANGE:TICKER */
+export const TICKER_WITH_EXCHANGE_PATTERN = /^[A-Z]{2,10}:[0-9A-Za-z]{1,10}$/;
+
+/** Date pattern: YYYYMMDD */
+export const DATE_PATTERN = /^\d{8}$/;
+
+/** Days in each month (non-leap year, 0-indexed) */
+export const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] as const;
+
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Validate a ticker string.
+ * Accepts Korean 6-digit or general alphanumeric up to 10 chars.
+ */
+export function isValidTicker(ticker: string): boolean {
+  return KOREAN_TICKER_PATTERN.test(ticker) || GENERAL_TICKER_PATTERN.test(ticker);
+}
+
+/**
+ * Validate a ticker with exchange prefix (e.g. KOSPI:005930).
+ */
+export function isValidExchangeTicker(ticker: string): boolean {
+  return TICKER_WITH_EXCHANGE_PATTERN.test(ticker);
+}
+
+/**
+ * Validate a date string as a real calendar date.
+ * Rejects Feb 30, Apr 31, etc.
+ * Range: 2020-01-01 to 2100-12-31.
+ */
+export function isValidCalendarDate(dateStr: string): boolean {
+  if (!DATE_PATTERN.test(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  if (year < 2020 || year > 2100) return false;
+  if (month < 1 || month > 12) return false;
+
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  if (day < 1 || day > maxDay) return false;
+
+  return true;
+}
+
+/**
+ * Validate a date is not in the far future (tomorrow at most).
+ */
+export function isDateNotFuture(dateStr: string): boolean {
+  if (!isValidCalendarDate(dateStr)) return false;
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6));
+  const day = parseInt(dateStr.slice(6, 8));
+
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(23, 59, 59, 999);
+  const inputDate = new Date(year, month - 1, day);
+  return inputDate <= tomorrow;
+}
+
+/** Maximum tickers allowed per request */
+export const MAX_TICKERS_PER_REQUEST = 10;

--- a/lib/sendgrid.ts
+++ b/lib/sendgrid.ts
@@ -284,6 +284,18 @@ export async function sendSingleRecipient(
     const error = err as { code?: number; response?: { statusCode?: number; body?: unknown } };
     const statusCode = error.response?.statusCode || error.code;
 
+    // 429 (rate limit) and 408 (request timeout) are 4xx but transient: the same
+    // payload succeeds once the window resets. Classifying them permanent burns a
+    // recipient's remaining attempts and drops a deliverable address for good —
+    // lib/delivery/service.ts routes !retryable straight to a terminal 'failed'.
+    if (statusCode === 429 || statusCode === 408) {
+      return {
+        accepted: false,
+        retryable: true,
+        error: `Provider throttled: ${statusCode}`,
+      };
+    }
+
     if (statusCode && statusCode >= 400 && statusCode < 500) {
       // 4xx = permanent (bad email, suppression, etc)
       return {
@@ -329,7 +341,12 @@ export async function sendStockNewsletter(
       try {
         const result = await sendSingleRecipient(recipient, data);
         if (!result.accepted) {
+          // A provider rejection never throws, so it must be pushed onto `errors`
+          // explicitly. Logging alone let the function return normally and print
+          // "전송 완료: N명" while N recipients had been rejected — the cron routes
+          // that call this then recorded the run as fully successful.
           console.error(`[sendgrid] Failed for recipient (hash: ${recipient.email.length}chars): ${result.error}`);
+          errors.push(new Error(result.error ?? 'provider rejected'));
         }
       } catch (err) {
         errors.push(err instanceof Error ? err : new Error(String(err)));

--- a/lib/sendgrid.ts
+++ b/lib/sendgrid.ts
@@ -1,4 +1,14 @@
 import sgMail from '@sendgrid/mail';
+import { generateUnsubscribeToken } from '@/lib/security/timing-safe-auth';
+
+/**
+ * Generate opaque unsubscribe token for a given email.
+ * Fail-closed: throws if UNSUBSCRIBE_TOKEN_SECRET is not configured.
+ * Caller must ensure the secret is set before sending mail.
+ */
+function generateUnsubscribeTokenForEmail(email: string): string {
+  return generateUnsubscribeToken(email);
+}
 
 /**
  * HTML 특수문자 이스케이프 (LLM 출력 삽입 시 XSS 방지)
@@ -10,6 +20,111 @@ function escapeHtml(str: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+/**
+ * Send double opt-in confirmation email.
+ * Token-only HTTPS URL, escaped content, no PII logging.
+ * Throws on send failure (caller must handle cleanup).
+ */
+export async function sendSubscriptionConfirmation(email: string, token: string): Promise<void> {
+  initSendGrid();
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr';
+  const confirmUrl = `${appUrl}/subscribe?confirm=${encodeURIComponent(token)}`;
+  const escapedUrl = escapeHtml(confirmUrl);
+
+  const html = `<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>구독 확인</title></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans KR',sans-serif;background:#F8FAFC;">
+<table role="presentation" width="100%" style="background:#F8FAFC;padding:40px 20px;">
+<tr><td>
+<table role="presentation" width="100%" style="max-width:560px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+<tr><td style="padding:32px 24px;background:#0F172A;border-radius:8px 8px 0 0;text-align:center;">
+<p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#10B981;letter-spacing:0.05em;text-transform:uppercase;">Stock Matrix</p>
+<h1 style="margin:0;font-size:22px;font-weight:700;color:#FFFFFF;">이메일 주소 확인</h1>
+</td></tr>
+<tr><td style="padding:32px 24px;">
+<p style="margin:0 0 16px;font-size:15px;color:#334155;line-height:1.6;">안녕하세요,</p>
+<p style="margin:0 0 24px;font-size:15px;color:#334155;line-height:1.6;">Stock Matrix 뉴스레터 구독을 요청하셨습니다. 아래 링크를 클릭하여 구독을 확인해주세요.</p>
+<table role="presentation" width="100%"><tr><td style="text-align:center;padding:8px 0 24px;">
+<a href="${escapedUrl}" target="_blank" rel="noopener" style="display:inline-block;padding:14px 32px;background:#10B981;color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:6px;">구독 확인하기</a>
+</td></tr></table>
+<p style="margin:0 0 8px;font-size:13px;color:#64748B;line-height:1.5;">이 링크는 24시간 동안 유효합니다.</p>
+<p style="margin:0;font-size:13px;color:#64748B;line-height:1.5;">본인이 요청하지 않았다면 이 이메일을 무시해주세요.</p>
+</td></tr>
+<tr><td style="padding:16px 24px;border-top:1px solid #E2E8F0;text-align:center;">
+<p style="margin:0;font-size:12px;color:#94A3B8;">&copy; Stock Matrix. 모든 권리 보유.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body></html>`;
+
+  await sgMail.send({
+    to: email,
+    from: {
+      email: process.env.SENDGRID_FROM_EMAIL as string,
+      name: process.env.SENDGRID_FROM_NAME as string,
+    },
+    subject: '[Stock Matrix] 이메일 주소 확인',
+    html,
+  });
+}
+
+/**
+ * Send a fresh unsubscribe link.
+ *
+ * Newsletters delivered before opaque tokens existed carry `?email=` links, and
+ * issued tokens expire. Without this path a subscriber holding an old or expired
+ * link has no way to opt out, which 정보통신망법 제50조 does not allow.
+ * Requesting a link is not itself an opt-out — the emailed link still requires
+ * explicit confirmation.
+ */
+export async function sendUnsubscribeLink(email: string, token: string): Promise<void> {
+  initSendGrid();
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr';
+  const unsubscribeUrl = `${appUrl}/unsubscribe?token=${encodeURIComponent(token)}`;
+  const escapedUrl = escapeHtml(unsubscribeUrl);
+
+  const html = `<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>구독 취소</title></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Noto Sans KR',sans-serif;background:#F8FAFC;">
+<table role="presentation" width="100%" style="background:#F8FAFC;padding:40px 20px;">
+<tr><td>
+<table role="presentation" width="100%" style="max-width:560px;margin:0 auto;background:#FFFFFF;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+<tr><td style="padding:32px 24px;background:#0F172A;border-radius:8px 8px 0 0;text-align:center;">
+<p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#10B981;letter-spacing:0.05em;text-transform:uppercase;">Stock Matrix</p>
+<h1 style="margin:0;font-size:22px;font-weight:700;color:#FFFFFF;">구독 취소 링크</h1>
+</td></tr>
+<tr><td style="padding:32px 24px;">
+<p style="margin:0 0 24px;font-size:15px;color:#334155;line-height:1.6;">요청하신 구독 취소 링크입니다. 아래 버튼을 눌러 구독 취소를 완료해주세요.</p>
+<table role="presentation" width="100%"><tr><td style="text-align:center;padding:8px 0 24px;">
+<a href="${escapedUrl}" target="_blank" rel="noopener" style="display:inline-block;padding:14px 32px;background:#DC2626;color:#FFFFFF;font-size:15px;font-weight:600;text-decoration:none;border-radius:6px;">구독 취소하기</a>
+</td></tr></table>
+<p style="margin:0 0 8px;font-size:13px;color:#64748B;line-height:1.5;">이 링크는 30일 동안 유효합니다.</p>
+<p style="margin:0;font-size:13px;color:#64748B;line-height:1.5;">본인이 요청하지 않았다면 이 이메일을 무시해주세요. 구독은 그대로 유지됩니다.</p>
+</td></tr>
+<tr><td style="padding:16px 24px;border-top:1px solid #E2E8F0;text-align:center;">
+<p style="margin:0;font-size:12px;color:#94A3B8;">&copy; Stock Matrix. 모든 권리 보유.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body></html>`;
+
+  await sgMail.send({
+    to: email,
+    from: {
+      email: process.env.SENDGRID_FROM_EMAIL as string,
+      name: process.env.SENDGRID_FROM_NAME as string,
+    },
+    subject: '[Stock Matrix] 구독 취소 링크',
+    html,
+  });
 }
 
 // API 키 + 발신자 정보 초기화 함수
@@ -113,13 +228,24 @@ export function parseCrashAlert(jsonString: string): CrashAlertData | null {
 }
 
 /**
- * SendGrid로 주식 뉴스레터 이메일 전송
+ * Result of a single-recipient send attempt.
  */
-export async function sendStockNewsletter(
-  recipients: EmailRecipient[],
-  data: StockNewsletterData
-): Promise<void> {
-  // SendGrid 초기화 (API 키 + 발신자 정보 검증 포함)
+export interface SingleSendResult {
+  accepted: boolean;
+  messageId?: string;
+  retryable?: boolean;
+  error?: string;
+}
+
+/**
+ * Send newsletter to a single recipient. Returns structured outcome.
+ * Does NOT throw on provider rejection — returns a result object.
+ * Only throws on non-recoverable internal errors (missing config, etc).
+ */
+export async function sendSingleRecipient(
+  recipient: EmailRecipient,
+  data: StockNewsletterData,
+): Promise<SingleSendResult> {
   initSendGrid();
 
   const isCrash = parseCrashAlert(data.geminiAnalysis) !== null;
@@ -127,28 +253,103 @@ export async function sendStockNewsletter(
     ? `[Stock Matrix] ${data.date} 긴급 시장 분석`
     : `[Stock Matrix] ${data.date} AI 기술적 분석`;
 
-  try {
-    // 각 수신자별로 개별 이메일 전송 (수신거부 링크 개인화)
-    await Promise.all(
-      recipients.map((recipient) => {
-        const html = generateNewsletterHTML(data, recipient.email);
-        return sgMail.send({
-          to: recipient.email,
-          from: {
-            email: process.env.SENDGRID_FROM_EMAIL as string,
-            name: process.env.SENDGRID_FROM_NAME as string,
-          },
-          subject,
-          html,
-        });
-      })
-    );
+  const html = generateNewsletterHTML(data, recipient.email);
 
-    console.log(`✅ 이메일 전송 완료: ${recipients.length}명`);
-  } catch (error) {
-    console.error('❌ SendGrid 이메일 전송 실패:', error);
-    throw error;
+  try {
+    const [response] = await sgMail.send({
+      to: recipient.email,
+      from: {
+        email: process.env.SENDGRID_FROM_EMAIL as string,
+        name: process.env.SENDGRID_FROM_NAME as string,
+      },
+      subject,
+      html,
+    });
+
+    // SendGrid returns x-message-id in response headers
+    const messageId = response?.headers?.['x-message-id'] as string | undefined;
+
+    if (response?.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+      return { accepted: true, messageId };
+    }
+
+    // Unexpected non-2xx without throw
+    return {
+      accepted: false,
+      retryable: response?.statusCode ? response.statusCode >= 500 : false,
+      error: `Unexpected status ${response?.statusCode}`,
+    };
+  } catch (err: unknown) {
+    // Classify SendGrid errors
+    const error = err as { code?: number; response?: { statusCode?: number; body?: unknown } };
+    const statusCode = error.response?.statusCode || error.code;
+
+    if (statusCode && statusCode >= 400 && statusCode < 500) {
+      // 4xx = permanent (bad email, suppression, etc)
+      return {
+        accepted: false,
+        retryable: false,
+        error: `Provider rejected: ${statusCode}`,
+      };
+    }
+
+    if (statusCode && statusCode >= 500) {
+      // 5xx = retryable
+      return {
+        accepted: false,
+        retryable: true,
+        error: `Provider error: ${statusCode}`,
+      };
+    }
+
+    // Network errors, timeouts — ambiguous
+    throw err;
   }
+}
+
+/**
+ * SendGrid로 주식 뉴스레터 이메일 전송 (bounded concurrency)
+ *
+ * @deprecated Use `executeDelivery` from `@/lib/delivery/service` for
+ * production sends. This function is retained for backward compatibility
+ * but now uses bounded concurrency internally.
+ */
+export async function sendStockNewsletter(
+  recipients: EmailRecipient[],
+  data: StockNewsletterData,
+): Promise<void> {
+  initSendGrid();
+
+  const CONCURRENCY = 10;
+  const executing = new Set<Promise<void>>();
+  const errors: Error[] = [];
+
+  for (const recipient of recipients) {
+    const promise = (async () => {
+      try {
+        const result = await sendSingleRecipient(recipient, data);
+        if (!result.accepted) {
+          console.error(`[sendgrid] Failed for recipient (hash: ${recipient.email.length}chars): ${result.error}`);
+        }
+      } catch (err) {
+        errors.push(err instanceof Error ? err : new Error(String(err)));
+      }
+    })().then(() => { executing.delete(promise); });
+
+    executing.add(promise);
+
+    if (executing.size >= CONCURRENCY) {
+      await Promise.race(executing);
+    }
+  }
+
+  await Promise.all(executing);
+
+  if (errors.length > 0) {
+    throw new Error(`SendGrid delivery failed for ${errors.length} recipient(s)`);
+  }
+
+  console.log(`✅ 이메일 전송 완료: ${recipients.length}명`);
 }
 
 /**
@@ -243,7 +444,7 @@ function generateNewsletterHTML(data: StockNewsletterData, email: string): strin
           <tr>
             <td style="padding: 32px 40px; background-color: #F8FAFC; border-radius: 0 0 8px 8px; text-align: center;">
               <p style="margin: 0 0 16px 0; padding: 0; font-size: 12px; font-weight: 400; color: #94A3B8; line-height: 1.5;">Stock Matrix</p>
-              <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr'}/unsubscribe?email=${encodeURIComponent(email)}" style="display: inline-block; padding: 8px 16px; font-size: 12px; font-weight: 500; color: #64748B; text-decoration: none; border: 1px solid #E2E8F0; border-radius: 6px; transition: all 0.2s;">구독 취소</a>
+              <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://stockmatrix.co.kr'}/unsubscribe?token=${encodeURIComponent(generateUnsubscribeTokenForEmail(email))}" style="display: inline-block; padding: 8px 16px; font-size: 12px; font-weight: 500; color: #64748B; text-decoration: none; border: 1px solid #E2E8F0; border-radius: 6px; transition: all 0.2s;">구독 취소</a>
             </td>
           </tr>
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,15 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: '/og-background-v1.png',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
         source: '/:path*',
         headers: [
           {
@@ -37,6 +46,14 @@ const nextConfig: NextConfig = {
             value: 'camera=(), microphone=(), geolocation=()',
           },
           {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Permitted-Cross-Domain-Policies',
+            value: 'none',
+          },
+          {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
@@ -47,6 +64,8 @@ const nextConfig: NextConfig = {
               "connect-src 'self' https://*.supabase.co https://vitals.vercel-insights.com https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com",
               "frame-src https://vercel.live",
               "frame-ancestors 'none'",
+              "object-src 'none'",
+              "base-uri 'self'",
             ].join('; '),
           },
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-rehype": "^11.1.2",
+        "server-only": "0.0.1",
         "tailwind-merge": "^3.4.0",
         "twitter-api-v2": "^1.27.0",
         "undici": "^7.21.0",
@@ -11422,6 +11423,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-rehype": "^11.1.2",
+    "server-only": "0.0.1",
     "tailwind-merge": "^3.4.0",
     "twitter-api-v2": "^1.27.0",
     "undici": "^7.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       remark-rehype:
         specifier: ^11.1.2
         version: 11.1.2
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -3800,6 +3803,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8215,6 +8221,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/supabase/migrations/056b_lockdown_stock_price_cache_writes.sql
+++ b/supabase/migrations/056b_lockdown_stock_price_cache_writes.sql
@@ -1,0 +1,119 @@
+-- ================================================
+-- Migration: Revoke anonymous INSERT/UPDATE on stock_price_cache
+-- and restrict SECURITY DEFINER function grants
+-- ================================================
+--
+-- Before: anon role could INSERT/UPDATE stock_price_cache rows via RLS policies
+-- After:  Only authenticated (service_role) can write; public can still read
+--
+-- Also restricts clean_expired_stock_price_cache SECURITY DEFINER function
+-- to be executable only by service_role (was previously public).
+-- ================================================
+
+-- 1. Drop overly permissive INSERT/UPDATE policies
+DROP POLICY IF EXISTS "Public insert access" ON public.stock_price_cache;
+DROP POLICY IF EXISTS "Public update access" ON public.stock_price_cache;
+
+-- 2. Create service-role-only write policies
+CREATE POLICY "Service role insert access"
+  ON public.stock_price_cache
+  FOR INSERT
+  WITH CHECK (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  );
+
+CREATE POLICY "Service role update access"
+  ON public.stock_price_cache
+  FOR UPDATE
+  USING (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  )
+  WITH CHECK (
+    auth.jwt() IS NOT NULL
+    AND (auth.jwt()->>'role' = 'service_role')
+  );
+
+-- 3. Revoke public EXECUTE on SECURITY DEFINER functions.
+-- Guarded: an unqualified REVOKE against a missing object aborts the whole
+-- migration, which would leave the lockdown half-applied.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'clean_expired_stock_price_cache'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM public';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() FROM authenticated';
+    -- Supabase internal cron runs as service_role
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.clean_expired_stock_price_cache() TO service_role';
+  END IF;
+END $$;
+
+-- ================================================
+-- Notes:
+-- - Existing server-side code using service_role key continues to work
+-- - Client-side/anon reads still work (SELECT policy unchanged)
+-- - The pg_cron job runs as service_role so cleanup continues working
+-- ================================================
+
+-- ================================================
+-- 4. Revoke anon EXECUTE on insert_mcp_analytics
+--    This RPC trusts caller-provided ip_hash for rate-limit enforcement.
+--    Since the function is not called from any current client code,
+--    restrict to service_role only to prevent spoofed ip_hash abuse.
+-- ================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'insert_mcp_analytics'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM authenticated';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION insert_mcp_analytics(text, text, text, text) FROM public';
+  END IF;
+END $$;
+
+-- 5. Remove table-level write privileges as defense in depth and clear any
+-- rows that may have been written through the former anonymous policies.
+TRUNCATE TABLE public.stock_price_cache;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.stock_price_cache FROM authenticated;
+GRANT SELECT ON TABLE public.stock_price_cache TO anon, authenticated;
+GRANT ALL ON TABLE public.stock_price_cache TO service_role;
+
+-- 6. Keep the scientific prediction containment boundary canonical: callers
+-- must use the validated public scientific RPC, not the legacy v4 view.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = 'v_prediction_v4_serving'
+  ) THEN
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM PUBLIC';
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM anon';
+    EXECUTE 'REVOKE SELECT ON TABLE public.v_prediction_v4_serving FROM authenticated';
+    EXECUTE 'GRANT SELECT ON TABLE public.v_prediction_v4_serving TO service_role';
+  END IF;
+END $$;
+
+-- 7. View counting is performed by the server repository with service_role.
+-- Public execution allowed arbitrary counter inflation.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'increment_blog_view_count'
+  ) THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM PUBLIC';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) FROM authenticated';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.increment_blog_view_count(VARCHAR) TO service_role';
+  END IF;
+END $$;

--- a/supabase/migrations/057_rate_limit_and_double_optin.sql
+++ b/supabase/migrations/057_rate_limit_and_double_optin.sql
@@ -1,0 +1,231 @@
+-- ================================================
+-- Migration 057: Atomic rate limiting + double opt-in
+-- ================================================
+--
+-- Rate limiting: fixed-window counter using INSERT ... ON CONFLICT DO UPDATE ... RETURNING
+-- keyed by (identity_hash, bucket, window_start). Time derived inside PostgreSQL.
+-- Double opt-in: service-role-only transactional confirm_subscription RPC.
+-- ================================================
+
+-- 1. Rate limit table: atomic fixed-window counter
+CREATE TABLE IF NOT EXISTS public.rate_limit_counters (
+  identity_hash TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  window_start BIGINT NOT NULL, -- epoch seconds, derived server-side
+  request_count INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (identity_hash, bucket, window_start)
+);
+
+ALTER TABLE public.rate_limit_counters ENABLE ROW LEVEL SECURITY;
+-- No policies: service_role only (bypasses RLS)
+
+-- 2. Atomic check-and-increment RPC (SECURITY DEFINER)
+-- Derives time inside PostgreSQL; ignores caller-supplied timestamps.
+-- Validates max_requests (1..10000) and window_seconds (1..86400).
+CREATE OR REPLACE FUNCTION public.check_rate_limit(
+  p_identity_hash TEXT,
+  p_bucket TEXT,
+  p_max_requests INTEGER,
+  p_window_seconds INTEGER
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_now BIGINT;
+  v_window_start BIGINT;
+  v_count INTEGER;
+  v_limited BOOLEAN;
+BEGIN
+  -- Validate ranges
+  IF p_max_requests < 1 OR p_max_requests > 10000 THEN
+    RAISE EXCEPTION 'max_requests must be between 1 and 10000';
+  END IF;
+  IF p_window_seconds < 1 OR p_window_seconds > 86400 THEN
+    RAISE EXCEPTION 'window_seconds must be between 1 and 86400';
+  END IF;
+
+  v_now := EXTRACT(EPOCH FROM clock_timestamp())::BIGINT;
+  v_window_start := v_now - (v_now % p_window_seconds);
+
+  -- Atomic upsert: increment or insert
+  INSERT INTO public.rate_limit_counters (identity_hash, bucket, window_start, request_count)
+  VALUES (p_identity_hash, p_bucket, v_window_start, 1)
+  ON CONFLICT (identity_hash, bucket, window_start)
+  DO UPDATE SET request_count = public.rate_limit_counters.request_count + 1
+  RETURNING request_count INTO v_count;
+
+  v_limited := v_count > p_max_requests;
+
+  RETURN json_build_object(
+    'limited', v_limited,
+    'request_count', v_count,
+    'window_start', v_window_start,
+    'window_seconds', p_window_seconds
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM anon;
+REVOKE ALL ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.check_rate_limit(TEXT, TEXT, INTEGER, INTEGER) TO service_role;
+
+-- 3. Safe retention cleanup (delete windows older than 2 hours)
+CREATE OR REPLACE FUNCTION public.clean_rate_limit_counters()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_deleted INTEGER;
+  v_cutoff BIGINT;
+BEGIN
+  v_cutoff := EXTRACT(EPOCH FROM clock_timestamp())::BIGINT - 7200;
+  DELETE FROM public.rate_limit_counters WHERE window_start < v_cutoff;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM anon;
+REVOKE ALL ON FUNCTION public.clean_rate_limit_counters() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clean_rate_limit_counters() TO service_role;
+
+-- Schedule cleanup if pg_cron exists (safe: checks existence, no unschedule call)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Use upsert-style: schedule only if not already scheduled
+    IF NOT EXISTS (
+      SELECT 1 FROM cron.job WHERE jobname = 'cleanup-rate-limit-counters'
+    ) THEN
+      PERFORM cron.schedule(
+        'cleanup-rate-limit-counters',
+        '*/15 * * * *',
+        $sched$ SELECT public.clean_rate_limit_counters() $sched$
+      );
+    END IF;
+  END IF;
+END $$;
+
+-- 4. Pending subscribers table for double opt-in
+CREATE TABLE IF NOT EXISTS public.pending_subscribers (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL,
+  name TEXT,
+  confirm_token_hash TEXT NOT NULL,
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  confirmed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Unconditional unique constraint on email (suitable for upsert)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'pending_subscribers_email_key'
+  ) THEN
+    ALTER TABLE public.pending_subscribers ADD CONSTRAINT pending_subscribers_email_key UNIQUE (email);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_pending_subscribers_expires
+  ON public.pending_subscribers (expires_at);
+
+ALTER TABLE public.pending_subscribers ENABLE ROW LEVEL SECURITY;
+-- No policies: service_role only
+
+-- 5. Transactional confirm_subscription RPC (SECURITY DEFINER)
+-- Locks pending row, verifies token hash + expiry, activates subscriber atomically.
+CREATE OR REPLACE FUNCTION public.confirm_subscription(
+  p_token_hash TEXT,
+  p_email TEXT
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_pending RECORD;
+BEGIN
+  -- Lock the pending row
+  SELECT id, email, name, expires_at, confirmed_at
+  INTO v_pending
+  FROM public.pending_subscribers
+  WHERE email = p_email
+    AND confirm_token_hash = p_token_hash
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'not_found');
+  END IF;
+
+  IF v_pending.confirmed_at IS NOT NULL THEN
+    RETURN json_build_object('success', false, 'error', 'already_confirmed');
+  END IF;
+
+  IF v_pending.expires_at < NOW() THEN
+    RETURN json_build_object('success', false, 'error', 'expired');
+  END IF;
+
+  -- Mark pending as confirmed (consume the token)
+  UPDATE public.pending_subscribers
+  SET confirmed_at = NOW()
+  WHERE id = v_pending.id;
+
+  -- Upsert into subscribers (activate or create)
+  INSERT INTO public.subscribers (email, name, is_active)
+  VALUES (v_pending.email, v_pending.name, true)
+  ON CONFLICT (email)
+  DO UPDATE SET is_active = true, name = COALESCE(EXCLUDED.name, public.subscribers.name);
+
+  RETURN json_build_object('success', true, 'email', v_pending.email);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION public.confirm_subscription(TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.confirm_subscription(TEXT, TEXT) TO service_role;
+
+-- 6. Cleanup expired pending subscriptions
+CREATE OR REPLACE FUNCTION public.clean_expired_pending_subscribers()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  DELETE FROM public.pending_subscribers
+  WHERE expires_at < NOW() AND confirmed_at IS NULL;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM anon;
+REVOKE ALL ON FUNCTION public.clean_expired_pending_subscribers() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clean_expired_pending_subscribers() TO service_role;
+
+-- Revoke table access from public/anon/authenticated
+REVOKE ALL ON TABLE public.rate_limit_counters FROM PUBLIC;
+REVOKE ALL ON TABLE public.rate_limit_counters FROM anon;
+REVOKE ALL ON TABLE public.rate_limit_counters FROM authenticated;
+GRANT ALL ON TABLE public.rate_limit_counters TO service_role;
+
+REVOKE ALL ON TABLE public.pending_subscribers FROM PUBLIC;
+REVOKE ALL ON TABLE public.pending_subscribers FROM anon;
+REVOKE ALL ON TABLE public.pending_subscribers FROM authenticated;
+GRANT ALL ON TABLE public.pending_subscribers TO service_role;
+
+COMMENT ON TABLE public.rate_limit_counters IS 'Atomic fixed-window rate limit counters (service_role only)';
+COMMENT ON TABLE public.pending_subscribers IS 'Double opt-in pending confirmations (service_role only)';

--- a/supabase/migrations/migration-version.test.ts
+++ b/supabase/migrations/migration-version.test.ts
@@ -1,0 +1,37 @@
+import { readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const MIGRATION_DIR = resolve(process.cwd(), 'supabase', 'migrations')
+const VERSIONED_MIGRATION = /^(\d+[a-z]?)_.+\.sql$/i
+
+describe('Supabase migration file ordering', () => {
+  it('uses unique version prefixes and preserves the 056 hardening sequence', async () => {
+    const files = (await readdir(MIGRATION_DIR)).filter((file) => file.endsWith('.sql'))
+    const versions = files.flatMap((file) => {
+      const match = VERSIONED_MIGRATION.exec(file)
+      return match ? [{ file, version: match[1].toLowerCase() }] : []
+    })
+    const counts = new Map<string, number>()
+
+    for (const { version } of versions) {
+      counts.set(version, (counts.get(version) ?? 0) + 1)
+    }
+
+    const duplicates = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([version]) => version)
+      .sort()
+
+    expect(duplicates).toEqual([])
+
+    const ordered = files.sort((left, right) => left.localeCompare(right, 'en'))
+    const dropIndexes = ordered.indexOf('056_drop_unused_indexes.sql')
+    const lockdown = ordered.indexOf('056b_lockdown_stock_price_cache_writes.sql')
+    const rateLimit = ordered.indexOf('057_rate_limit_and_double_optin.sql')
+
+    expect(dropIndexes).toBeGreaterThanOrEqual(0)
+    expect(lockdown).toBeGreaterThan(dropIndexes)
+    expect(rateLimit).toBeGreaterThan(lockdown)
+  })
+})


### PR DESCRIPTION
PR #111 분할 시리즈 **1/5**. base `main`.

- 전체 리뷰: [`docs/PR111_REVIEW_2026-07-31.md`](docs/PR111_REVIEW_2026-07-31.md)
- 배포 절차: [`docs/deploy/01-security-containment.md`](docs/deploy/01-security-containment.md)
- 원본 finding: [`docs/PROJECT_READINESS_FULL_REVIEW_2026-07-30.md`](docs/PROJECT_READINESS_FULL_REVIEW_2026-07-30.md)

> 이전 시도 이력: #112로 머지됐다가 배포 실패로 `0bac372`에서 revert, #117은 브랜치 재작성으로 닫힘.
> **배포 실패 원인은 아래 4번에서 찾아 고쳤습니다.**

## 범위

SEC-001/002/003/005 — 보안 격리. 마이그레이션 `056b`, `057`.

| 항목 | 내용 |
|---|---|
| cron 인증 | Bearer `CRON_SECRET` timing-safe 비교, 미설정 시 fail-closed |
| 이중 옵트인 | `pending_subscribers` + 트랜잭셔널 `confirm_subscription` RPC |
| 구독취소 토큰 | AES-256-GCM opaque 토큰, 이메일이 URL에 노출되지 않음, 키 회전 지원 |
| 캐시 잠금 | `stock_price_cache` 익명 INSERT/UPDATE 회수 |
| Rate limit | Supabase 원자적 고정 윈도우 카운터, fail-closed |
| KIS 토큰 | anon fallback 제거, service_role 전용 |
| 보안 헤더 | HSTS, `object-src 'none'`, `base-uri 'self'` |

## 리뷰에서 발견해 수정한 결함

### 1. 기 발송분의 구독취소 링크가 전부 죽음 (Blocker)

원본은 페이지·API를 token 전용으로 바꿨는데, 이미 발송된 모든 뉴스레터의 링크는 `/unsubscribe?email=`
형식이라 전부 "Invalid Request"로 끝났다. 신규 토큰도 TTL 30일이라 그 이후 발송분도 동일해진다.
정보통신망법 제50조 수신거부 조치 요건에 걸린다.

`/unsubscribe`에 이메일 입력 폴백을 추가했다.

```
/unsubscribe            → 이메일 입력 폼
/unsubscribe?token=xxx  → 기존 확인 플로우
/unsubscribe?email=xxx  → 이메일 프리필 + 폼 (즉시 해지 없음)
만료된 토큰               → 이메일 프리필 + 폼
```

`POST /api/unsubscribe/request`는 구독 중인 주소일 때만 새 토큰을 메일로 보내고, 응답 본문은
구독 여부와 무관하게 동일하다(열거 방지). 링크 요청 자체는 해지가 아니며 메일의 링크에서 명시적
확인을 거치므로, 인증 없는 호출자가 타인을 해지시킬 수 없다.

**추가 보강** (자체 재리뷰에서 발견):
- SendGrid 실패 시 구독 중인 주소에만 500이 나가 구독 여부가 드러났다 → 발송 오류를 삼키고 동일 응답
- IP 기준 제한만 있어 IP를 바꾸면 한 구독자에게 메일 폭탄 가능 → 주소 기준 버킷(시간당 3회) 추가.
  제한에 걸려도 성공과 동일한 본문을 반환한다.

### 2. 구독 재신청이 영구 불가 (High)

`pending_subscribers` upsert가 `confirmed_at`을 초기화하지 않았다. 확인 → 구독취소 → 재신청 시
이전 `confirmed_at`이 남아 `confirm_subscription`이 `already_confirmed`를 반환하고, 라우트는
200 "이미 확인된 구독입니다"를 돌려주지만 `subscribers.is_active`는 `false`인 채로 남는다.
사용자는 다시는 메일을 받지 못하고 오류도 보지 못한다.

upsert에 `confirmed_at: null`을 추가했다.

### 3. `stock_price_cache` 고아화 (High)

056b가 테이블을 `TRUNCATE`하고 클라이언트 캐시 접근도 제거했는데(정당한 SEC-005 수정), 서버 쪽
대체 경로가 없었다. `getBatchPricesFromCache`/`saveBatchPricesToCache` 호출자가 0개가 되어 아무도
캐시를 채우지 않고, 아카이브 조회마다 KIS를 직접 호출한다(티커당 순차 + 100ms sleep).
런북의 "cache refill 이후 정상 동작"은 성립하지 않았다.

`/api/stock/price`가 service_role로 캐시를 읽고 쓰도록 재연결했다. 미스 티커만 KIS로 넘기고,
내부 필드 `expires_at`은 응답에서 제거한다.

### 4. 배포 실패 원인 (Blocker) — 락파일 불일치

실제 Vercel 빌드 로그:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
  because pnpm-lock.yaml is not up to date with package.json
* 1 dependencies were added: server-only@0.0.1
```

저장소에 `package-lock.json`과 `pnpm-lock.yaml`이 **둘 다** 있고 Vercel은 `pnpm-lock.yaml`을 감지해
pnpm을 쓴다. 원본 PR #111이 `server-only`를 `package.json`과 npm 락파일에만 추가해서, CI 기본값인
`--frozen-lockfile` 검사에서 **빌드가 시작되기도 전에 install이 실패**했다. 로컬 `next build`로는
재현되지 않는 이유다.

원본 PR #111 머지(`21c0866`)와 Task 1 머지(`6088e36`)가 모두 이것 때문에 배포에 실패했다.
`pnpm-lock.yaml`을 갱신했고 `pnpm install --frozen-lockfile` 통과를 확인했다.

### 5. sitemap 조회 실패 정책

락파일 수정 후 빌드는 돌아가고 `/sitemap.xml` prerender가 `Invalid API key`로 죽었다.
**Preview 환경에 `SUPABASE_SERVICE_ROLE_KEY`가 없고 anon 키도 거부된다** (Production에는 둘 다 존재).
손대지 않은 `main`도 Supabase 접근이 안 되면 동일하게 실패하므로 이 PR이 만든 문제는 아니다.

무조건 빈 배열로 물러나면 `app/sitemap.ts` 상단 주석이 경고하는 대로 빈 sitemap이 조용히 배포돼
색인이 유실된다. `VERCEL_ENV=production`일 때만 던지고 그 외에는 정적 페이지만 담은 부분 sitemap으로
물러나도록 했다. 프로덕션 색인 보장은 유지하면서 preview 배포는 막지 않는다.

Preview 환경변수 누락은 **별개 설정 문제로 남아 있다** — 이 변경이 가리지 않으며 프로덕션에서는
여전히 크게 실패한다. Preview에서 DB 의존 페이지를 제대로 확인하려면 키를 넣어야 한다.

### 6. 정리 (Low)

- 소비자가 0개인 `lib/security/index.ts` barrel export 제외 (conventions anti-pattern #3)
- 라우트에 인라인 중복돼 있던 티커 검증을 `lib/security/validators.ts`로 통합

## 회귀 테스트

- `app/api/__tests__/subscription-lifecycle.test.ts` (6건) — `confirmed_at` 초기화, 링크 재발급 열거
  방지, 발급 토큰 유효성, 발송 실패 시 동일 응답, 주소 기준 rate limit
- `app/api/stock/__tests__/price-cache-wiring.test.ts` (3건) — 캐시 미스만 KIS 호출, 조회 결과 캐시
  기록, 전체 히트 시 KIS 미호출 및 `expires_at` 미노출
- `app/__tests__/sitemap-failure-policy.test.ts` (3건) — 프로덕션은 던지고 preview는 부분 sitemap

## 검증

- `tsc --noEmit`: 0 errors
- `eslint .`: 0 errors (warning 22건, 신규 없음)
- `vitest run`: 전량 통과
- `next build --turbopack`: 성공
- `pnpm install --frozen-lockfile`: 통과 (배포 실패 재현 경로)

## DB 마이그레이션 적용 현황

프로덕션 Supabase를 service_role로 조회해 확인했다. **056b~063 중 적용된 것은 없다.**
존재 판정은 알려진 객체로 캘리브레이션했다(존재=`status 200`+count / 부재=`status 204`+null).
`stock_price_cache`도 169행 그대로라 `TRUNCATE`는 실행되지 않았다. DB는 깨끗하다.

## 배포 주의

- `RATE_LIMIT_HMAC_SECRET`, `UNSUBSCRIBE_TOKEN_SECRET`(각 32자 이상)을 **DB 적용 전에** 모든 대상
  환경에 주입해야 한다. 없으면 관련 라우트가 fail-closed로 503을 반환한다.
- `056b`가 `stock_price_cache`를 `TRUNCATE`한다. KRX 장 시간 외에 적용한다.
